### PR TITLE
Enhance SafeCmd.run: error handling, sinks, and decoding

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -110,8 +110,12 @@ and echo semantics and returns a structured `CommandResult`:
   - `env` overlays key/value pairs on top of the current environment without
     mutating `os.environ`; use it to pass per-command settings.
   - `cwd` sets the working directory for the subprocess when provided.
-  - `cancel_grace` controls how long Cuprum waits after `SIGTERM` before
-    escalating to `SIGKILL`.
+  - `cancel_grace` controls how long Cuprum waits after `SIGTERM` (termination
+    signal) before escalating to `SIGKILL` (kill signal).
+  - `stdout_sink` and `stderr_sink` route echoed output to alternative text
+    streams when `echo=True`.
+  - `encoding` and `errors` configure how captured output is decoded; defaults
+    are `"utf-8"` with `"replace"`.
 - `exit_code`, `pid`, and `ok` on the `CommandResult` make it easy to branch on
   success.
 


### PR DESCRIPTION
## Summary
- Improves error handling and cancellation flow in SafeCmd.run to be more robust during termination and kill phases.
- Adds configurable sinks and decoding options for echoed streams, enabling custom output targets and encoding behavior.
- Refines stream consumption to support capturing and echoing with per-stream configuration.
- Expands test coverage for stderr handling, custom sinks, and encoding configurations.
- Updates user guide to document new options and behaviors.

## Changes
### Core
- Introduced default encoding and error handling: `_DEFAULT_ENCODING = "utf-8"`, `_DEFAULT_ERROR_HANDLING = "replace"`.
- Expanded ExecutionContext with:
  - `stdout_sink` and `stderr_sink` (text sinks for echoed output), defaulting to `sys.stdout`/`sys.stderr`.
  - `encoding` and `errors` for decoding subprocess output.
- Added `_StreamConfig` dataclass to encapsulate per-stream decoding and echo behavior:
  - `capture_output`, `echo_output`, `sink`, `encoding`, `errors`.
- SafeCmd.run now wires sinks from context and uses a per-stream `_StreamConfig` for both stdout and stderr consumption.
- Reworked stream consumption: `_consume_stream` accepts a `config` and respects per-stream capture, echo, and decoding settings.
- Replaced ad-hoc stdout/stderr handling with a unified task approach using `consumers` list and `asyncio.gather`.
- Improved `_write_chunk` to support custom encoding and error handling when echoing to sinks.
- Hardened `_terminate_process` to safely handle missing processes on terminate/kill paths.

### Tests
- Added new unit tests in `cuprum/unittests/test_safe_cmd_run.py`:
  - `test_run_captures_stderr_only` – verifies capturing only stderr while stdout remains empty.
  - `test_run_captures_and_echoes_stderr` – ensures stderr is captured and echoed to the terminal when `echo=True`.
  - `test_run_echoes_to_custom_sinks` – validates that echoed output can be directed to custom sinks provided via `ExecutionContext`.
  - `test_run_decodes_with_configured_encoding` – confirms decoding uses configured `encoding` and `errors` (e.g., CP1252 with strict error handling).

### Docs
- Updated `docs/users-guide.md`:
  - Clarified the `cancel_grace` wording to describe termination vs. kill signals.
  - Documented `stdout_sink` and `stderr_sink` options for redirecting echoed output.
  - Documented `encoding` and `errors` options with defaults (`"utf-8"` and `"replace"`).

## Why
- Provides safer, more predictable error handling when subprocesses are long-running or non-cooperative.
- Enables flexible output handling by allowing custom sinks and explicit decoding behavior, improving testability and integration scenarios.

## Testing plan
- Run unit tests: pytest cuprum/unittests/test_safe_cmd_run.py
- Validate new encoding test against CP1252 environments.
- Manually inspect behavior when using custom sinks and `echo=True` for both stdout and stderr.

## Compatibility
- Backwards compatible for existing users: default behavior remains stdout/stderr echoed to the terminal and decoded with UTF-8 using replace errors unless overridden.
- New options are optional and opt-in via `ExecutionContext` and `SafeCmd.run` parameters.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/39077fba-50c2-4c7a-911b-a04a8a1747d4

## Summary by Sourcery

Enhance SafeCmd.run stream handling with configurable sinks, decoding, and more robust process termination behavior.

New Features:
- Allow SafeCmd.run to direct echoed stdout and stderr to configurable text sinks via ExecutionContext.
- Support configurable character encoding and error handling for decoding subprocess output, applied per stream.

Enhancements:
- Unify stdout and stderr consumption through a shared stream configuration, enabling independent capture and echo semantics.
- Improve subprocess termination logic to safely handle missing or already-exited processes during terminate/kill flows.

Documentation:
- Update the user guide to document new ExecutionContext options for cancel_grace semantics, output sinks, and encoding/error configuration.

Tests:
- Add unit tests covering stderr-only capture, combined capture and echo, custom echo sinks, and non-default encoding/decoding behavior.