### PR TITLE
Introduce typed Program core and safety catalogue

### DIFF
--- a/cuprum/__init__.py
+++ b/cuprum/__init__.py
@@ -1,4 +1,15 @@
-"""cuprum package."""
+"""cuprum package.
+
+Provides a typed programme catalogue system for managing curated, allowlisted
+executables. Re-exports core types and the default catalogue for convenience.
+
+Example:
+>>> from cuprum import DEFAULT_CATALOGUE, ECHO
+>>> entry = DEFAULT_CATALOGUE.lookup(ECHO)
+>>> entry.project_name
+'core-ops'
+
+"""
 
 from __future__ import annotations
 
@@ -7,6 +18,7 @@ from cuprum.catalogue import (
     DEFAULT_CATALOGUE,
     DEFAULT_PROJECTS,
     DOC_TOOL,
+    DOCUMENTATION_PROJECT,
     ECHO,
     LS,
     ProgramCatalogue,
@@ -22,6 +34,7 @@ __all__ = [
     "CORE_OPS_PROJECT",
     "DEFAULT_CATALOGUE",
     "DEFAULT_PROJECTS",
+    "DOCUMENTATION_PROJECT",
     "DOC_TOOL",
     "ECHO",
     "LS",

--- a/cuprum/__init__.py
+++ b/cuprum/__init__.py
@@ -2,5 +2,33 @@
 
 from __future__ import annotations
 
+from cuprum.catalogue import (
+    CORE_OPS_PROJECT,
+    DEFAULT_CATALOGUE,
+    DEFAULT_PROJECTS,
+    DOC_TOOL,
+    ECHO,
+    LS,
+    ProgramCatalogue,
+    ProgramEntry,
+    ProjectSettings,
+    UnknownProgramError,
+)
+from cuprum.program import Program
+
 PACKAGE_NAME = "cuprum"
 
+__all__ = [
+    "CORE_OPS_PROJECT",
+    "DEFAULT_CATALOGUE",
+    "DEFAULT_PROJECTS",
+    "DOC_TOOL",
+    "ECHO",
+    "LS",
+    "PACKAGE_NAME",
+    "Program",
+    "ProgramCatalogue",
+    "ProgramEntry",
+    "ProjectSettings",
+    "UnknownProgramError",
+]

--- a/cuprum/catalogue.py
+++ b/cuprum/catalogue.py
@@ -1,0 +1,147 @@
+"""Curated catalogue of allowed executables and their metadata."""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import typing as typ
+from types import MappingProxyType
+
+from cuprum.program import Program
+
+
+class UnknownProgramError(LookupError):
+    """Raised when a program is not present in the catalogue allowlist."""
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ProjectSettings:
+    """Metadata shared by a project's curated programs."""
+
+    name: str
+    programs: tuple[Program, ...]
+    documentation_locations: tuple[str, ...]
+    noise_rules: tuple[str, ...]
+
+    def owns(self, program: Program) -> bool:
+        """Return True when the program belongs to this project."""
+        return program in self.programs
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ProgramEntry:
+    """A resolved program with its owning project metadata."""
+
+    program: Program
+    project: ProjectSettings
+
+    @property
+    def project_name(self) -> str:
+        """Return the owning project's name."""
+        return self.project.name
+
+
+class ProgramCatalogue:
+    """Catalogue of curated programs with a default allowlist."""
+
+    def __init__(self, *, projects: typ.Iterable[ProjectSettings]) -> None:
+        """Build a catalogue from the supplied project definitions."""
+        self._projects = self._index_projects(projects)
+        self._program_to_project = self._index_programs(self._projects)
+        self._allowlist = frozenset(self._program_to_project)
+
+    @property
+    def allowlist(self) -> frozenset[Program]:
+        """Return the curated allowlist of programs."""
+        return self._allowlist
+
+    def is_allowed(self, program: Program) -> bool:
+        """Return True when the program is part of the default allowlist."""
+        return program in self._allowlist
+
+    def lookup(self, program: Program | str) -> ProgramEntry:
+        """Resolve a program into its entry, blocking unknown executables."""
+        program_value = _coerce_program(program)
+        project = self._program_to_project.get(program_value)
+        if project is None:
+            msg = f"Program '{program_value}' is not in the catalogue allowlist"
+            raise UnknownProgramError(msg)
+        return ProgramEntry(program=program_value, project=project)
+
+    def project_for(self, program: Program | str) -> ProjectSettings:
+        """Return the owning project for the given program."""
+        return self.lookup(program).project
+
+    def visible_settings(self) -> typ.Mapping[str, ProjectSettings]:
+        """Expose project metadata to downstream services."""
+        return MappingProxyType(dict(self._projects))
+
+    @staticmethod
+    def _index_projects(
+        projects: typ.Iterable[ProjectSettings],
+    ) -> dict[str, ProjectSettings]:
+        """Index project settings by name and guard against duplicates."""
+        indexed: dict[str, ProjectSettings] = {}
+        for project in projects:
+            if project.name in indexed:
+                msg = f"Project '{project.name}' registered more than once"
+                raise ValueError(msg)
+            indexed[project.name] = project
+        return indexed
+
+    @staticmethod
+    def _index_programs(
+        projects: dict[str, ProjectSettings],
+    ) -> dict[Program, ProjectSettings]:
+        """Index programs by value, enforcing unique ownership."""
+        program_map: dict[Program, ProjectSettings] = {}
+        for project in projects.values():
+            for program in project.programs:
+                if program in program_map:
+                    owner = program_map[program].name
+                    msg = f"Program '{program}' already owned by '{owner}'"
+                    raise ValueError(msg)
+                program_map[program] = project
+        return program_map
+
+
+CORE_OPS_PROJECT = "core-ops"
+DOCUMENTATION_PROJECT = "docs"
+
+ECHO = Program("echo")
+LS = Program("ls")
+DOC_TOOL = Program("mdbook")
+
+DEFAULT_PROJECTS: tuple[ProjectSettings, ...] = (
+    ProjectSettings(
+        name=CORE_OPS_PROJECT,
+        programs=(ECHO, LS),
+        documentation_locations=("docs/users-guide.md#program-catalogue",),
+        noise_rules=(r"^progress:", r"^note:"),
+    ),
+    ProjectSettings(
+        name=DOCUMENTATION_PROJECT,
+        programs=(DOC_TOOL,),
+        documentation_locations=("https://docs.example.invalid/cuprum/catalogue",),
+        noise_rules=(r"^\[INFO\]",),
+    ),
+)
+
+DEFAULT_CATALOGUE = ProgramCatalogue(projects=DEFAULT_PROJECTS)
+
+__all__ = [
+    "CORE_OPS_PROJECT",
+    "DEFAULT_CATALOGUE",
+    "DEFAULT_PROJECTS",
+    "DOC_TOOL",
+    "ECHO",
+    "LS",
+    "ProgramCatalogue",
+    "ProgramEntry",
+    "ProjectSettings",
+    "UnknownProgramError",
+]
+
+
+def _coerce_program(raw: Program | str) -> Program:
+    """Normalise raw program inputs into the Program NewType."""
+    return Program(raw)

--- a/cuprum/program.py
+++ b/cuprum/program.py
@@ -1,4 +1,12 @@
-"""Program NewType representing curated executables."""
+"""Represent curated executables with a nominal ``Program`` type.
+
+Examples:
+>>> from cuprum.program import Program
+>>> ECHO = Program("echo")
+>>> ECHO == "echo"
+True
+
+"""
 
 from __future__ import annotations
 

--- a/cuprum/program.py
+++ b/cuprum/program.py
@@ -1,0 +1,9 @@
+"""Program NewType representing curated executables."""
+
+from __future__ import annotations
+
+import typing as typ
+
+Program = typ.NewType("Program", str)
+
+__all__ = ["Program"]

--- a/cuprum/unittests/test_catalogue.py
+++ b/cuprum/unittests/test_catalogue.py
@@ -82,7 +82,7 @@ def test_duplicate_project_names_are_rejected() -> None:
     )
     with pytest.raises(ValueError, match="duplicate") as exc:
         ProgramCatalogue(projects=(dup, dup))
-    assert "duplicate" in str(exc.value)
+    assert "duplicate" in str(exc.value), "Error message must mention duplicate name"
 
 
 def test_duplicate_programs_across_projects_are_rejected() -> None:
@@ -102,13 +102,17 @@ def test_duplicate_programs_across_projects_are_rejected() -> None:
     )
     with pytest.raises(ValueError, match="shared") as exc:
         ProgramCatalogue(projects=(first, second))
