### PR TITLE
Add SafeCmd.run_sync with full parity tests

### DIFF
--- a/cuprum/sh.py
+++ b/cuprum/sh.py
@@ -258,6 +258,35 @@ class SafeCmd:
             stderr=stderr_text,
         )
 
+    def run_sync(
+        self,
+        *,
+        capture: bool = True,
+        echo: bool = False,
+        context: ExecutionContext | None = None,
+    ) -> CommandResult:
+        """Execute the command synchronously with predictable semantics.
+
+        This method mirrors ``run()`` by driving the event loop internally.
+        All parameters and return semantics are identical.
+
+        Parameters
+        ----------
+        capture:
+            When ``True`` capture stdout/stderr; otherwise discard them.
+        echo:
+            When ``True`` tee stdout/stderr to the parent process.
+        context:
+            Optional execution settings such as env, cwd, and cancel grace.
+
+        Returns
+        -------
+        CommandResult
+            Structured information about the completed process.
+
+        """
+        return asyncio.run(self.run(capture=capture, echo=echo, context=context))
+
 
 def make(
     program: Program,

--- a/cuprum/unittests/test_safe_cmd_run.py
+++ b/cuprum/unittests/test_safe_cmd_run.py
@@ -13,11 +13,31 @@ from pathlib import Path
 import pytest
 
 from cuprum import ECHO, sh
-from cuprum.sh import ExecutionContext
+from cuprum.sh import CommandResult, ExecutionContext
 from tests.helpers.catalogue import python_builder as build_python_builder
 
 if typ.TYPE_CHECKING:
     from cuprum.sh import SafeCmd
+
+type ExecuteFn = typ.Callable[[SafeCmd, dict[str, typ.Any]], CommandResult]
+
+
+def _execute_async(cmd: SafeCmd, kwargs: dict[str, typ.Any]) -> CommandResult:
+    """Execute a SafeCmd using the async run() method."""
+    return asyncio.run(cmd.run(**kwargs))
+
+
+def _execute_sync(cmd: SafeCmd, kwargs: dict[str, typ.Any]) -> CommandResult:
+    """Execute a SafeCmd using the sync run_sync() method."""
+    return cmd.run_sync(**kwargs)
+
+
+@pytest.fixture(params=["async", "sync"], ids=["run()", "run_sync()"])
+def execution_strategy(request: pytest.FixtureRequest) -> tuple[str, ExecuteFn]:
+    """Provide parametrised execution strategies for run() and run_sync()."""
+    if request.param == "async":
+        return ("async", _execute_async)
+    return ("sync", _execute_sync)
 
 
 @pytest.fixture
@@ -26,11 +46,14 @@ def python_builder() -> typ.Callable[..., SafeCmd]:
     return build_python_builder()
 
 
-def test_run_captures_output_and_exit_code() -> None:
-    """run() captures stdout/stderr and exit code by default."""
+def test_captures_output_and_exit_code(
+    execution_strategy: tuple[str, ExecuteFn],
+) -> None:
+    """Both run() and run_sync() capture stdout/stderr and exit code by default."""
+    _, execute = execution_strategy
     command = sh.make(ECHO)("-n", "hello")
 
-    result = asyncio.run(command.run())
+    result = execute(command, {})
 
     assert result.exit_code == 0
     assert result.ok is True
@@ -38,16 +61,18 @@ def test_run_captures_output_and_exit_code() -> None:
     assert result.stderr == ""
 
 
-def test_run_captures_stderr_only(
+def test_captures_stderr_only(
     python_builder: typ.Callable[..., SafeCmd],
+    execution_strategy: tuple[str, ExecuteFn],
 ) -> None:
-    """run() captures stderr independently when only stderr is written."""
+    """Both run() and run_sync() capture stderr independently."""
+    _, execute = execution_strategy
     command = python_builder(
         "-c",
         'import sys; print("err", file=sys.stderr)',
     )
 
-    result = asyncio.run(command.run())
+    result = execute(command, {})
 
     assert result.exit_code == 0
     assert result.ok is True
@@ -56,17 +81,19 @@ def test_run_captures_stderr_only(
     assert result.stderr.strip() == "err"
 
 
-def test_run_captures_and_echoes_stderr(
+def test_captures_and_echoes_stderr(
     python_builder: typ.Callable[..., SafeCmd],
     capsys: pytest.CaptureFixture[str],
+    execution_strategy: tuple[str, ExecuteFn],
 ) -> None:
-    """run(echo=True) both echoes stderr and captures it separately."""
+    """Both run() and run_sync() echo stderr and capture it separately."""
+    _, execute = execution_strategy
     command = python_builder(
         "-c",
         'import sys; print("err", file=sys.stderr)',
     )
 
-    result = asyncio.run(command.run(echo=True))
+    result = execute(command, {"echo": True})
 
     captured = capsys.readouterr()
 
@@ -79,11 +106,15 @@ def test_run_captures_and_echoes_stderr(
     assert captured.err.strip() == "err"
 
 
-def test_run_echoes_when_requested(capfd: pytest.CaptureFixture[str]) -> None:
-    """run() can echo output to stdout while still capturing it."""
+def test_echoes_when_requested(
+    capfd: pytest.CaptureFixture[str],
+    execution_strategy: tuple[str, ExecuteFn],
+) -> None:
+    """Both run() and run_sync() echo output to stdout while still capturing it."""
+    _, execute = execution_strategy
     command = sh.make(ECHO)("hello runtime")
 
-    result = asyncio.run(command.run(echo=True))
+    result = execute(command, {"echo": True})
 
     captured = capfd.readouterr()
     assert result.stdout is not None
@@ -91,10 +122,12 @@ def test_run_echoes_when_requested(capfd: pytest.CaptureFixture[str]) -> None:
     assert result.stdout.strip() == "hello runtime"
 
 
-def test_run_applies_env_overrides(
+def test_applies_env_overrides(
     python_builder: typ.Callable[..., SafeCmd],
+    execution_strategy: tuple[str, ExecuteFn],
 ) -> None:
-    """run() overlays provided env vars on top of the current environment."""
+    """Both run() and run_sync() overlay env vars without global mutation."""
+    _, execute = execution_strategy
     env_var = "CUPRUM_TEST_ENV"
     original_value = os.environ.get(env_var)
     command = python_builder(
@@ -102,9 +135,7 @@ def test_run_applies_env_overrides(
         f"import os;print(os.getenv('{env_var}'))",
     )
 
-    result = asyncio.run(
-        command.run(context=ExecutionContext(env={env_var: "present"})),
-    )
+    result = execute(command, {"context": ExecutionContext(env={env_var: "present"})})
 
     assert result.stdout is not None
     assert result.stdout.strip() == "present"
@@ -113,43 +144,118 @@ def test_run_applies_env_overrides(
     )
 
 
-def test_run_captures_nonzero_exit_code_and_ok_flag(
+def test_captures_nonzero_exit_code_and_ok_flag(
     python_builder: typ.Callable[..., SafeCmd],
+    execution_strategy: tuple[str, ExecuteFn],
 ) -> None:
-    """run() captures non-zero exits and exposes ok flag."""
+    """Both run() and run_sync() capture non-zero exits and expose ok flag."""
+    _, execute = execution_strategy
     command = python_builder("-c", "import sys; sys.exit(3)")
 
-    result = asyncio.run(command.run())
+    result = execute(command, {})
 
     assert result.exit_code == 3
     assert result.ok is False
 
 
-def test_run_applies_cwd_override(
+def test_applies_cwd_override(
     python_builder: typ.Callable[..., SafeCmd],
     tmp_path: Path,
+    execution_strategy: tuple[str, ExecuteFn],
 ) -> None:
-    """run() executes in the provided working directory when supplied."""
+    """Both run() and run_sync() execute in the provided working directory."""
+    _, execute = execution_strategy
     working_dir = tmp_path / "work"
     working_dir.mkdir()
     command = python_builder("-c", "import os;print(os.getcwd())")
 
-    result = asyncio.run(command.run(context=ExecutionContext(cwd=working_dir)))
+    result = execute(command, {"context": ExecutionContext(cwd=working_dir)})
 
     assert result.stdout is not None
     cwd_result = Path(result.stdout.strip())
     assert cwd_result == working_dir
 
 
-def test_run_allows_disabling_capture() -> None:
-    """run(capture=False) executes the command without retaining stdout/err."""
+def test_allows_disabling_capture(
+    execution_strategy: tuple[str, ExecuteFn],
+) -> None:
+    """Both run() and run_sync() execute without retaining output when disabled."""
+    _, execute = execution_strategy
     command = sh.make(ECHO)("uncaptured output")
 
-    result = asyncio.run(command.run(capture=False))
+    result = execute(command, {"capture": False})
 
     assert result.exit_code == 0
     assert result.stdout is None
     assert result.stderr is None
+
+
+def test_echoes_to_custom_sinks(
+    python_builder: typ.Callable[..., SafeCmd],
+    capsys: pytest.CaptureFixture[str],
+    execution_strategy: tuple[str, ExecuteFn],
+) -> None:
+    """Both run() and run_sync() direct echo output to injected sinks."""
+    _, execute = execution_strategy
+    stdout_sink = io.StringIO()
+    stderr_sink = io.StringIO()
+    command = python_builder(
+        "-c",
+        'import sys; print("out"); print("err", file=sys.stderr)',
+    )
+
+    result = execute(
+        command,
+        {
+            "echo": True,
+            "context": ExecutionContext(
+                stdout_sink=stdout_sink,
+                stderr_sink=stderr_sink,
+            ),
+        },
+    )
+    captured = capsys.readouterr()
+
+    assert result.stdout is not None
+    assert result.stderr is not None
+    assert result.stdout.strip() == "out"
+    assert result.stderr.strip() == "err"
+    assert stdout_sink.getvalue().strip() == "out"
+    assert stderr_sink.getvalue().strip() == "err"
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_decodes_with_configured_encoding(
+    python_builder: typ.Callable[..., SafeCmd],
+    execution_strategy: tuple[str, ExecuteFn],
+) -> None:
+    """Both run() and run_sync() use configured encoding/errors for decoding."""
+    _, execute = execution_strategy
+    command = python_builder(
+        "-c",
+        ("import sys; sys.stdout.buffer.write(bytes([0x96])); sys.stdout.flush()"),
+    )
+
+    result = execute(
+        command,
+        {
+            "context": ExecutionContext(
+                encoding="cp1252",
+                errors="strict",
+            ),
+        },
+    )
+
+    assert result.exit_code == 0
+    assert result.ok is True
+    assert result.stdout == "\u2013"
+    assert result.stderr == ""
+
+
+# -----------------------------------------------------------------------------
+# Async-only tests (cancellation semantics)
+# -----------------------------------------------------------------------------
 
 
 def test_non_cooperative_subprocess_is_escalated_and_killed(
@@ -210,63 +316,6 @@ def test_non_cooperative_subprocess_is_escalated_and_killed(
     _poll_process_death(pid)
 
 
-def test_run_echoes_to_custom_sinks(
-    python_builder: typ.Callable[..., SafeCmd],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """run(echo=True) can direct echo output to injected sinks."""
-    stdout_sink = io.StringIO()
-    stderr_sink = io.StringIO()
-    command = python_builder(
-        "-c",
-        'import sys; print("out"); print("err", file=sys.stderr)',
-    )
-
-    result = asyncio.run(
-        command.run(
-            echo=True,
-            context=ExecutionContext(
-                stdout_sink=stdout_sink,
-                stderr_sink=stderr_sink,
-            ),
-        ),
-    )
-    captured = capsys.readouterr()
-
-    assert result.stdout is not None
-    assert result.stderr is not None
-    assert result.stdout.strip() == "out"
-    assert result.stderr.strip() == "err"
-    assert stdout_sink.getvalue().strip() == "out"
-    assert stderr_sink.getvalue().strip() == "err"
-    assert captured.out == ""
-    assert captured.err == ""
-
-
-def test_run_decodes_with_configured_encoding(
-    python_builder: typ.Callable[..., SafeCmd],
-) -> None:
-    """run() uses the configured encoding/errors when decoding output."""
-    command = python_builder(
-        "-c",
-        ("import sys; sys.stdout.buffer.write(bytes([0x96])); sys.stdout.flush()"),
-    )
-
-    result = asyncio.run(
-        command.run(
-            context=ExecutionContext(
-                encoding="cp1252",
-                errors="strict",
-            ),
-        ),
-    )
-
-    assert result.exit_code == 0
-    assert result.ok is True
-    assert result.stdout == "\u2013"
-    assert result.stderr == ""
-
-
 def _poll_process_death(pid: int, *, timeout: float = 1.0) -> None:
     """Poll for process exit within a timeout, failing if still alive."""
     deadline = time.time() + timeout
@@ -277,185 +326,3 @@ def _poll_process_death(pid: int, *, timeout: float = 1.0) -> None:
             return
         time.sleep(0.02)
     pytest.fail(f"Process {pid} still alive after {timeout}s of polling")
-
-
-# -----------------------------------------------------------------------------
-# run_sync() parity tests
-# -----------------------------------------------------------------------------
-
-
-def test_run_sync_captures_output_and_exit_code() -> None:
-    """run_sync() captures stdout/stderr and exit code by default."""
-    command = sh.make(ECHO)("-n", "hello")
-
-    result = command.run_sync()
-
-    assert result.exit_code == 0
-    assert result.ok is True
-    assert result.stdout == "hello"
-    assert result.stderr == ""
-
-
-def test_run_sync_captures_stderr_only(
-    python_builder: typ.Callable[..., SafeCmd],
-) -> None:
-    """run_sync() captures stderr independently when only stderr is written."""
-    command = python_builder(
-        "-c",
-        'import sys; print("err", file=sys.stderr)',
-    )
-
-    result = command.run_sync()
-
-    assert result.exit_code == 0
-    assert result.ok is True
-    assert result.stdout == ""
-    assert result.stderr is not None
-    assert result.stderr.strip() == "err"
-
-
-def test_run_sync_captures_and_echoes_stderr(
-    python_builder: typ.Callable[..., SafeCmd],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """run_sync(echo=True) both echoes stderr and captures it separately."""
-    command = python_builder(
-        "-c",
-        'import sys; print("err", file=sys.stderr)',
-    )
-
-    result = command.run_sync(echo=True)
-
-    captured = capsys.readouterr()
-
-    assert result.exit_code == 0
-    assert result.ok is True
-    assert result.stdout == ""
-    assert result.stderr is not None
-    assert result.stderr.strip() == "err"
-    assert captured.out == ""
-    assert captured.err.strip() == "err"
-
-
-def test_run_sync_echoes_when_requested(capfd: pytest.CaptureFixture[str]) -> None:
-    """run_sync() can echo output to stdout while still capturing it."""
-    command = sh.make(ECHO)("hello runtime")
-
-    result = command.run_sync(echo=True)
-
-    captured = capfd.readouterr()
-    assert result.stdout is not None
-    assert "hello runtime" in captured.out
-    assert result.stdout.strip() == "hello runtime"
-
-
-def test_run_sync_applies_env_overrides(
-    python_builder: typ.Callable[..., SafeCmd],
-) -> None:
-    """run_sync() overlays provided env vars on top of the current environment."""
-    env_var = "CUPRUM_TEST_ENV"
-    original_value = os.environ.get(env_var)
-    command = python_builder(
-        "-c",
-        f"import os;print(os.getenv('{env_var}'))",
-    )
-
-    result = command.run_sync(context=ExecutionContext(env={env_var: "present"}))
-
-    assert result.stdout is not None
-    assert result.stdout.strip() == "present"
-    assert os.environ.get(env_var) == original_value, (
-        "Environment overlays must not leak globally"
-    )
-
-
-def test_run_sync_captures_nonzero_exit_code_and_ok_flag(
-    python_builder: typ.Callable[..., SafeCmd],
-) -> None:
-    """run_sync() captures non-zero exits and exposes ok flag."""
-    command = python_builder("-c", "import sys; sys.exit(3)")
-
-    result = command.run_sync()
-
-    assert result.exit_code == 3
-    assert result.ok is False
-
-
-def test_run_sync_applies_cwd_override(
-    python_builder: typ.Callable[..., SafeCmd],
-    tmp_path: Path,
-) -> None:
-    """run_sync() executes in the provided working directory when supplied."""
-    working_dir = tmp_path / "work"
-    working_dir.mkdir()
-    command = python_builder("-c", "import os;print(os.getcwd())")
-
-    result = command.run_sync(context=ExecutionContext(cwd=working_dir))
-
-    assert result.stdout is not None
-    cwd_result = Path(result.stdout.strip())
-    assert cwd_result == working_dir
-
-
-def test_run_sync_allows_disabling_capture() -> None:
-    """run_sync(capture=False) executes the command without retaining output."""
-    command = sh.make(ECHO)("uncaptured output")
-
-    result = command.run_sync(capture=False)
-
-    assert result.exit_code == 0
-    assert result.stdout is None
-    assert result.stderr is None
-
-
-def test_run_sync_echoes_to_custom_sinks(
-    python_builder: typ.Callable[..., SafeCmd],
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """run_sync(echo=True) can direct echo output to injected sinks."""
-    stdout_sink = io.StringIO()
-    stderr_sink = io.StringIO()
-    command = python_builder(
-        "-c",
-        'import sys; print("out"); print("err", file=sys.stderr)',
-    )
-
-    result = command.run_sync(
-        echo=True,
-        context=ExecutionContext(
-            stdout_sink=stdout_sink,
-            stderr_sink=stderr_sink,
-        ),
-    )
-    captured = capsys.readouterr()
-
-    assert result.stdout is not None
-    assert result.stderr is not None
-    assert result.stdout.strip() == "out"
-    assert result.stderr.strip() == "err"
-    assert stdout_sink.getvalue().strip() == "out"
-    assert stderr_sink.getvalue().strip() == "err"
-    assert captured.out == ""
-    assert captured.err == ""
-
-
-def test_run_sync_decodes_with_configured_encoding(
-    python_builder: typ.Callable[..., SafeCmd],
-) -> None:
-    """run_sync() uses the configured encoding/errors when decoding output."""
-    command = python_builder(
-        "-c",
-        ("import sys; sys.stdout.buffer.write(bytes([0x96])); sys.stdout.flush()"),
-    )
-
-    result = command.run_sync(
-        context=ExecutionContext(
-            encoding="cp1252",
-            errors="strict",
-        ),
-    )
-
-    assert result.exit_code == 0
-    assert result.ok is True
-    assert result.stdout == "\u2013"
-    assert result.stderr == ""

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@ command execution.
       overrides, structured result object, and cancellation that sends
       terminate then kill after a grace period; add integration tests that
       assert cleanup on cancellation.
-- [ ] Provide `run_sync` that mirrors async behaviour by driving the event loop
+- [x] Provide `run_sync` that mirrors async behaviour by driving the event loop
       and ensures identical error and result semantics; cover parity with
       tests.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -135,3 +135,23 @@ async def greet() -> None:
 If the awaiting task is cancelled while a command is running, Cuprum sends
 `SIGTERM` to the subprocess, waits for a short grace period, and then escalates
 to `SIGKILL` to ensure the child process is cleaned up.
+
+### Synchronous execution
+
+For scripts or contexts where async/await is not available, use `run_sync()`:
+
+```python
+from cuprum import ECHO, ExecutionContext, sh
+
+
+def greet() -> None:
+    cmd = sh.make(ECHO)("-n", "hello sync")
+    ctx = ExecutionContext(env={"GREETING": "1"})
+    result = cmd.run_sync(echo=True, context=ctx)
+    if not result.ok:
+        raise RuntimeError(f"echo failed: {result.exit_code}")
+    print(result.stdout)
+```
+
+`run_sync()` accepts the same parameters as `run()` and returns an identical
+`CommandResult`. It drives the event loop internally via `asyncio.run()`.

--- a/tests/behaviour/test_execution_runtime.py
+++ b/tests/behaviour/test_execution_runtime.py
@@ -45,6 +45,14 @@ def test_cancellation_terminates_subprocess() -> None:
     """Behavioural coverage for cancellation cleanup."""
 
 
+@scenario(
+    "../features/execution_runtime.feature",
+    "Sync run captures output by default",
+)
+def test_sync_run_captures_output() -> None:
+    """Behavioural coverage for sync capture semantics."""
+
+
 @pytest.fixture
 def behaviour_state() -> dict[str, object]:
     """Shared mutable state for behaviour scenarios."""
@@ -65,6 +73,15 @@ def given_simple_echo_command() -> SafeCmd:
 def when_run_command(simple_echo_command: SafeCmd) -> CommandResult:
     """Execute the SafeCmd using the async runtime."""
     return asyncio.run(simple_echo_command.run())
+
+
+@when(
+    "I run the command synchronously",
+    target_fixture="run_result",
+)
+def when_run_command_sync(simple_echo_command: SafeCmd) -> CommandResult:
+    """Execute the SafeCmd using the sync runtime."""
+    return simple_echo_command.run_sync()
 
 
 @then("the command result contains captured output")

--- a/tests/features/execution_runtime.feature
+++ b/tests/features/execution_runtime.feature
@@ -15,3 +15,8 @@ Feature: Execution runtime
     Given a non-cooperative safe command
     When I cancel the command with a short grace period
     Then the subprocess is killed after escalation
+
+  Scenario: Sync run captures output by default
+    Given a simple safe echo command
+    When I run the command synchronously
+    Then the command result contains captured output


### PR DESCRIPTION
## Summary
- Implement SafeCmd.run_sync to drive the event loop synchronously with identical semantics to run()
- Add comprehensive unit tests for parity and edge-cases
- Update docs to reflect the synchronous API and usage

## Changes

### Core Functionality
- Implemented SafeCmd.run_sync in cuprum/sh.py using asyncio.run(self.run(...)) to mirror async behavior and identical return semantics (capture, echo, context).

### Tests
- Added extensive unit tests in cuprum/unittests/test_safe_cmd_run.py to verify:
  - run_sync captures stdout/stderr and exit code by default
  - Capturing and stderr-only scenarios
  - echo=True echoes output while capturing
  - env overrides via ExecutionContext are correctly applied without leaking to global env
  - Non-zero exit codes are captured and ok flag is set accordingly
  - cwd override works as expected
  - capture=False disables capturing stdout/stderr
  - Echoing to custom sinks via ExecutionContext stdout_sink and stderr_sink
  - Decoding with configured encoding and error handling
- Extended behaviour tests:
  - tests/behaviour/test_execution_runtime.py: added scenario to cover synchronous run captures output by default
  - tests/features/execution_runtime.feature: added corresponding feature scenario

### Documentation
- docs/roadmap.md: mark run_sync parity as implemented (x)
- docs/users-guide.md: document synchronous execution with run_sync and its parity with run()

### Test Plan
- Run unit tests for SafeCmd run_sync parity (e.g., pytest cuprum/unittests/test_safe_cmd_run.py -q)
- Run full test suite (pytest) including tests related to execution runtime and behaviour
- Optionally run behave to execute updated behaviours/features (tests/features/execution_runtime.feature)



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9122a1b4-abf8-4c90-a8a1-c87d1e77cf7e