### PR TITLE
Implement typed command core with safety

### DIFF
--- a/cuprum/__init__.py
+++ b/cuprum/__init__.py
@@ -27,6 +27,9 @@ from cuprum.catalogue import (
     UnknownProgramError,
 )
 from cuprum.program import Program
+from cuprum.sh import SafeCmd, SafeCmdBuilder
+
+from . import sh
 
 PACKAGE_NAME = "cuprum"
 
@@ -43,5 +46,8 @@ __all__ = [
     "ProgramCatalogue",
     "ProgramEntry",
     "ProjectSettings",
+    "SafeCmd",
+    "SafeCmdBuilder",
     "UnknownProgramError",
+    "sh",
 ]

--- a/cuprum/sh.py
+++ b/cuprum/sh.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import collections.abc as cabc
 import dataclasses as dc
 import typing as typ
+from pathlib import Path
 
 from cuprum.catalogue import (
     DEFAULT_CATALOGUE,
@@ -22,8 +23,8 @@ from cuprum.catalogue import UnknownProgramError as UnknownProgramError
 if typ.TYPE_CHECKING:
     from cuprum.program import Program
 
-type _ArgValue = object
-type SafeCmdBuilder = cabc.Callable[..., SafeCmd[str]]
+type _ArgValue = str | int | float | bool | Path
+type SafeCmdBuilder = cabc.Callable[..., SafeCmd]
 
 
 def _stringify_arg(value: _ArgValue) -> str:
@@ -59,7 +60,7 @@ def _coerce_argv(
 
 
 @dc.dataclass(frozen=True, slots=True)
-class SafeCmd[Out_co]:
+class SafeCmd:
     """Typed representation of a curated command ready for execution."""
 
     program: Program
@@ -69,7 +70,7 @@ class SafeCmd[Out_co]:
     @property
     def argv_with_program(self) -> tuple[str, ...]:
         """Return argv prefixed with the program name."""
-        return (self.program, *self.argv)
+        return (str(self.program), *self.argv)
 
 
 def make(
@@ -84,7 +85,7 @@ def make(
     """
     entry = catalogue.lookup(program)
 
-    def builder(*args: _ArgValue, **kwargs: _ArgValue) -> SafeCmd[str]:
+    def builder(*args: _ArgValue, **kwargs: _ArgValue) -> SafeCmd:
         argv = _coerce_argv(args, kwargs)
         return SafeCmd(program=entry.program, argv=argv, project=entry.project)
 

--- a/cuprum/sh.py
+++ b/cuprum/sh.py
@@ -1,0 +1,94 @@
+"""Safe command construction facade for curated programs.
+
+This module focuses on the typed core: building ``SafeCmd`` instances from
+curated ``Program`` values. Execution is intentionally out of scope for this
+phase; the commands produced here are data objects that carry program
+metadata and structured argv for later runtime layers.
+"""
+
+from __future__ import annotations
+
+import collections.abc as cabc
+import dataclasses as dc
+import typing as typ
+
+from cuprum.catalogue import (
+    DEFAULT_CATALOGUE,
+    ProgramCatalogue,
+    ProjectSettings,
+)
+from cuprum.catalogue import UnknownProgramError as UnknownProgramError
+
+if typ.TYPE_CHECKING:
+    from cuprum.program import Program
+
+type _ArgValue = object
+type SafeCmdBuilder = cabc.Callable[..., SafeCmd[str]]
+
+
+def _stringify_arg(value: _ArgValue) -> str:
+    """Convert values into argv-safe strings.
+
+    ``None`` is disallowed because it is almost always a mistake in CLI argv
+    construction. Callers should decide how to represent missing values (for
+    example, omit the flag) before invoking ``sh.make``.
+    """
+    if value is None:
+        msg = "None is not a valid argv element for sh.make"
+        raise TypeError(msg)
+    return str(value)
+
+
+def _serialize_kwargs(kwargs: dict[str, _ArgValue]) -> tuple[str, ...]:
+    """Serialise keyword arguments to CLI-style ``--flag=value`` entries."""
+    flags: list[str] = []
+    for key, value in kwargs.items():
+        normalized_key = key.replace("_", "-")
+        flags.append(f"--{normalized_key}={_stringify_arg(value)}")
+    return tuple(flags)
+
+
+def _coerce_argv(
+    args: tuple[_ArgValue, ...],
+    kwargs: dict[str, _ArgValue],
+) -> tuple[str, ...]:
+    """Convert positional and keyword arguments into a single argv tuple."""
+    positional = tuple(_stringify_arg(arg) for arg in args)
+    flags = _serialize_kwargs(kwargs)
+    return positional + flags
+
+
+@dc.dataclass(frozen=True, slots=True)
+class SafeCmd[Out_co]:
+    """Typed representation of a curated command ready for execution."""
+
+    program: Program
+    argv: tuple[str, ...]
+    project: ProjectSettings
+
+    @property
+    def argv_with_program(self) -> tuple[str, ...]:
+        """Return argv prefixed with the program name."""
+        return (self.program, *self.argv)
+
+
+def make(
+    program: Program,
+    *,
+    catalogue: ProgramCatalogue = DEFAULT_CATALOGUE,
+) -> SafeCmdBuilder:
+    """Build a callable that produces ``SafeCmd`` instances for ``program``.
+
+    The supplied ``program`` must exist in the provided catalogue; otherwise an
+    ``UnknownProgramError`` is raised to keep the allowlist the default gate.
+    """
+    entry = catalogue.lookup(program)
+
+    def builder(*args: _ArgValue, **kwargs: _ArgValue) -> SafeCmd[str]:
+        argv = _coerce_argv(args, kwargs)
+        return SafeCmd(program=entry.program, argv=argv, project=entry.project)
+
+    return builder
+
+
+__all__ = ["SafeCmd", "SafeCmdBuilder", "UnknownProgramError", "make"]

--- a/cuprum/unittests/test_sh.py
+++ b/cuprum/unittests/test_sh.py
@@ -34,7 +34,7 @@ def test_make_returns_callable_and_safe_command_metadata() -> None:
     assert cmd.program == ECHO, "Program should be preserved"
     assert cmd.argv == ("-n", "hello"), "Positional args should be captured"
     assert cmd.argv_with_program == (
-        ECHO,
+        str(ECHO),
         "-n",
         "hello",
     ), "Program name must prefix argv"
@@ -53,7 +53,16 @@ def test_keyword_arguments_are_serialised_to_flags() -> None:
         "hello",
         "--punctuation=!",
     ), "Keyword args should become --k=v flags"
-    assert cmd.argv_with_program[0] == ECHO, "Program must remain first element"
+    assert cmd.argv_with_program[0] == str(ECHO), "Program must remain first element"
+
+
+def test_keyword_arguments_normalise_underscores() -> None:
+    """Kwarg names are normalised from underscores to hyphens."""
+    builder = sh.make(ECHO)
+
+    cmd = builder("hello", user_id=42)
+
+    assert cmd.argv[-1] == "--user-id=42", "Underscores should become hyphens"
 
 
 def test_arguments_are_stringified_safely(tmp_path: Path) -> None:
@@ -67,6 +76,26 @@ def test_arguments_are_stringified_safely(tmp_path: Path) -> None:
         working_dir.as_posix(),
         "--count=3",
     ), "Arguments must be stringified in order"
+
+
+def test_make_rejects_none_positional_argument() -> None:
+    """None as a positional argument is rejected with a TypeError."""
+    builder = sh.make(ECHO)
+
+    with pytest.raises(TypeError) as excinfo:
+        builder(None)
+
+    assert "None" in str(excinfo.value), "None should be explicitly rejected"
+
+
+def test_make_rejects_none_keyword_argument() -> None:
+    """None as a keyword argument is rejected with a TypeError."""
+    builder = sh.make(ECHO)
+
+    with pytest.raises(TypeError) as excinfo:
+        builder(flag=None)
+
+    assert "None" in str(excinfo.value), "None should be explicitly rejected"
 
 
 def test_make_supports_custom_catalogue() -> None:
@@ -84,6 +113,6 @@ def test_make_supports_custom_catalogue() -> None:
 
     assert cmd.project is custom_project, "Custom catalogue metadata should be used"
     assert cmd.argv_with_program == (
-        program,
+        str(program),
         "run",
     ), "Full argv should include program and args"

--- a/cuprum/unittests/test_sh.py
+++ b/cuprum/unittests/test_sh.py
@@ -1,0 +1,89 @@
+"""Unit tests for the sh.make typed command core."""
+
+from __future__ import annotations
+
+import typing as typ
+
+import pytest
+
+from cuprum import ECHO, sh
+from cuprum.catalogue import (
+    ProgramCatalogue,
+    ProjectSettings,
+    UnknownProgramError,
+)
+from cuprum.program import Program
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_make_rejects_unknown_program() -> None:
+    """Unknown programs are blocked when constructing builders."""
+    with pytest.raises(UnknownProgramError):
+        sh.make(Program("missing"))
+
+
+def test_make_returns_callable_and_safe_command_metadata() -> None:
+    """sh.make returns SafeCmd instances populated with catalogue metadata."""
+    builder = sh.make(ECHO)
+
+    cmd = builder("-n", "hello")
+
+    assert isinstance(cmd, sh.SafeCmd), "Builder should yield SafeCmd instances"
+    assert cmd.program == ECHO, "Program should be preserved"
+    assert cmd.argv == ("-n", "hello"), "Positional args should be captured"
+    assert cmd.argv_with_program == (
+        ECHO,
+        "-n",
+        "hello",
+    ), "Program name must prefix argv"
+    assert cmd.project.name == "core-ops", "Project metadata should be attached"
+    assert cmd.project.noise_rules, "Noise rules should be surfaced"
+    assert cmd.project.documentation_locations, "Documentation links should surface"
+
+
+def test_keyword_arguments_are_serialised_to_flags() -> None:
+    """Keyword arguments are converted into CLI-style flags."""
+    builder = sh.make(ECHO)
+
+    cmd = builder("hello", punctuation="!")
+
+    assert cmd.argv[-2:] == (
+        "hello",
+        "--punctuation=!",
+    ), "Keyword args should become --k=v flags"
+    assert cmd.argv_with_program[0] == ECHO, "Program must remain first element"
+
+
+def test_arguments_are_stringified_safely(tmp_path: Path) -> None:
+    """Non-string arguments are stringified to maintain typed argv."""
+    builder = sh.make(ECHO)
+    working_dir = tmp_path / "example"
+
+    cmd = builder(working_dir, count=3)
+
+    assert cmd.argv == (
+        working_dir.as_posix(),
+        "--count=3",
+    ), "Arguments must be stringified in order"
+
+
+def test_make_supports_custom_catalogue() -> None:
+    """Injected catalogues drive metadata visible to downstream services."""
+    program = Program("tool")
+    custom_project = ProjectSettings(
+        name="custom",
+        programs=(program,),
+        documentation_locations=("docs/runbook.md",),
+        noise_rules=(r"^skip-me",),
+    )
+    catalogue = ProgramCatalogue(projects=(custom_project,))
+
+    cmd = sh.make(program, catalogue=catalogue)("run")
+
+    assert cmd.project is custom_project, "Custom catalogue metadata should be used"
+    assert cmd.argv_with_program == (
+        program,
+        "run",
+    ), "Full argv should include program and args"

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -248,10 +248,10 @@ to read noise rules and documentation links without mutating the catalogue.
 
 Cuprum distinguishes between:
 
-- **`SafeCmd[Out]`** – commands created from curated `Program` values and typed
+- **`SafeCmd`** – commands created from curated `Program` values and typed
   argument builders;
-- **`DynamicCmd[Out]`** – commands constructed directly from arbitrary argv
-  (user input, legacy integration).
+- **`DynamicCmd`** – commands constructed directly from arbitrary argv (user
+  input, legacy integration).
 
 The public “safe” API produces `SafeCmd` instances. The `cuprum.unsafe`
 namespace exposes functions that construct `DynamicCmd` for the rare cases
@@ -327,10 +327,10 @@ Nominal identifier for an executable, as described above:
 Program = NewType("Program", str)
 ```
 
-#### 6.1.2 `SafeCmd[Out]`
+#### 6.1.2 `SafeCmd`
 
-Represents a prepared command instance that, when run, yields an `Out` value
-(e.g. `str`, `bytes`, or a user type):
+Represents a prepared command instance that, when run, yields a value (e.g.
+`str`, `bytes`, or a user type):
 
 - constructed from a `Program` and arguments;
 - carries execution options (cwd, env overrides, timeout, echo options);
@@ -339,17 +339,18 @@ Represents a prepared command instance that, when run, yields an `Out` value
 Example (type sketch, not final signature):
 
 ```python
-class SafeCmd(Generic[Out]):
+class SafeCmd:
     program: Program
     argv: tuple[str, ...]  # not including program name
 
-    def before(self, hook: BeforeHook) -> "SafeCmd[Out]": ...
-    def after(self, hook: AfterHook) -> "SafeCmd[Out]": ...
+    def before(self, hook: BeforeHook) -> "SafeCmd": ...
+    def after(self, hook: AfterHook) -> "SafeCmd": ...
 
-    async def run(self, *, capture: bool = True, echo: bool = False) -> Out: ...
-    def run_sync(self, *, capture: bool = True, echo: bool = False) -> Out: ...
+    async def run(self, *, capture: bool = True, echo: bool = False) -> object: ...
+    def run_sync(self, *, capture: bool = True, echo: bool = False) -> object: ...
 
-    def __or__(self, other: "SafeCmd[Any]") -> "Pipeline[Out]": ...
+    def __or__(self, other: "SafeCmd") -> "Pipeline":
+        ...
 ```
 
 #### 6.1.3 `DynamicCmd[Out]`
@@ -678,7 +679,8 @@ These events are surfaced to user code via hooks. A typical hook signature
 might be:
 
 ```python
-@dataclass class ExecEvent:
+@dataclass
+class ExecEvent:
     phase: Literal["plan", "start", "stdout", "stderr", "exit"]
     program: Program | None
     argv: tuple[str, ...]

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -483,14 +483,11 @@ classDiagram
         +project: ProjectSettings
     }
 
-    class SafeCmd~Out_co~ {
+    class SafeCmd {
         +program: Program
         +argv: tuple~str,...~
         +project: ProjectSettings
         +argv_with_program() tuple~str,...~
-    }
-
-    class SafeCmd_str {
     }
 
     class SafeCmdBuilder {
@@ -509,12 +506,10 @@ classDiagram
     ProgramEntry --> Program : has
     ProgramEntry --> ProjectSettings : has
 
-    SafeCmd~Out_co~ --> Program : uses
-    SafeCmd~Out_co~ --> ProjectSettings : uses
+    SafeCmd --> Program : uses
+    SafeCmd --> ProjectSettings : uses
 
-    SafeCmd_str --> SafeCmd~Out_co~ : specializes
-
-    SafeCmdBuilder --> SafeCmd_str : builds
+    SafeCmdBuilder --> SafeCmd : builds
 
     sh_module --> ProgramCatalogue : uses
     sh_module --> SafeCmdBuilder : returns

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -492,7 +492,7 @@ classDiagram
 
     class SafeCmdBuilder {
         <<callable>>
-        +__call__(*args: object, **kwargs: object) SafeCmd~str~
+        +__call__(*args: object, **kwargs: object) SafeCmd
     }
 
     class sh_module {
@@ -513,8 +513,7 @@ classDiagram
 
     sh_module --> ProgramCatalogue : uses
     sh_module --> SafeCmdBuilder : returns
-    sh_module --> SafeCmd_str : constructs
-    sh_module --> SafeCmd~Out_co~ : constructs
+    sh_module --> SafeCmd : constructs
 ```
 
 Under the hood, this produces a `Pipeline[str]` instance, starts all component

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -451,7 +451,7 @@ pipeline = ls("-l", "/var/log") | grep("ERROR")
 text = pipeline.run_sync(echo=True)
 ```
 
-Implementation notes for the first iteration:
+##### Implementation notes for the first iteration
 
 - `sh.make` validates the program against the active catalogue when the builder
   is created, surfacing `UnknownProgramError` immediately.
@@ -540,7 +540,7 @@ from cmds import GIT, LS
 # Extend current context’s allowlist
 reg = sh.allow(GIT, LS)
 
-# … commands here can run GIT and LS …
+# ... commands here can run GIT and LS ...
 
 reg.detach()  # remove these from the allowlist again
 ```
@@ -567,7 +567,8 @@ and async tasks.
 hooks:
 
 ```python
-from cuprum import sh from cmds import GIT
+from cuprum import sh
+from cmds import GIT
 
 async def deploy():
     async with sh.scoped(allow={GIT}, before=[audit_hook], after=[metrics_hook]):
@@ -601,12 +602,14 @@ def log_after(cmd, result):
     logger.info("Done %s: exit=%s", cmd, result.exit_code)
 
 # Register context-wide hooks
-before_reg = sh.before(log_before) after_reg = sh.after(log_after)
+before_reg = sh.before(log_before)
+after_reg = sh.after(log_after)
 
 # Hooks apply to all commands in this context
 await do_some_work()
 
-before_reg.detach() after_reg.detach()
+before_reg.detach()
+after_reg.detach()
 ```
 
 As with allowlists, hooks can be registered for a limited scope:
@@ -620,8 +623,9 @@ with sh.before(log_before):
 Per‑command hooks are attached directly to `SafeCmd` instances:
 
 ```python
-cmd = make_deploy_cmd() cmd.before(per_call_before).after(per_call_after) await
-cmd.run()
+cmd = make_deploy_cmd()
+cmd.before(per_call_before).after(per_call_after)
+await cmd.run()
 ```
 
 Hook call order is deterministic. A reasonable order is:
@@ -642,8 +646,8 @@ Examples (conceptual):
 from cuprum import unsafe
 
 # Construct from raw argv (no Program NewType, no builder)
-cmd = unsafe.command_from_argv(["bash", "-lc", user_supplied_script]) await
-cmd.run()
+cmd = unsafe.command_from_argv(["bash", "-lc", user_supplied_script])
+await cmd.run()
 ```
 
 or
@@ -651,8 +655,8 @@ or
 ```python
 from cuprum import sh, unsafe
 
-cmd = unsafe.dynamic("/usr/local/bin/custom-tool", "--flag", user_input) await
-cmd.run()
+cmd = unsafe.dynamic("/usr/local/bin/custom-tool", "--flag", user_input)
+await cmd.run()
 ```
 
 These commands **still** pass through the runtime allowlist (if enabled) and
@@ -683,7 +687,7 @@ might be:
 @dataclass class ExecEvent:
     phase: Literal["plan", "start", "stdout", "stderr", "exit"]
     program: Program | None
-    argv: tuple[str, …]
+    argv: tuple[str, ...]
     cwd: Path | None
     env: Mapping[str, str] | None
     pid: int | None
@@ -862,12 +866,13 @@ Key recommendations that the design encourages:
   For example:
 
   ```python
-  actions: dict[str, Callable[…, SafeCmd[str]]] = {
+  actions: dict[str, Callable[..., SafeCmd[str]]] = {
       "status": git_status,
       "deploy": git_deploy,
   }
 
-  cmd = actions[user_choice](…) await cmd.run()
+  cmd = actions[user_choice](...)
+  await cmd.run()
   ```
 
   Here, the user controls *which builder* is called, but not the argv contents

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -449,6 +449,19 @@ grep = sh.make(GREP)
 
 pipeline = ls("-l", "/var/log") | grep("ERROR")
 text = pipeline.run_sync(echo=True)
+
+Implementation notes for the first iteration:
+
+- `sh.make` validates the program against the active catalogue when the builder
+  is created, surfacing `UnknownProgramError` immediately.
+- Positional arguments are stringified with `str()`. Keyword arguments are
+  serialised as `--flag=value`, replacing underscores with hyphens in flag
+  names to align with common CLI conventions.
+- `None` is rejected as an argument value to catch accidental omissions early;
+  builders should decide whether to omit the flag or substitute a value.
+- `SafeCmd` instances carry the owning `ProjectSettings`, making catalogue
+  noise rules and documentation links visible to downstream hooks without an
+  extra lookup.
 ```
 
 Under the hood, this produces a `Pipeline[str]` instance, starts all component

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -456,7 +456,7 @@ Implementation notes for the first iteration:
 - `sh.make` validates the program against the active catalogue when the builder
   is created, surfacing `UnknownProgramError` immediately.
 - Positional arguments are stringified with `str()`. Keyword arguments are
-  serialised as `--flag=value`, replacing underscores with hyphens in flag
+  serialized as `--flag=value`, replacing underscores with hyphens in flag
   names to align with common CLI conventions.
 - `None` is rejected as an argument value to catch accidental omissions early;
   builders should decide whether to omit the flag or substitute a value.
@@ -464,7 +464,7 @@ Implementation notes for the first iteration:
   noise rules and documentation links visible to downstream hooks without an
   extra lookup.
 
-The following diagram summarises the relationships in the typed command core:
+The following diagram summarizes the relationships in the typed command core:
 
 ```mermaid
 classDiagram

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,7 +15,7 @@ command execution.
 - [x] Introduce the `Program` NewType and a curated catalogue module with a
       default allowlist; block unknown executables by default and cover with
       unit tests.
-- [ ] Add `sh.make` to construct `SafeCmd` instances with typed argv handling
+- [x] Add `sh.make` to construct `SafeCmd` instances with typed argv handling
       and minimal builder examples; document the expected builder pattern in
       `docs/users-guide.md`.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -43,8 +43,8 @@ propagate noise filters and documentation links alongside the allowlist.
 
 Cuprum provides `sh.make` to build typed `SafeCmd` instances from curated
 programs. Builders enforce the catalogue allowlist up front and carry project
-metadata alongside argv so downstream services can apply noise rules or link to
-documentation without a second lookup.
+metadata alongside argv, so downstream services can apply noise rules or link
+to documentation without a second lookup.
 
 - `sh.make` raises `UnknownProgramError` when the program is not in the current
   catalogue.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -65,7 +65,7 @@ print(cmd.project.noise_rules)  # metadata for downstream loggers
 
 ### Writing project-specific builders
 
-Wrap `sh.make` in project modules to centralise validation and expose a clear
+Wrap `sh.make` in project modules to centralize validation and expose a clear
 API for callers:
 
 ```python

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -71,7 +71,7 @@ API for callers:
 ```python
 from pathlib import Path
 
-from cuprum import Program, sh
+from cuprum import Program, SafeCmd, sh
 
 SAFE_CAT = Program("cat")
 
@@ -84,7 +84,7 @@ def _safe_path(path: Path) -> str:
     return path.as_posix()
 
 
-def cat_file(path: Path, numbered: bool = False) -> sh.SafeCmd[str]:
+def cat_file(path: Path, numbered: bool = False) -> SafeCmd:
     args: list[str] = []
     if numbered:
         args.append("-n")

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -38,3 +38,60 @@ catalogue = ProgramCatalogue(projects=(project,))
 
 Downstream services can fetch metadata via `catalogue.visible_settings()` to
 propagate noise filters and documentation links alongside the allowlist.
+
+## Typed command core
+
+Cuprum provides `sh.make` to build typed `SafeCmd` instances from curated
+programs. Builders enforce the catalogue allowlist up front and carry project
+metadata alongside argv so downstream services can apply noise rules or link to
+documentation without a second lookup.
+
+- `sh.make` raises `UnknownProgramError` when the program is not in the current
+  catalogue.
+- Positional arguments are stringified with `str()`.
+- Keyword arguments become `--flag=value` entries with underscores in flag
+  names converted to hyphens.
+- `None` is rejected; decide whether to skip or substitute a flag before
+  calling the builder.
+
+```python
+from cuprum import ECHO, sh
+
+echo = sh.make(ECHO)
+cmd = echo("-n", "hello world")
+print(cmd.argv_with_program)  # ('echo', '-n', 'hello world')
+print(cmd.project.noise_rules)  # metadata for downstream loggers
+```
+
+### Writing project-specific builders
+
+Wrap `sh.make` in project modules to centralise validation and expose a clear
+API for callers:
+
+```python
+from pathlib import Path
+
+from cuprum import Program, sh
+
+SAFE_CAT = Program("cat")
+
+
+def _safe_path(path: Path) -> str:
+    path = path.resolve()
+    if not path.is_file():
+        msg = f"{path} is not a readable file"
+        raise ValueError(msg)
+    return path.as_posix()
+
+
+def cat_file(path: Path, numbered: bool = False) -> sh.SafeCmd[str]:
+    args: list[str] = []
+    if numbered:
+        args.append("-n")
+    args.append(_safe_path(path))
+    return sh.make(SAFE_CAT)(*args)
+```
+
+Builders keep argv construction in one place, making it easier to validate
+inputs, document behaviour, and reuse the same allowlisted program across a
+codebase.

--- a/tests/behaviour/test_catalogue_behaviour.py
+++ b/tests/behaviour/test_catalogue_behaviour.py
@@ -7,6 +7,7 @@ import typing as typ
 from pytest_bdd import given, parsers, scenario, then, when
 
 import cuprum as c
+from cuprum import sh
 from cuprum.catalogue import (
     DEFAULT_CATALOGUE,
     ProgramCatalogue,
@@ -14,9 +15,12 @@ from cuprum.catalogue import (
     ProjectSettings,
     UnknownProgramError,
 )
+from cuprum.program import Program
 
 if typ.TYPE_CHECKING:
     from types import ModuleType
+
+    from cuprum.sh import SafeCmd
 
 
 @scenario("../features/catalogue.feature", "Unknown program is blocked by default")
@@ -38,6 +42,14 @@ def test_project_metadata_visible() -> None:
 )
 def test_curated_program_accepted() -> None:
     """Behavioural coverage for the public API surface."""
+
+
+@scenario(
+    "../features/catalogue.feature",
+    "Safe command builder constructs typed argv",
+)
+def test_safe_command_builder() -> None:
+    """Behavioural coverage for the sh.make safe command factory."""
 
 
 @given("the default catalogue", target_fixture="catalogue")
@@ -87,6 +99,15 @@ def when_lookup_curated_program(
     return result
 
 
+@given(
+    parsers.parse('the curated program "{program_name}" is present in the catalogue'),
+    target_fixture="curated_program",
+)
+def given_curated_program(program_name: str) -> Program:
+    """Provide a curated Program value for sh.make scenarios."""
+    return Program(program_name)
+
+
 @then("the catalogue rejects it with an unknown program error")
 def then_catalogue_rejects(catalogue_result: dict[str, object]) -> None:
     """Assert that an unknown program was rejected."""
@@ -103,6 +124,20 @@ def when_request_visible_settings(
 ) -> typ.Mapping[str, ProjectSettings]:
     """Expose project metadata to the scenario."""
     return catalogue.visible_settings()
+
+
+@when(
+    parsers.parse('I build a safe command with "{first}" and "{second}"'),
+    target_fixture="safe_command",
+)
+def when_build_safe_command(
+    curated_program: Program,
+    first: str,
+    second: str,
+) -> SafeCmd[str]:
+    """Construct a safe command using the sh.make facade."""
+    builder = sh.make(curated_program)
+    return builder(first, second)
 
 
 @then(parsers.parse('project "{project_name}" advertises noise rules and docs'))
@@ -147,4 +182,28 @@ def then_allowlist_accepts_string_name(
     """Confirm allowlist permits string inputs for curated programs."""
     assert public_api.DEFAULT_CATALOGUE.is_allowed(program_name), (
         "Allowlist must accept the curated program's string name"
+    )
+
+
+@then("the safe command argv includes the program name and arguments")
+def then_safe_command_includes_program(
+    safe_command: SafeCmd[str],
+) -> None:
+    """Verify sh.make prepends the program name and stringifies args."""
+    assert safe_command.argv_with_program == (
+        safe_command.program,
+        "-n",
+        "hello world",
+    ), "Full argv should include program name and provided arguments"
+
+
+@then("the safe command exposes project metadata for downstream services")
+def then_safe_command_exposes_metadata(
+    safe_command: SafeCmd[str],
+) -> None:
+    """Ensure downstream services can see project metadata via the command."""
+    project = safe_command.project
+    assert project.noise_rules, "Noise rules should be exposed to consumers"
+    assert project.documentation_locations, (
+        "Documentation links should be exposed to consumers"
     )

--- a/tests/behaviour/test_catalogue_behaviour.py
+++ b/tests/behaviour/test_catalogue_behaviour.py
@@ -134,7 +134,7 @@ def when_build_safe_command(
     curated_program: Program,
     first: str,
     second: str,
-) -> SafeCmd[str]:
+) -> SafeCmd:
     """Construct a safe command using the sh.make facade."""
     builder = sh.make(curated_program)
     return builder(first, second)
@@ -187,11 +187,11 @@ def then_allowlist_accepts_string_name(
 
 @then("the safe command argv includes the program name and arguments")
 def then_safe_command_includes_program(
-    safe_command: SafeCmd[str],
+    safe_command: SafeCmd,
 ) -> None:
     """Verify sh.make prepends the program name and stringifies args."""
     assert safe_command.argv_with_program == (
-        safe_command.program,
+        str(safe_command.program),
         "-n",
         "hello world",
     ), "Full argv should include program name and provided arguments"
@@ -199,7 +199,7 @@ def then_safe_command_includes_program(
 
 @then("the safe command exposes project metadata for downstream services")
 def then_safe_command_exposes_metadata(
-    safe_command: SafeCmd[str],
+    safe_command: SafeCmd,
 ) -> None:
     """Ensure downstream services can see project metadata via the command."""
     project = safe_command.project

--- a/tests/features/catalogue.feature
+++ b/tests/features/catalogue.feature
@@ -15,3 +15,9 @@ Feature: Catalogue defaults
     When I look up the curated program "echo"
     Then the lookup succeeds for project "core-ops" with a typed program
     And the allowlist accepts the string name "ls"
+
+  Scenario: Safe command builder constructs typed argv
+    Given the curated program "echo" is present in the catalogue
+    When I build a safe command with "-n" and "hello world"
+    Then the safe command argv includes the program name and arguments
+    And the safe command exposes project metadata for downstream services


### PR DESCRIPTION
## Summary
- Introduces a typed command core for curated programs via a SafeCmd data object.
- Adds a factory `sh.make` that validates programs against the catalogue and builds SafeCmd instances with structured argv and attached project metadata.
- Improves argv construction: positional args are stringified; keyword args become CLI-style `--flag=value` entries (underscores in flag names are hyphenated). `None` values are rejected to catch mistakes early.
- Exposes `SafeCmd` and `SafeCmdBuilder` publicly and wires up a small façade module (`cuprum.sh`).

## Changes
- New module: cuprum/sh.py
  - SafeCmd dataclass (program, argv, project)
  - SafeCmdBuilder type and `make(program, catalogue=...)` factory
  - Internal helpers: `_stringify_arg`, `_serialize_kwargs`, `_coerce_argv`
  - `argv_with_program` property for easy access to full argv including program name
  - Validation against a catalogue; unknown programs raise `UnknownProgramError`
- Public API exposure
  - Exported `SafeCmd`, `SafeCmdBuilder`, `UnknownProgramError`, and `sh` in cuprum/__init__.py
- Tests
  - Added unit tests: cuprum/unittests/test_sh.py covering
    - Unknown program rejection
    - SafeCmd metadata population from catalogue
    - Keyword args serialisation to flags
    - Stringification of non-string arguments
    - Custom catalogue usage
  - Extended behaviour/tests to include a safe command builder scenario
- Documentation
  - Updated docs/cuprum-design.md with implementation notes for the first iteration
  - Updated docs/users-guide.md to describe the Typed command core and provide usage examples
  - Roadmap updated to reflect completed sh.make task

## How it works
- `sh.make(program, catalogue=...)` validates the provided program exists in the catalogue and returns a builder.
- The builder, when called as `builder(*args, **kwargs)`, produces a `SafeCmd`:
  - `argv` is the positional args stringified plus `--flag=value` entries for kwargs (normalized keys replace `_` with `-`).
  - `argv_with_program` prefixes the argv with the program name.
  - `project` holds the corresponding `ProjectSettings` from the catalogue for downstream visibility (noise rules, docs links).

## Examples
```python
from cuprum import ECHO, sh

cmd_builder = sh.make(ECHO)
cmd = cmd_builder("-n", "hello world", punctuation="!")
print(cmd.argv)  # ('-n', 'hello world', '--punctuation=!')
print(cmd.argv_with_program)  # (ECHO, '-n', 'hello world', '--punctuation=!')
print(cmd.project.noise_rules)  # metadata for downstream loggers
```

## Testing plan
- [x] Unknown programs are rejected by the builder factory
- [x] Builder returns SafeCmd with correct program, argv, and project metadata
- [x] Keyword args serialize to `--flag=value` and underscores are hyphenated
- [x] Non-string positional args are stringified in order
- [x] Custom catalogue can drive project metadata surfaced on SafeCmd
- [x] Safety and type surface validated via unit tests and feature scenarios

## Notes
- Execution of the commands remains out of scope; SafeCmd is a data object that carries metadata and a structured argv for downstream runtimes.
- The design ensures an explicit gate through the catalogue, improving safety and predictability of command construction.

📎 **Task**: https://www.terragonlabs.com/task/853937e5-d75d-4e73-b78c-60c795e47b93