-    assert "shared" in str(exc.value)
-    assert "first" in str(exc.value)
+    assert "shared" in str(exc.value), "Error must mention the shared program name"
+    assert "first" in str(exc.value), (
+        "Error must include the original owning project name"
+    )
 
 
 def test_coercion_accepts_program_and_string() -> None:
     """Allowlist checks accept both Program and raw strings."""
-    assert DEFAULT_CATALOGUE.is_allowed(Program("echo"))
+    assert DEFAULT_CATALOGUE.is_allowed(Program("echo")), (
+        "Program instance must be accepted by is_allowed"
+    )
     assert DEFAULT_CATALOGUE.is_allowed("echo"), "Raw strings should also be accepted"
 
 

--- a/cuprum/unittests/test_catalogue.py
+++ b/cuprum/unittests/test_catalogue.py
@@ -7,7 +7,9 @@ import pytest
 from cuprum.catalogue import (
     CORE_OPS_PROJECT,
     DEFAULT_CATALOGUE,
+    DOC_TOOL,
     ECHO,
+    LS,
     ProgramCatalogue,
     ProjectSettings,
     UnknownProgramError,
@@ -18,14 +20,17 @@ from cuprum.program import Program
 def test_program_newtype_round_trip() -> None:
     """Program behaves like a string while keeping nominal typing."""
     program = Program("echo")
-    assert isinstance(program, str)
-    assert program == "echo"
+    assert isinstance(program, str), "Program should subtype str for ergonomics"
+    assert program == "echo", "Program must preserve wrapped value"
 
 
 def test_default_allowlist_contains_curated_programs() -> None:
     """The default allowlist surfaces curated program constants."""
-    assert ECHO in DEFAULT_CATALOGUE.allowlist
-    assert CORE_OPS_PROJECT in DEFAULT_CATALOGUE.visible_settings()
+    assert ECHO in DEFAULT_CATALOGUE.allowlist, "Echo missing from allowlist"
+    assert CORE_OPS_PROJECT in DEFAULT_CATALOGUE.visible_settings(), (
+        "Core project metadata not exposed"
+    )
+    assert DEFAULT_CATALOGUE.is_allowed("ls"), "String program names should pass"
 
 
 def test_unknown_programs_are_blocked_by_default() -> None:
@@ -38,9 +43,11 @@ def test_visible_settings_surface_project_metadata() -> None:
     """Project metadata is available to downstream services."""
     settings = DEFAULT_CATALOGUE.visible_settings()
     project = settings[CORE_OPS_PROJECT]
-    assert project.noise_rules
-    assert project.documentation_locations
-    assert ECHO in project.programs
+    assert project.noise_rules, "Noise rules should be populated"
+    assert project.documentation_locations, "Docs links should be populated"
+    assert ECHO in project.programs, "Project should enumerate its programs"
+    with pytest.raises(TypeError):
+        settings[CORE_OPS_PROJECT] = project  # type: ignore[index]
 
 
 def test_catalogue_can_be_extended_safely() -> None:
@@ -55,9 +62,64 @@ def test_catalogue_can_be_extended_safely() -> None:
     catalogue = ProgramCatalogue(projects=(docs_project,))
 
     resolved = catalogue.lookup("mdbook")
-    assert resolved.program == Program("mdbook")
-    assert resolved.project.name == "docs"
-    assert catalogue.is_allowed(Program("mdbook")) is True
+    assert resolved.program == Program("mdbook"), "Lookup returns typed program"
+    assert resolved.project.name == "docs", "Owning project should be attached"
+    assert catalogue.is_allowed(Program("mdbook")) is True, (
+        "Allowlist must accept known program"
+    )
 
     with pytest.raises(UnknownProgramError):
         catalogue.lookup("nonexistent")
+
+
+def test_duplicate_project_names_are_rejected() -> None:
+    """Duplicate project names raise an error during catalogue construction."""
+    dup = ProjectSettings(
+        name="duplicate",
+        programs=(Program("tool"),),
+        documentation_locations=("https://example.test/docs",),
+        noise_rules=(r"^info",),
+    )
+    with pytest.raises(ValueError, match="duplicate") as exc:
+        ProgramCatalogue(projects=(dup, dup))
+    assert "duplicate" in str(exc.value)
+
+
+def test_duplicate_programs_across_projects_are_rejected() -> None:
+    """The same program cannot be owned by two projects."""
+    shared = Program("shared")
+    first = ProjectSettings(
+        name="first",
+        programs=(shared,),
+        documentation_locations=("https://example.test/first",),
+        noise_rules=(r"^first",),
+    )
+    second = ProjectSettings(
+        name="second",
+        programs=(shared,),
+        documentation_locations=("https://example.test/second",),
+        noise_rules=(r"^second",),
+    )
+    with pytest.raises(ValueError, match="shared") as exc:
+        ProgramCatalogue(projects=(first, second))
+    assert "shared" in str(exc.value)
+    assert "first" in str(exc.value)
+
+
+def test_coercion_accepts_program_and_string() -> None:
+    """Allowlist checks accept both Program and raw strings."""
+    assert DEFAULT_CATALOGUE.is_allowed(Program("echo"))
+    assert DEFAULT_CATALOGUE.is_allowed("echo"), "Raw strings should also be accepted"
+
+
+def test_program_hash_and_equality_usage() -> None:
+    """Program can be used as a dict key without surprising behaviour."""
+    key = Program("ls")
+    lookup = {key: "ok"}
+    assert lookup[Program("ls")] == "ok", "Program keys should hash consistently"
+    assert DEFAULT_CATALOGUE.lookup(LS).program == Program("ls"), (
+        "Lookup should keep nominal type"
+    )
+    assert DEFAULT_CATALOGUE.lookup(DOC_TOOL).project.name == "docs", (
+        "DOC_TOOL should belong to docs project"
+    )

--- a/cuprum/unittests/test_catalogue.py
+++ b/cuprum/unittests/test_catalogue.py
@@ -1,0 +1,63 @@
+"""Unit tests for the curated program catalogue."""
+
+from __future__ import annotations
+
+import pytest
+
+from cuprum.catalogue import (
+    CORE_OPS_PROJECT,
+    DEFAULT_CATALOGUE,
+    ECHO,
+    ProgramCatalogue,
+    ProjectSettings,
+    UnknownProgramError,
+)
+from cuprum.program import Program
+
+
+def test_program_newtype_round_trip() -> None:
+    """Program behaves like a string while keeping nominal typing."""
+    program = Program("echo")
+    assert isinstance(program, str)
+    assert program == "echo"
+
+
+def test_default_allowlist_contains_curated_programs() -> None:
+    """The default allowlist surfaces curated program constants."""
+    assert ECHO in DEFAULT_CATALOGUE.allowlist
+    assert CORE_OPS_PROJECT in DEFAULT_CATALOGUE.visible_settings()
+
+
+def test_unknown_programs_are_blocked_by_default() -> None:
+    """Unknown executables are rejected to maintain safety by default."""
+    with pytest.raises(UnknownProgramError):
+        DEFAULT_CATALOGUE.lookup("unknown-tool")
+
+
+def test_visible_settings_surface_project_metadata() -> None:
+    """Project metadata is available to downstream services."""
+    settings = DEFAULT_CATALOGUE.visible_settings()
+    project = settings[CORE_OPS_PROJECT]
+    assert project.noise_rules
+    assert project.documentation_locations
+    assert ECHO in project.programs
+
+
+def test_catalogue_can_be_extended_safely() -> None:
+    """A new catalogue accepts extra projects while blocking unknown ones."""
+    docs_project = ProjectSettings(
+        name="docs",
+        programs=(Program("mdbook"),),
+        documentation_locations=("https://example.test/docs/commands",),
+        noise_rules=(r"^\[INFO\]",),
+    )
+
+    catalogue = ProgramCatalogue(projects=(docs_project,))
+
+    resolved = catalogue.lookup("mdbook")
+    assert resolved.program == Program("mdbook")
+    assert resolved.project.name == "docs"
+    assert catalogue.is_allowed(Program("mdbook")) is True
+
+    with pytest.raises(UnknownProgramError):
+        catalogue.lookup("nonexistent")

--- a/cuprum/unittests/test_public_api.py
+++ b/cuprum/unittests/test_public_api.py
@@ -1,0 +1,29 @@
+"""Unit tests for cuprum public exports."""
+
+from __future__ import annotations
+
+import cuprum as c
+
+
+def test_public_exports_are_available() -> None:
+    """Top-level cuprum exports default catalogue symbols."""
+    assert c.DEFAULT_CATALOGUE is not None
+    assert c.DEFAULT_PROJECTS
+    assert c.CORE_OPS_PROJECT == "core-ops"
+    assert c.DOCUMENTATION_PROJECT == "docs"
+    assert c.Program("echo") == c.ECHO
+    assert c.Program("ls") == c.LS
+    assert c.Program("mdbook") == c.DOC_TOOL
+    assert c.ProgramCatalogue is not None
+    assert c.ProgramEntry is not None
+    assert c.ProjectSettings is not None
+    assert c.UnknownProgramError is not None
+
+
+def test_public_catalogue_behaviour_via_reexports() -> None:
+    """Catalogue lookups work through the re-exported API surface."""
+    entry = c.DEFAULT_CATALOGUE.lookup(c.ECHO)
+    assert entry.program == c.Program("echo")
+    assert entry.project_name == c.CORE_OPS_PROJECT
+    assert c.DEFAULT_CATALOGUE.is_allowed("ls")
+    assert not c.DEFAULT_CATALOGUE.is_allowed("definitely-not-allowed")

--- a/cuprum/unittests/test_public_api.py
+++ b/cuprum/unittests/test_public_api.py
@@ -7,23 +7,25 @@ import cuprum as c
 
 def test_public_exports_are_available() -> None:
     """Top-level cuprum exports default catalogue symbols."""
-    assert c.DEFAULT_CATALOGUE is not None
-    assert c.DEFAULT_PROJECTS
-    assert c.CORE_OPS_PROJECT == "core-ops"
-    assert c.DOCUMENTATION_PROJECT == "docs"
-    assert c.Program("echo") == c.ECHO
-    assert c.Program("ls") == c.LS
-    assert c.Program("mdbook") == c.DOC_TOOL
-    assert c.ProgramCatalogue is not None
-    assert c.ProgramEntry is not None
-    assert c.ProjectSettings is not None
-    assert c.UnknownProgramError is not None
+    assert c.DEFAULT_CATALOGUE is not None, "DEFAULT_CATALOGUE must be exported"
+    assert c.DEFAULT_PROJECTS, "DEFAULT_PROJECTS must not be empty"
+    assert c.CORE_OPS_PROJECT == "core-ops", "CORE_OPS_PROJECT value mismatch"
+    assert c.DOCUMENTATION_PROJECT == "docs", "DOCUMENTATION_PROJECT value mismatch"
+    assert c.Program("echo") == c.ECHO, "ECHO must round-trip via Program"
+    assert c.Program("ls") == c.LS, "LS must round-trip via Program"
+    assert c.Program("mdbook") == c.DOC_TOOL, "DOC_TOOL must round-trip via Program"
+    assert c.ProgramCatalogue is not None, "ProgramCatalogue must be exported"
+    assert c.ProgramEntry is not None, "ProgramEntry must be exported"
+    assert c.ProjectSettings is not None, "ProjectSettings must be exported"
+    assert c.UnknownProgramError is not None, "UnknownProgramError must be exported"
 
 
 def test_public_catalogue_behaviour_via_reexports() -> None:
     """Catalogue lookups work through the re-exported API surface."""
     entry = c.DEFAULT_CATALOGUE.lookup(c.ECHO)
-    assert entry.program == c.Program("echo")
-    assert entry.project_name == c.CORE_OPS_PROJECT
-    assert c.DEFAULT_CATALOGUE.is_allowed("ls")
-    assert not c.DEFAULT_CATALOGUE.is_allowed("definitely-not-allowed")
+    assert entry.program == c.Program("echo"), "Lookup must return typed Program"
+    assert entry.project_name == c.CORE_OPS_PROJECT, "Project name mismatch"
+    assert c.DEFAULT_CATALOGUE.is_allowed("ls"), "Curated program ls must be allowed"
+    assert not c.DEFAULT_CATALOGUE.is_allowed("definitely-not-allowed"), (
+        "Unknown program should not be allowlisted"
+    )

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -228,6 +228,22 @@ Higher‑level code imports these names instead of sprinkling raw strings
 throughout the codebase. This is both a readability and safety device:
 grep‑and‑replace, review, and static analysis become easier.
 
+#### 5.1.1 Catalogue metadata
+
+A `ProgramCatalogue` defines the curated allowlist that guards the safe command
+surface. Each entry belongs to a `ProjectSettings` record that holds:
+
+- `programs`: curated `Program` values owned by the project;
+- `documentation_locations`: runbooks or background docs for reviewers and
+  operators;
+- `noise_rules`: output patterns downstream loggers may drop to cut chatter.
+
+Cuprum ships with `DEFAULT_CATALOGUE`, anchored by the `core-ops` project and
+extended with project-specific metadata. The catalogue rejects unknown
+executables via `UnknownProgramError`, making the allowlist the default gate.
+Downstream services (for example, logging hooks) can call `visible_settings()`
+to read noise rules and documentation links without mutating the catalogue.
+
 ### 5.2 Safe vs Dynamic Commands
 
 Cuprum distinguishes between:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@ command execution.
 
 ### Step: typed command core
 
-- [ ] Introduce the `Program` NewType and a curated catalogue module with a
+- [x] Introduce the `Program` NewType and a curated catalogue module with a
       default allowlist; block unknown executables by default and cover with
       unit tests.
 - [ ] Add `sh.make` to construct `SafeCmd` instances with typed argv handling

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -7,7 +7,7 @@ ships with a curated catalogue (`DEFAULT_CATALOGUE`) that defines an allowlist
 of programs and project metadata. Requests for unknown executables raise
 `UnknownProgramError` so accidental shell access is blocked by default.
 
-- Import curated programs from `cuprum.catalogue` (for example `ECHO`, `LS`).
+- Import curated programs from `cuprum` (for example `ECHO`, `LS`).
 - Each project in the catalogue includes `noise_rules` (output lines that
   downstream loggers can safely drop) and `documentation_locations` (links for
   operators and reviewers).

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1,1 +1,41 @@
 # cuprum Users' Guide
+
+## Program catalogue
+
+Cuprum exposes a typed `Program` NewType to identify executables. The library
+ships with a curated catalogue (`DEFAULT_CATALOGUE`) that defines an allowlist
+of programs and project metadata. Requests for unknown executables raise
+`UnknownProgramError` so accidental shell access is blocked by default.
+
+- Import curated programs from `cuprum.catalogue` (for example `ECHO`, `LS`).
+- Each project in the catalogue includes `noise_rules` (output lines that
+  downstream loggers can safely drop) and `documentation_locations` (links for
+  operators and reviewers).
+
+```python
+from cuprum.catalogue import DEFAULT_CATALOGUE, ECHO
+
+entry = DEFAULT_CATALOGUE.lookup(ECHO)
+print(entry.project.noise_rules)
+```
+
+### Adding project-specific programs
+
+Use `ProjectSettings` and `ProgramCatalogue` to extend or replace the default
+catalogue:
+
+```python
+from cuprum.catalogue import ProgramCatalogue, ProjectSettings
+from cuprum.program import Program
+
+project = ProjectSettings(
+    name="data-pipeline",
+    programs=(Program("python"),),
+    documentation_locations=("docs/pipelines.md",),
+    noise_rules=(r"^progress:",),
+)
+catalogue = ProgramCatalogue(projects=(project,))
+```
+
+Downstream services can fetch metadata via `catalogue.visible_settings()` to
+propagate noise filters and documentation links alongside the allowlist.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -13,7 +13,7 @@ of programs and project metadata. Requests for unknown executables raise
   operators and reviewers).
 
 ```python
-from cuprum.catalogue import DEFAULT_CATALOGUE, ECHO
+from cuprum import DEFAULT_CATALOGUE, ECHO
 
 entry = DEFAULT_CATALOGUE.lookup(ECHO)
 print(entry.project.noise_rules)
@@ -25,8 +25,7 @@ Use `ProjectSettings` and `ProgramCatalogue` to extend or replace the default
 catalogue:
 
 ```python
-from cuprum.catalogue import ProgramCatalogue, ProjectSettings
-from cuprum.program import Program
+from cuprum import Program, ProgramCatalogue, ProjectSettings
 
 project = ProjectSettings(
     name="data-pipeline",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = []
 [dependency-groups]
 dev = [
     "pytest",
+    "pytest-bdd",
     "ruff",
     "pyright",
     "pytest-timeout",

--- a/tests/behaviour/test_catalogue_behaviour.py
+++ b/tests/behaviour/test_catalogue_behaviour.py
@@ -1,0 +1,77 @@
+"""Behavioural tests for the program catalogue."""
+
+from __future__ import annotations
+
+import typing as typ
+
+from pytest_bdd import given, parsers, scenario, then, when
+
+from cuprum.catalogue import (
+    DEFAULT_CATALOGUE,
+    ProgramCatalogue,
+    ProjectSettings,
+    UnknownProgramError,
+)
+
+
+@scenario("../features/catalogue.feature", "Unknown program is blocked by default")
+def test_unknown_program_blocked() -> None:
+    """Behavioural guard rail for unknown executables."""
+
+
+@scenario(
+    "../features/catalogue.feature",
+    "Projects expose metadata for downstream services",
+)
+def test_project_metadata_visible() -> None:
+    """Behavioural contract for exposing catalogue metadata."""
+
+
+@given("the default catalogue", target_fixture="catalogue")
+def given_default_catalogue() -> ProgramCatalogue:
+    """Provide the default catalogue fixture."""
+    return DEFAULT_CATALOGUE
+
+
+@when(
+    parsers.parse('I request the program "{program_name}"'),
+    target_fixture="catalogue_result",
+)
+def when_request_program(
+    catalogue: ProgramCatalogue,
+    program_name: str,
+) -> dict[str, object]:
+    """Attempt to resolve a program name using the catalogue."""
+    result: dict[str, object] = {}
+    try:
+        result["entry"] = catalogue.lookup(program_name)
+    except UnknownProgramError as exc:  # pragma: no cover - behaviour assertion step
+        result["error"] = exc
+    return result
+
+
+@then("the catalogue rejects it with an unknown program error")
+def then_catalogue_rejects(catalogue_result: dict[str, object]) -> None:
+    """Assert that an unknown program was rejected."""
+    assert "error" in catalogue_result, "Expected an UnknownProgramError"
+    assert isinstance(catalogue_result["error"], UnknownProgramError)
+
+
+@when("downstream services request visible settings", target_fixture="visible_settings")
+def when_request_visible_settings(
+    catalogue: ProgramCatalogue,
+) -> typ.Mapping[str, ProjectSettings]:
+    """Expose project metadata to the scenario."""
+    return catalogue.visible_settings()
+
+
+@then(parsers.parse('project "{project_name}" advertises noise rules and docs'))
+def then_project_metadata_present(
+    visible_settings: typ.Mapping[str, ProjectSettings],
+    project_name: str,
+) -> None:
+    """Ensure downstream services can see project metadata."""
+    assert project_name in visible_settings
+    project = visible_settings[project_name]
+    assert project.noise_rules, "Noise rules should be visible to callers"
+    assert project.documentation_locations, "Docs should be visible to callers"

--- a/tests/behaviour/test_catalogue_behaviour.py
+++ b/tests/behaviour/test_catalogue_behaviour.py
@@ -91,7 +91,10 @@ def when_lookup_curated_program(
 def then_catalogue_rejects(catalogue_result: dict[str, object]) -> None:
     """Assert that an unknown program was rejected."""
     assert "error" in catalogue_result, "Expected an UnknownProgramError"
-    assert isinstance(catalogue_result["error"], UnknownProgramError)
+    assert isinstance(
+        catalogue_result["error"],
+        UnknownProgramError,
+    ), "Error must be an UnknownProgramError instance"
 
 
 @when("downstream services request visible settings", target_fixture="visible_settings")
@@ -108,7 +111,7 @@ def then_project_metadata_present(
     project_name: str,
 ) -> None:
     """Ensure downstream services can see project metadata."""
-    assert project_name in visible_settings
+    assert project_name in visible_settings, "Project must be present in settings"
     project = visible_settings[project_name]
     assert project.noise_rules, "Noise rules should be visible to callers"
     assert project.documentation_locations, "Docs should be visible to callers"
@@ -124,11 +127,16 @@ def then_lookup_succeeds(
     project_name: str,
 ) -> None:
     """Validate successful lookups via the public API."""
-    assert "entry" in public_lookup
+    assert "entry" in public_lookup, "Expected a successful lookup entry"
     entry = typ.cast("ProgramEntry", public_lookup["entry"])
-    assert entry.project_name == project_name
-    assert isinstance(entry.program, str)
-    assert entry.program == c.Program("echo")
+    assert entry.project_name == project_name, "Project name must match expectation"
+    assert isinstance(
+        entry.program,
+        str,
+    ), "Program should behave as str at runtime"
+    assert entry.program == c.Program("echo"), (
+        "Entry must carry the curated Program value"
+    )
 
 
 @then(parsers.parse('the allowlist accepts the string name "{program_name}"'))
@@ -137,4 +145,6 @@ def then_allowlist_accepts_string_name(
     program_name: str,
 ) -> None:
     """Confirm allowlist permits string inputs for curated programs."""
-    assert public_api.DEFAULT_CATALOGUE.is_allowed(program_name)
+    assert public_api.DEFAULT_CATALOGUE.is_allowed(program_name), (
+        "Allowlist must accept the curated program's string name"
+    )

--- a/tests/features/catalogue.feature
+++ b/tests/features/catalogue.feature
@@ -9,3 +9,9 @@ Feature: Catalogue defaults
     Given the default catalogue
     When downstream services request visible settings
     Then project "core-ops" advertises noise rules and docs
+
+  Scenario: Curated program is accepted via the public API
+    Given the cuprum public API surface
+    When I look up the curated program "echo"
+    Then the lookup succeeds for project "core-ops" with a typed program
+    And the allowlist accepts the string name "ls"

--- a/tests/features/catalogue.feature
+++ b/tests/features/catalogue.feature
@@ -1,0 +1,11 @@
+Feature: Catalogue defaults
+
+  Scenario: Unknown program is blocked by default
+    Given the default catalogue
+    When I request the program "unknown-tool"
+    Then the catalogue rejects it with an unknown program error
+
+  Scenario: Projects expose metadata for downstream services
+    Given the default catalogue
+    When downstream services request visible settings
+    Then project "core-ops" advertises noise rules and docs

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ source = { editable = "." }
 dev = [
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-bdd" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -31,6 +32,7 @@ dev = [
 dev = [
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-bdd" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -46,12 +48,96 @@ wheels = [
 ]
 
 [[package]]
+name = "gherkin-official"
+version = "29.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d8/7a28537efd7638448f7512a0cce011d4e3bf1c7f4794ad4e9c87b3f1e98e/gherkin_official-29.0.0.tar.gz", hash = "sha256:dbea32561158f02280d7579d179b019160d072ce083197625e2f80a6776bb9eb", size = 32303, upload-time = "2024-08-12T09:41:09.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/fc/b86c22ad3b18d8324a9d6fe5a3b55403291d2bf7572ba6a16efa5aa88059/gherkin_official-29.0.0-py3-none-any.whl", hash = "sha256:26967b0d537a302119066742669e0e8b663e632769330be675457ae993e1d1bc", size = 37085, upload-time = "2024-08-12T09:41:07.954Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -70,6 +156,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "parse"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391, upload-time = "2024-06-11T04:41:57.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126, upload-time = "2024-06-11T04:41:55.057Z" },
+]
+
+[[package]]
+name = "parse-type"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parse" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
 ]
 
 [[package]]
@@ -117,6 +225,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
+]
+
+[[package]]
+name = "pytest-bdd"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gherkin-official" },
+    { name = "mako" },
+    { name = "packaging" },
+    { name = "parse" },
+    { name = "parse-type" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/2f/14c2e55372a5718a93b56aea48cd6ccc15d2d245364e516cd7b19bbd07ad/pytest_bdd-8.1.0.tar.gz", hash = "sha256:ef0896c5cd58816dc49810e8ff1d632f4a12019fb3e49959b2d349ffc1c9bfb5", size = 56147, upload-time = "2024-12-05T21:45:58.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/7d/1461076b0cc9a9e6fa8b51b9dea2677182ba8bc248d99d95ca321f2c666f/pytest_bdd-8.1.0-py3-none-any.whl", hash = "sha256:2124051e71a05ad7db15296e39013593f72ebf96796e1b023a40e5453c47e5fb", size = 49149, upload-time = "2024-12-05T21:45:56.184Z" },
 ]
 
 [[package]]
@@ -168,6 +294,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/82/251d5f1aa4dcad30aed491b4657cecd9fb4274214da6960ffec144c260f7/ruff-0.14.7-py3-none-win32.whl", hash = "sha256:e33052c9199b347c8937937163b9b149ef6ab2e4bb37b042e593da2e6f6cccfa", size = 13126751, upload-time = "2025-11-28T20:55:03.47Z" },
     { url = "https://files.pythonhosted.org/packages/a8/b5/d0b7d145963136b564806f6584647af45ab98946660d399ec4da79cae036/ruff-0.14.7-py3-none-win_amd64.whl", hash = "sha256:e17a20ad0d3fad47a326d773a042b924d3ac31c6ca6deb6c72e9e6b5f661a7c6", size = 14531726, upload-time = "2025-11-28T20:54:59.121Z" },
     { url = "https://files.pythonhosted.org/packages/1d/d2/1637f4360ada6a368d3265bf39f2cf737a0aaab15ab520fc005903e883f8/ruff-0.14.7-py3-none-win_arm64.whl", hash = "sha256:be4d653d3bea1b19742fcc6502354e32f65cd61ff2fbdb365803ef2c2aec6228", size = 13609215, upload-time = "2025-11-28T20:55:15.375Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Introduces a typed Program NewType and a curated ProgramCatalogue with a default allowlist to gate command execution safely
- Unknown programs are blocked by default via UnknownProgramError
- Exposes project metadata to downstream services through `visible_settings()`
- Adds unit and behavioural tests and updates documentation to reflect the safety model

## Changes
- cuprum/program.py
  - Add `Program` as a NewType: `Program = NewType("Program", str)`
- cuprum/catalogue.py (new module)
  - Implement `UnknownProgramError`, `ProjectSettings`, `ProgramEntry`, and `ProgramCatalogue`
  - Define core constants: `CORE_OPS_PROJECT`, `ECHO`, `LS`, `DOC_TOOL`
  - Build a default catalogue `DEFAULT_CATALOGUE` with `DEFAULT_PROJECTS`
  - Provide `visible_settings()` to surface project metadata without mutation
  - Enforce safety by guarding unknown executables and duplicates
- cuprum/__init__.py
  - Re-export catalogue and program symbols for public API:
    - `CORE_OPS_PROJECT`, `DEFAULT_CATALOGUE`, `DEFAULT_PROJECTS`, `DOC_TOOL`, `ECHO`, `LS`, `ProgramCatalogue`, `ProgramEntry`, `ProjectSettings`, `UnknownProgramError`, `Program`
- Tests
  - unit tests: `cuprum/unittests/test_catalogue.py` cover NewType behaviour, default allowlist, safety errors, and metadata exposure
  - behavioural tests: `tests/behaviour/test_catalogue_behaviour.py` and feature file `tests/features/catalogue.feature` verify unknown programs are blocked and metadata is exposed
- Documentation
  - `docs/cuprum-design.md`: add section describing catalogue metadata and safety model
  - `docs/users-guide.md`: explain how to use the curated catalogue and read metadata
  - `docs/roadmap.md`: reflect completion of the typed command core step
- Dependencies
  - `pyproject.toml`: add `pytest-bdd` to dev dependencies
- Lockfile
  - `uv.lock` updated to reflect new/test dependencies

## Usage example
- Access the default safe catalogue and look up a program:
  - from cuprum.catalogue import DEFAULT_CATALOGUE, ECHO
  - from cuprum.program import Program
  - entry = DEFAULT_CATALOGUE.lookup(ECHO)
  - print(entry.program)  # echoes "echo"
  - print(entry.project.name)  # e.g., "core-ops"

- Unknown programs are rejected:
  - DEFAULT_CATALOGUE.lookup(Program("unknown-tool"))  # raises UnknownProgramError

## Why this matters
- Provides a concrete, typed command surface that is safety-first by default
- Makes the set of allowed commands explicit and discoverable via a catalogue
- Enables downstream components to fetch noise rules and documentation links without mutating the catalogue

## Testing
- [x] Unit tests verify typed Program behaviour and catalogue logic
- [x] Behavioural tests assert unknown programs are blocked and metadata is exposed
- [x] Documentation updated to reflect the safety model

## Next steps
- Optional: extend the default catalogue with additional projects/programs as needed while maintaining safety guarantees
- Consider adding runtime policy hooks to adjust noise rules dynamically if required

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c6f484cc-6f2b-418e-8025-9723e201d830

## Summary by Sourcery

Introduce a typed program representation and a curated, metadata-rich catalogue that safely gates command execution via an allowlist.

New Features:
- Add a Program NewType and a ProgramCatalogue with project-scoped metadata, including noise rules and documentation locations, plus a default catalogue of curated programs.
- Expose catalogue project metadata via visible_settings() for downstream consumers while keeping the catalogue immutable.
- Re-export core catalogue and program symbols from the top-level package for use as the public API.

Build:
- Add pytest-bdd to the development dependency group and refresh the lockfile.

Documentation:
- Extend the user guide and design docs to describe the program catalogue, metadata model, and safety guarantees, and update the roadmap to mark the typed command core as complete.

Tests:
- Add unit tests for the catalogue allowlist, UnknownProgramError behaviour, and metadata exposure, plus BDD-style behavioural tests and feature scenarios for catalogue safety and visibility.
