### PR TITLE
Add ContextVar-backed CuprumContext with scoped allowlists and hooks

### DIFF
--- a/cuprum/__init__.py
+++ b/cuprum/__init__.py
@@ -26,6 +26,20 @@ from cuprum.catalogue import (
     ProjectSettings,
     UnknownProgramError,
 )
+from cuprum.context import (
+    AfterHook,
+    AllowRegistration,
+    BeforeHook,
+    CuprumContext,
+    ForbiddenProgramError,
+    HookRegistration,
+    after,
+    allow,
+    before,
+    current_context,
+    get_context,
+    scoped,
+)
 from cuprum.program import Program
 from cuprum.sh import CommandResult, ExecutionContext, SafeCmd, SafeCmdBuilder
 
@@ -42,8 +56,14 @@ __all__ = [
     "ECHO",
     "LS",
     "PACKAGE_NAME",
+    "AfterHook",
+    "AllowRegistration",
+    "BeforeHook",
     "CommandResult",
+    "CuprumContext",
     "ExecutionContext",
+    "ForbiddenProgramError",
+    "HookRegistration",
     "Program",
     "ProgramCatalogue",
     "ProgramEntry",
@@ -51,5 +71,11 @@ __all__ = [
     "SafeCmd",
     "SafeCmdBuilder",
     "UnknownProgramError",
+    "after",
+    "allow",
+    "before",
+    "current_context",
+    "get_context",
+    "scoped",
     "sh",
 ]

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -57,7 +57,12 @@ class CuprumContext:
     after_hooks: tuple[AfterHook, ...] = ()
 
     def is_allowed(self, program: Program) -> bool:
-        """Return True when the program is in the allowlist."""
+        """Return True when the program is in the allowlist.
+
+        Note: An empty allowlist returns False for all programs, but
+        check_allowed() treats an empty allowlist as permissive.
+        Use check_allowed() for enforcement with permissive defaults.
+        """
         return program in self.allowlist
 
     def check_allowed(self, program: Program) -> None:
@@ -278,6 +283,10 @@ class AllowRegistration:
     that same scope, the programs are removed from the inner scope's context,
     leaving outer scopes unaffected. The context is *not* captured at
     registration time; operations always use whatever context is current.
+
+    Important: detach() removes programs from the current context rather than
+    restoring the original context. For automatic restoration, use
+    AllowRegistration as a context manager or wrap in a scoped() block.
     """
 
     __slots__ = ("_detached", "_programs")
@@ -355,6 +364,10 @@ class HookRegistration:
     that same scope, the hook is removed from the inner scope's context,
     leaving outer scopes unaffected. The context is *not* captured at
     registration time; operations always use whatever context is current.
+
+    Important: detach() removes the hook from the current context rather than
+    restoring the original context. For automatic restoration, use
+    HookRegistration as a context manager or wrap in a scoped() block.
     """
 
     __slots__ = ("_detached", "_hook", "_hook_type")

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -61,7 +61,14 @@ class CuprumContext:
         return program in self.allowlist
 
     def check_allowed(self, program: Program) -> None:
-        """Raise ForbiddenProgramError if program is not allowed."""
+        """Raise ForbiddenProgramError if program is not allowed.
+
+        When the allowlist is empty, all programs are permitted (permissive
+        default). This allows gradual adoption: code can run without explicit
+        context setup, and scoped() can later establish restrictions.
+        """
+        if not self.allowlist:
+            return  # Empty allowlist permits all programs
         if not self.is_allowed(program):
             msg = f"Program '{program}' is not allowed in the current context"
             raise ForbiddenProgramError(msg)

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -337,7 +337,25 @@ def allow(*programs: Program) -> AllowRegistration:
 
 
 class HookRegistration:
-    """Registration handle for hooks with detach() and context manager support."""
+    """Registration handle for hooks with detach() and context manager support.
+
+    Scope-aware Context Semantics
+    -----------------------------
+    HookRegistration operates on the current context (via `current_context()`)
+    at both registration and deregistration time. This design interacts with
+    nested scopes as follows:
+
+    - When created, the hook is added to the *current* context at that moment.
+    - When `detach()` is called (or the context manager exits), the hook is
+      removed from the *current* context at that moment.
+    - Each nested `scoped()` block creates its own isolated context via
+      `dc.replace()`. Exiting an inner scope restores the outer scope's context.
+
+    This means if you register within a nested scope and call `detach()` within
+    that same scope, the hook is removed from the inner scope's context,
+    leaving outer scopes unaffected. The context is *not* captured at
+    registration time; operations always use whatever context is current.
+    """
 
     __slots__ = ("_detached", "_hook", "_hook_type")
 

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -254,6 +254,23 @@ class AllowRegistration:
     """Registration handle for dynamic allowlist extension.
 
     Supports detach() and context manager usage for scoped allowing.
+
+    Scope-aware Context Semantics
+    -----------------------------
+    AllowRegistration operates on the current context (via `current_context()`)
+    at both registration and deregistration time. This design interacts with
+    nested scopes as follows:
+
+    - When created, programs are added to the *current* context at that moment.
+    - When `detach()` is called (or the context manager exits), programs are
+      removed from the *current* context at that moment.
+    - Each nested `scoped()` block creates its own isolated context via
+      `dc.replace()`. Exiting an inner scope restores the outer scope's context.
+
+    This means if you register within a nested scope and call `detach()` within
+    that same scope, the programs are removed from the inner scope's context,
+    leaving outer scopes unaffected. The context is *not* captured at
+    registration time; operations always use whatever context is current.
     """
 
     __slots__ = ("_detached", "_programs")

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -1,0 +1,426 @@
+"""Execution context with scoped allowlists and hooks.
+
+CuprumContext provides a ContextVar-backed execution context that scopes
+allowlists and hooks for command execution. Contexts support narrowing
+(restricting the allowlist) and hook registration with deterministic ordering.
+
+Example:
+>>> from cuprum.context import scoped, before, current_context
+>>> from cuprum.catalogue import ECHO
+>>> def log_hook(cmd):
+...     print(f"Running: {cmd}")
+>>> with scoped(allowlist=frozenset([ECHO])):
+...     with before(log_hook):
+...         ctx = current_context()
+...         ctx.is_allowed(ECHO)
+True
+
+"""
+
+from __future__ import annotations
+
+import collections.abc as cabc
+import dataclasses as dc
+import typing as typ
+from contextvars import ContextVar, Token
+
+if typ.TYPE_CHECKING:
+    from cuprum.program import Program
+    from cuprum.sh import CommandResult, SafeCmd
+
+
+type BeforeHook = cabc.Callable[[SafeCmd], None]
+type AfterHook = cabc.Callable[[SafeCmd, CommandResult], None]
+
+
+class ForbiddenProgramError(PermissionError):
+    """Raised when attempting to run a program not in the current allowlist."""
+
+
+@dc.dataclass(frozen=True, slots=True)
+class CuprumContext:
+    """Immutable execution context holding allowlist and hooks.
+
+    Attributes
+    ----------
+    allowlist:
+        Frozenset of programs permitted in this context.
+    before_hooks:
+        Tuple of hooks invoked before command execution (FIFO order).
+    after_hooks:
+        Tuple of hooks invoked after command execution (LIFO order).
+
+    """
+
+    allowlist: frozenset[Program] = dc.field(default_factory=frozenset)
+    before_hooks: tuple[BeforeHook, ...] = ()
+    after_hooks: tuple[AfterHook, ...] = ()
+
+    def is_allowed(self, program: Program) -> bool:
+        """Return True when the program is in the allowlist."""
+        return program in self.allowlist
+
+    def check_allowed(self, program: Program) -> None:
+        """Raise ForbiddenProgramError if program is not allowed."""
+        if not self.is_allowed(program):
+            msg = f"Program '{program}' is not allowed in the current context"
+            raise ForbiddenProgramError(msg)
+
+    def narrow(
+        self,
+        *,
+        allowlist: frozenset[Program] | None = None,
+        before_hooks: tuple[BeforeHook, ...] = (),
+        after_hooks: tuple[AfterHook, ...] = (),
+    ) -> CuprumContext:
+        """Create a derived context with narrowed allowlist and extended hooks.
+
+        Parameters
+        ----------
+        allowlist:
+            New allowlist; intersected with parent if parent is non-empty,
+            otherwise used directly. None keeps the parent list unchanged.
+        before_hooks:
+            Additional before hooks appended after parent hooks.
+        after_hooks:
+            Additional after hooks prepended before parent hooks (LIFO).
+
+        Returns
+        -------
+        CuprumContext
+            A new context with narrowed permissions and extended hooks.
+
+        Notes
+        -----
+        When the parent has an empty allowlist, the provided allowlist is used
+        directly to establish a base scope. When the parent has programs, the
+        new allowlist is intersected to enforce narrowing (can only remove, not
+        add programs). This ensures safety while allowing initial setup.
+
+        """
+        if allowlist is None:
+            new_allowlist = self.allowlist
+        elif self.allowlist:
+            # Parent has programs: intersect to narrow
+            new_allowlist = self.allowlist & allowlist
+        else:
+            # Parent is empty: use provided allowlist as new base
+            new_allowlist = allowlist
+
+        new_before = self.before_hooks + before_hooks
+        # After hooks run inner-to-outer, so prepend new hooks
+        new_after = after_hooks + self.after_hooks
+
+        return CuprumContext(
+            allowlist=new_allowlist,
+            before_hooks=new_before,
+            after_hooks=new_after,
+        )
+
+    def with_allowlist(self, allowlist: frozenset[Program]) -> CuprumContext:
+        """Return a context with the given allowlist replacing the current one.
+
+        Unlike narrow(), this sets the allowlist directly without intersection.
+        Use with care; prefer narrow() for enforcing safety invariants.
+        """
+        return dc.replace(self, allowlist=allowlist)
+
+    def with_before_hook(self, hook: BeforeHook) -> CuprumContext:
+        """Return a context with an additional before hook."""
+        return dc.replace(self, before_hooks=(*self.before_hooks, hook))
+
+    def without_before_hook(self, hook: BeforeHook) -> CuprumContext:
+        """Return a context with the specified before hook removed."""
+        new_hooks = tuple(h for h in self.before_hooks if h is not hook)
+        return dc.replace(self, before_hooks=new_hooks)
+
+    def with_after_hook(self, hook: AfterHook) -> CuprumContext:
+        """Return a context with an additional after hook (prepended for LIFO)."""
+        return dc.replace(self, after_hooks=(hook, *self.after_hooks))
+
+    def without_after_hook(self, hook: AfterHook) -> CuprumContext:
+        """Return a context with the specified after hook removed."""
+        new_hooks = tuple(h for h in self.after_hooks if h is not hook)
+        return dc.replace(self, after_hooks=new_hooks)
+
+    def with_program(self, program: Program) -> CuprumContext:
+        """Return a context with the program added to the allowlist."""
+        return dc.replace(self, allowlist=self.allowlist | {program})
+
+    def without_program(self, program: Program) -> CuprumContext:
+        """Return a context with the program removed from the allowlist."""
+        return dc.replace(self, allowlist=self.allowlist - {program})
+
+
+# Global ContextVar for the current execution context.
+# Default is the singleton _DEFAULT_CONTEXT which is immutable (frozen dataclass).
+_DEFAULT_CONTEXT = CuprumContext()
+_current_context: ContextVar[CuprumContext] = ContextVar(
+    "cuprum_context",
+    default=_DEFAULT_CONTEXT,
+)
+
+
+def current_context() -> CuprumContext:
+    """Return the current execution context."""
+    return _current_context.get()
+
+
+def get_context() -> CuprumContext:
+    """Alias for current_context()."""
+    return current_context()
+
+
+def _set_context(ctx: CuprumContext) -> Token[CuprumContext]:
+    """Set the current context and return a token for restoration."""
+    return _current_context.set(ctx)
+
+
+def _reset_context(token: Token[CuprumContext]) -> None:
+    """Restore the context to its previous state using the token."""
+    _current_context.reset(token)
+
+
+class _ScopedContext:
+    """Context manager for entering a scoped execution context."""
+
+    __slots__ = ("_ctx", "_token")
+
+    def __init__(
+        self,
+        *,
+        allowlist: frozenset[Program] | None = None,
+        before_hooks: tuple[BeforeHook, ...] = (),
+        after_hooks: tuple[AfterHook, ...] = (),
+    ) -> None:
+        parent = current_context()
+        self._ctx = parent.narrow(
+            allowlist=allowlist,
+            before_hooks=before_hooks,
+            after_hooks=after_hooks,
+        )
+        self._token: Token[CuprumContext] | None = None
+
+    def __enter__(self) -> CuprumContext:
+        self._token = _set_context(self._ctx)
+        return self._ctx
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        if self._token is not None:
+            _reset_context(self._token)
+
+
+def scoped(
+    *,
+    allowlist: frozenset[Program] | None = None,
+    before_hooks: tuple[BeforeHook, ...] = (),
+    after_hooks: tuple[AfterHook, ...] = (),
+) -> _ScopedContext:
+    """Create a scoped context manager for narrowed execution.
+
+    Parameters
+    ----------
+    allowlist:
+        Programs to allow (intersected with parent allowlist).
+    before_hooks:
+        Hooks to run before command execution.
+    after_hooks:
+        Hooks to run after command execution.
+
+    Returns
+    -------
+    _ScopedContext
+        A context manager that narrows the current context.
+
+    Example
+    -------
+    >>> with scoped(allowlist=frozenset([ECHO])) as ctx:
+    ...     assert ctx.is_allowed(ECHO)
+
+    """
+    return _ScopedContext(
+        allowlist=allowlist,
+        before_hooks=before_hooks,
+        after_hooks=after_hooks,
+    )
+
+
+class AllowRegistration:
+    """Registration handle for dynamic allowlist extension.
+
+    Supports detach() and context manager usage for scoped allowing.
+    """
+
+    __slots__ = ("_detached", "_programs")
+
+    def __init__(self, *programs: Program) -> None:
+        """Create an allowlist registration and add programs to current context."""
+        self._programs = frozenset(programs)
+        self._detached = False
+        # Add programs to current context
+        ctx = current_context()
+        new_ctx = dc.replace(ctx, allowlist=ctx.allowlist | self._programs)
+        _set_context(new_ctx)
+
+    def detach(self) -> None:
+        """Remove the allowed programs from the current context."""
+        if self._detached:
+            return
+        self._detached = True
+        ctx = current_context()
+        new_ctx = dc.replace(ctx, allowlist=ctx.allowlist - self._programs)
+        _set_context(new_ctx)
+
+    def __enter__(self) -> AllowRegistration:
+        """Enter context manager; programs are already registered."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        """Exit context manager; detach registered programs."""
+        self.detach()
+
+
+def allow(*programs: Program) -> AllowRegistration:
+    """Extend the current context's allowlist with additional programs.
+
+    Parameters
+    ----------
+    programs:
+        Programs to add to the allowlist.
+
+    Returns
+    -------
+    AllowRegistration
+        A handle that can be detached or used as a context manager.
+
+    Example
+    -------
+    >>> with allow(LS):
+    ...     assert current_context().is_allowed(LS)
+
+    """
+    return AllowRegistration(*programs)
+
+
+class HookRegistration:
+    """Registration handle for hooks with detach() and context manager support."""
+
+    __slots__ = ("_detached", "_hook", "_hook_type")
+
+    def __init__(
+        self,
+        hook: BeforeHook | AfterHook,
+        hook_type: typ.Literal["before", "after"],
+    ) -> None:
+        """Create a hook registration and add hook to current context."""
+        self._hook = hook
+        self._hook_type = hook_type
+        self._detached = False
+        # Add hook to current context
+        ctx = current_context()
+        if hook_type == "before":
+            new_ctx = ctx.with_before_hook(typ.cast("BeforeHook", hook))
+        else:
+            new_ctx = ctx.with_after_hook(typ.cast("AfterHook", hook))
+        _set_context(new_ctx)
+
+    def detach(self) -> None:
+        """Remove the hook from the current context."""
+        if self._detached:
+            return
+        self._detached = True
+        ctx = current_context()
+        if self._hook_type == "before":
+            new_ctx = ctx.without_before_hook(typ.cast("BeforeHook", self._hook))
+        else:
+            new_ctx = ctx.without_after_hook(typ.cast("AfterHook", self._hook))
+        _set_context(new_ctx)
+
+    def __enter__(self) -> HookRegistration:
+        """Enter context manager; hook is already registered."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        """Exit context manager; detach registered hook."""
+        self.detach()
+
+
+def before(hook: BeforeHook) -> HookRegistration:
+    """Register a before-execution hook in the current context.
+
+    Parameters
+    ----------
+    hook:
+        Callable invoked with the SafeCmd before execution.
+
+    Returns
+    -------
+    HookRegistration
+        A handle that can be detached or used as a context manager.
+
+    Example
+    -------
+    >>> def log_cmd(cmd):
+    ...     print(f"Running: {cmd.program}")
+    >>> with before(log_cmd):
+    ...     # Commands run here will trigger log_cmd
+    ...     pass
+
+    """
+    return HookRegistration(hook, "before")
+
+
+def after(hook: AfterHook) -> HookRegistration:
+    """Register an after-execution hook in the current context.
+
+    Parameters
+    ----------
+    hook:
+        Callable invoked with the SafeCmd and CommandResult after execution.
+
+    Returns
+    -------
+    HookRegistration
+        A handle that can be detached or used as a context manager.
+
+    Example
+    -------
+    >>> def log_result(cmd, result):
+    ...     print(f"Finished: {cmd.program} -> {result.exit_code}")
+    >>> with after(log_result):
+    ...     # Commands run here will trigger log_result
+    ...     pass
+
+    """
+    return HookRegistration(hook, "after")
+
+
+__all__ = [
+    "AfterHook",
+    "AllowRegistration",
+    "BeforeHook",
+    "CuprumContext",
+    "ForbiddenProgramError",
+    "HookRegistration",
+    "after",
+    "allow",
+    "before",
+    "current_context",
+    "get_context",
+    "scoped",
+]

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -267,28 +267,15 @@ class AllowRegistration:
 
     Supports detach() and context manager usage for scoped allowing.
 
-    Scope-aware Context Semantics
-    -----------------------------
-    AllowRegistration operates on the current context (via `current_context()`)
-    at both registration and deregistration time. This design interacts with
-    nested scopes as follows:
-
-    - When created, programs are added to the *current* context at that moment.
-    - When `detach()` is called (or the context manager exits), programs are
-      removed from the *current* context at that moment.
-    - Each nested `scoped()` block creates its own isolated context via
-      `dc.replace()`. Exiting an inner scope restores the outer scope's context.
-
-    This means if you register within a nested scope and call `detach()` within
-    that same scope, the programs are removed from the inner scope's context,
-    leaving outer scopes unaffected. The context is *not* captured at
-    registration time; operations always use whatever context is current.
-
     Token-based Restoration
     -----------------------
     The registration captures a token at creation time. When detach() is called,
     the original context is restored via the token, ensuring no context pollution
-    even when used outside scoped() blocks.
+    even when used outside scoped() blocks. This means detach() restores the
+    exact context that existed when the registration was created, regardless of
+    subsequent context modifications. If multiple registrations are created and
+    detached in non-LIFO order, earlier tokens may restore states that remove
+    programs added by later registrations.
     """
 
     __slots__ = ("_detached", "_programs", "_token")
@@ -350,28 +337,13 @@ def allow(*programs: Program) -> AllowRegistration:
 class HookRegistration:
     """Registration handle for hooks with detach() and context manager support.
 
-    Scope-aware Context Semantics
-    -----------------------------
-    HookRegistration operates on the current context (via `current_context()`)
-    at both registration and deregistration time. This design interacts with
-    nested scopes as follows:
-
-    - When created, the hook is added to the *current* context at that moment.
-    - When `detach()` is called (or the context manager exits), the hook is
-      removed from the *current* context at that moment.
-    - Each nested `scoped()` block creates its own isolated context via
-      `dc.replace()`. Exiting an inner scope restores the outer scope's context.
-
-    This means if you register within a nested scope and call `detach()` within
-    that same scope, the hook is removed from the inner scope's context,
-    leaving outer scopes unaffected. The context is *not* captured at
-    registration time; operations always use whatever context is current.
-
     Token-based Restoration
     -----------------------
     The registration captures a token at creation time. When detach() is called,
     the original context is restored via the token, ensuring no context pollution
-    even when used outside scoped() blocks.
+    even when used outside scoped() blocks. This means detach() restores the
+    exact context that existed when the registration was created, regardless of
+    subsequent context modifications.
     """
 
     __slots__ = ("_detached", "_hook", "_hook_type", "_token")

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -275,7 +275,11 @@ class AllowRegistration:
     exact context that existed when the registration was created, regardless of
     subsequent context modifications. If multiple registrations are created and
     detached in non-LIFO order, earlier tokens may restore states that remove
-    programs added by later registrations.
+    programs added by other registrations.
+
+    Detach in the same logical Context (thread or Task) in which the
+    registration was created. Resetting a ContextVar with a token from a
+    different Context raises ValueError and would break this guarantee.
     """
 
     __slots__ = ("_detached", "_programs", "_token")
@@ -344,6 +348,10 @@ class HookRegistration:
     even when used outside scoped() blocks. This means detach() restores the
     exact context that existed when the registration was created, regardless of
     subsequent context modifications.
+
+    As with AllowRegistration, detach the hook only from the Context where
+    it was registered; using the token in a different Context will raise
+    ValueError in the standard library.
     """
 
     __slots__ = ("_detached", "_hook", "_hook_type", "_token")

--- a/cuprum/unittests/test_context.py
+++ b/cuprum/unittests/test_context.py
@@ -70,11 +70,11 @@ def test_empty_hooks_by_default() -> None:
 
 def test_context_with_hooks() -> None:
     """Context retains provided hooks."""
-    before: BeforeHook = mock.Mock()
-    after: AfterHook = mock.Mock()
-    ctx = CuprumContext(before_hooks=(before,), after_hooks=(after,))
-    assert ctx.before_hooks == (before,)
-    assert ctx.after_hooks == (after,)
+    before_hook: BeforeHook = mock.Mock()
+    after_hook: AfterHook = mock.Mock()
+    ctx = CuprumContext(before_hooks=(before_hook,), after_hooks=(after_hook,))
+    assert ctx.before_hooks == (before_hook,)
+    assert ctx.after_hooks == (after_hook,)
 
 
 # =============================================================================
@@ -163,7 +163,7 @@ def test_scoped_restores_on_exception() -> None:
     """scoped() restores context even when exception is raised."""
     original = current_context()
     with (
-        pytest.raises(ValueError),  # noqa: PT011
+        pytest.raises(ValueError, match=r"test"),
         scoped(allowlist=frozenset([ECHO])),
     ):
         raise ValueError("test")

--- a/cuprum/unittests/test_context.py
+++ b/cuprum/unittests/test_context.py
@@ -30,9 +30,16 @@ from cuprum.program import Program
 
 
 def test_empty_context_has_no_allowlist() -> None:
-    """A context without explicit allowlist blocks all programs."""
+    """A context without explicit allowlist has an empty frozenset."""
     ctx = CuprumContext()
     assert ctx.allowlist == frozenset()
+
+
+def test_check_allowed_permits_all_with_empty_allowlist() -> None:
+    """check_allowed permits all programs when allowlist is empty."""
+    ctx = CuprumContext()  # Empty allowlist permits all (permissive default)
+    ctx.check_allowed(ECHO)  # Must not raise
+    ctx.check_allowed(LS)  # Must not raise
 
 
 def test_context_with_allowlist() -> None:

--- a/cuprum/unittests/test_context.py
+++ b/cuprum/unittests/test_context.py
@@ -1,0 +1,385 @@
+"""Unit tests for CuprumContext and hooks."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import typing as typ
+from unittest import mock
+
+import pytest
+
+from cuprum.catalogue import ECHO, LS
+from cuprum.context import (
+    AfterHook,
+    BeforeHook,
+    CuprumContext,
+    ForbiddenProgramError,
+    current_context,
+    get_context,
+    scoped,
+)
+from cuprum.program import Program
+
+# =============================================================================
+# CuprumContext Basics
+# =============================================================================
+
+
+def test_empty_context_has_no_allowlist() -> None:
+    """A context without explicit allowlist blocks all programs."""
+    ctx = CuprumContext()
+    assert ctx.allowlist == frozenset()
+
+
+def test_context_with_allowlist() -> None:
+    """Context retains provided allowlist."""
+    programs = frozenset([ECHO, LS])
+    ctx = CuprumContext(allowlist=programs)
+    assert ctx.allowlist == programs
+
+
+def test_is_allowed_returns_true_for_allowed_program() -> None:
+    """is_allowed returns True when program is in allowlist."""
+    ctx = CuprumContext(allowlist=frozenset([ECHO]))
+    assert ctx.is_allowed(ECHO) is True
+
+
+def test_is_allowed_returns_false_for_disallowed_program() -> None:
+    """is_allowed returns False when program is not in allowlist."""
+    ctx = CuprumContext(allowlist=frozenset([ECHO]))
+    assert ctx.is_allowed(LS) is False
+
+
+def test_empty_hooks_by_default() -> None:
+    """Context has empty hooks by default."""
+    ctx = CuprumContext()
+    assert ctx.before_hooks == ()
+    assert ctx.after_hooks == ()
+
+
+def test_context_with_hooks() -> None:
+    """Context retains provided hooks."""
+    before: BeforeHook = mock.Mock()
+    after: AfterHook = mock.Mock()
+    ctx = CuprumContext(before_hooks=(before,), after_hooks=(after,))
+    assert ctx.before_hooks == (before,)
+    assert ctx.after_hooks == (after,)
+
+
+# =============================================================================
+# Context Narrowing
+# =============================================================================
+
+
+def test_narrow_reduces_allowlist() -> None:
+    """narrow() intersects with parent allowlist."""
+    parent = CuprumContext(allowlist=frozenset([ECHO, LS]))
+    narrowed = parent.narrow(allowlist=frozenset([ECHO]))
+    assert narrowed.allowlist == frozenset([ECHO])
+
+
+def test_narrow_cannot_widen_allowlist() -> None:
+    """narrow() cannot add programs not in parent when parent is non-empty."""
+    new_program = Program("cat")
+    parent = CuprumContext(allowlist=frozenset([ECHO]))
+    narrowed = parent.narrow(allowlist=frozenset([ECHO, new_program]))
+    assert narrowed.allowlist == frozenset([ECHO])
+
+
+def test_narrow_establishes_base_when_parent_empty() -> None:
+    """narrow() uses provided allowlist when parent is empty."""
+    parent = CuprumContext()  # Empty allowlist
+    narrowed = parent.narrow(allowlist=frozenset([ECHO, LS]))
+    assert narrowed.allowlist == frozenset([ECHO, LS])
+
+
+def test_narrow_appends_before_hooks() -> None:
+    """narrow() appends new before hooks after parent hooks."""
+    parent_hook: BeforeHook = mock.Mock()
+    child_hook: BeforeHook = mock.Mock()
+    parent = CuprumContext(before_hooks=(parent_hook,))
+    narrowed = parent.narrow(before_hooks=(child_hook,))
+    assert narrowed.before_hooks == (parent_hook, child_hook)
+
+
+def test_narrow_prepends_after_hooks() -> None:
+    """narrow() prepends new after hooks before parent hooks (LIFO)."""
+    parent_hook: AfterHook = mock.Mock()
+    child_hook: AfterHook = mock.Mock()
+    parent = CuprumContext(after_hooks=(parent_hook,))
+    narrowed = parent.narrow(after_hooks=(child_hook,))
+    # After hooks run inner-to-outer: child first, then parent
+    assert narrowed.after_hooks == (child_hook, parent_hook)
+
+
+# =============================================================================
+# Global ContextVar Access
+# =============================================================================
+
+
+def test_current_context_returns_context() -> None:
+    """current_context() returns the current context."""
+    ctx = current_context()
+    assert isinstance(ctx, CuprumContext)
+
+
+def test_get_context_returns_same_as_current() -> None:
+    """get_context() is an alias for current_context()."""
+    assert get_context() is current_context()
+
+
+# =============================================================================
+# Scoped Context Manager
+# =============================================================================
+
+
+def test_scoped_narrows_allowlist_in_block() -> None:
+    """scoped() narrows allowlist within the context block."""
+    with scoped(allowlist=frozenset([ECHO])) as ctx:
+        assert ctx.is_allowed(ECHO) is True
+        assert current_context() is ctx
+
+
+def test_scoped_restores_context_after_block() -> None:
+    """scoped() restores previous context after exiting block."""
+    original = current_context()
+    with scoped(allowlist=frozenset([ECHO])):
+        pass
+    assert current_context() is original
+
+
+def test_scoped_restores_on_exception() -> None:
+    """scoped() restores context even when exception is raised."""
+    original = current_context()
+    with (
+        pytest.raises(ValueError),  # noqa: PT011
+        scoped(allowlist=frozenset([ECHO])),
+    ):
+        raise ValueError("test")
+    assert current_context() is original
+
+
+def test_nested_scopes_stack_correctly() -> None:
+    """Nested scoped() calls narrow progressively."""
+    with scoped(allowlist=frozenset([ECHO, LS])) as outer:
+        assert outer.is_allowed(ECHO) is True
+        assert outer.is_allowed(LS) is True
+        with scoped(allowlist=frozenset([ECHO])) as inner:
+            assert inner.is_allowed(ECHO) is True
+            assert inner.is_allowed(LS) is False
+        # Back to outer scope
+        assert current_context().is_allowed(LS) is True
+
+
+# =============================================================================
+# AllowRegistration
+# =============================================================================
+
+
+def test_allow_adds_programs_to_context() -> None:
+    """AllowRegistration adds programs to current context allowlist."""
+    with scoped(allowlist=frozenset([ECHO])):
+        from cuprum.context import allow
+
+        reg = allow(LS)
+        assert current_context().is_allowed(LS) is True
+        reg.detach()
+        # After detach, LS should no longer be allowed in current scope
+        assert current_context().is_allowed(LS) is False
+
+
+def test_allow_as_context_manager() -> None:
+    """AllowRegistration can be used as a context manager."""
+    with scoped(allowlist=frozenset([ECHO])):
+        from cuprum.context import allow
+
+        with allow(LS):
+            assert current_context().is_allowed(LS) is True
+        assert current_context().is_allowed(LS) is False
+
+
+# =============================================================================
+# HookRegistration
+# =============================================================================
+
+
+def test_before_hook_registration_and_detach() -> None:
+    """before() registers a hook that can be detached."""
+    from cuprum.context import before
+
+    hook: BeforeHook = mock.Mock()
+    with scoped():
+        reg = before(hook)
+        assert hook in current_context().before_hooks
+        reg.detach()
+        assert hook not in current_context().before_hooks
+
+
+def test_after_hook_registration_and_detach() -> None:
+    """after() registers a hook that can be detached."""
+    from cuprum.context import after
+
+    hook: AfterHook = mock.Mock()
+    with scoped():
+        reg = after(hook)
+        assert hook in current_context().after_hooks
+        reg.detach()
+        assert hook not in current_context().after_hooks
+
+
+def test_before_hook_as_context_manager() -> None:
+    """before() can be used as a context manager."""
+    from cuprum.context import before
+
+    hook: BeforeHook = mock.Mock()
+    with scoped():
+        with before(hook):
+            assert hook in current_context().before_hooks
+        assert hook not in current_context().before_hooks
+
+
+def test_after_hook_as_context_manager() -> None:
+    """after() can be used as a context manager."""
+    from cuprum.context import after
+
+    hook: AfterHook = mock.Mock()
+    with scoped():
+        with after(hook):
+            assert hook in current_context().after_hooks
+        assert hook not in current_context().after_hooks
+
+
+# =============================================================================
+# Hook Ordering
+# =============================================================================
+
+
+def test_before_hooks_execute_in_registration_order() -> None:
+    """Before hooks execute in registration order (FIFO)."""
+    call_order: list[int] = []
+
+    def hook1(cmd: object) -> None:
+        _ = cmd  # Unused
+        call_order.append(1)
+
+    def hook2(cmd: object) -> None:
+        _ = cmd  # Unused
+        call_order.append(2)
+
+    def hook3(cmd: object) -> None:
+        _ = cmd  # Unused
+        call_order.append(3)
+
+    ctx = CuprumContext(
+        before_hooks=(
+            typ.cast("BeforeHook", hook1),
+            typ.cast("BeforeHook", hook2),
+            typ.cast("BeforeHook", hook3),
+        ),
+    )
+
+    # Execute hooks manually to verify order
+    for hook in ctx.before_hooks:
+        hook(typ.cast("typ.Any", None))
+
+    assert call_order == [1, 2, 3]
+
+
+def test_after_hooks_execute_in_reverse_registration_order() -> None:
+    """After hooks execute inner-to-outer (LIFO within a level)."""
+    call_order: list[int] = []
+
+    def hook1(cmd: object, result: object) -> None:
+        _, _ = cmd, result  # Unused
+        call_order.append(1)
+
+    def hook2(cmd: object, result: object) -> None:
+        _, _ = cmd, result  # Unused
+        call_order.append(2)
+
+    def hook3(cmd: object, result: object) -> None:
+        _, _ = cmd, result  # Unused
+        call_order.append(3)
+
+    # In after_hooks, prepended hooks run first
+    ctx = CuprumContext(
+        after_hooks=(
+            typ.cast("AfterHook", hook3),
+            typ.cast("AfterHook", hook2),
+            typ.cast("AfterHook", hook1),
+        ),
+    )
+
+    for hook in ctx.after_hooks:
+        hook(typ.cast("typ.Any", None), typ.cast("typ.Any", None))
+
+    assert call_order == [3, 2, 1]
+
+
+# =============================================================================
+# Context Isolation (Threads)
+# =============================================================================
+
+
+def test_context_is_isolated_per_thread() -> None:
+    """Each thread has its own context."""
+    results: dict[str, bool] = {}
+
+    def thread_worker(name: str, programs: frozenset[Program]) -> None:
+        with scoped(allowlist=programs):
+            results[name] = current_context().is_allowed(ECHO)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        f1 = executor.submit(thread_worker, "thread1", frozenset([ECHO]))
+        f2 = executor.submit(thread_worker, "thread2", frozenset([LS]))
+        f1.result()
+        f2.result()
+
+    assert results["thread1"] is True
+    assert results["thread2"] is False
+
+
+# =============================================================================
+# Context Isolation (Async Tasks)
+# =============================================================================
+
+
+def test_context_is_isolated_per_async_task() -> None:
+    """Each async task has its own context."""
+    results: dict[str, bool] = {}
+
+    async def task_worker(name: str, programs: frozenset[Program]) -> None:
+        with scoped(allowlist=programs):
+            await asyncio.sleep(0.01)  # Yield to allow interleaving
+            results[name] = current_context().is_allowed(ECHO)
+
+    async def run_tasks() -> None:
+        await asyncio.gather(
+            task_worker("task1", frozenset([ECHO])),
+            task_worker("task2", frozenset([LS])),
+        )
+
+    asyncio.run(run_tasks())
+
+    assert results["task1"] is True
+    assert results["task2"] is False
+
+
+# =============================================================================
+# ForbiddenProgramError
+# =============================================================================
+
+
+def test_forbidden_program_error_raised_for_disallowed() -> None:
+    """check_allowed raises ForbiddenProgramError for disallowed programs."""
+    ctx = CuprumContext(allowlist=frozenset([ECHO]))
+    with pytest.raises(ForbiddenProgramError) as exc_info:
+        ctx.check_allowed(LS)
+    assert "ls" in str(exc_info.value).lower()
+
+
+def test_check_allowed_passes_for_allowed_program() -> None:
+    """check_allowed does not raise for allowed programs."""
+    ctx = CuprumContext(allowlist=frozenset([ECHO]))
+    ctx.check_allowed(ECHO)  # Should not raise

--- a/cuprum/unittests/test_context.py
+++ b/cuprum/unittests/test_context.py
@@ -15,6 +15,9 @@ from cuprum.context import (
     BeforeHook,
     CuprumContext,
     ForbiddenProgramError,
+    after,
+    allow,
+    before,
     current_context,
     get_context,
     scoped,
@@ -180,8 +183,6 @@ def test_nested_scopes_stack_correctly() -> None:
 def test_allow_adds_programs_to_context() -> None:
     """AllowRegistration adds programs to current context allowlist."""
     with scoped(allowlist=frozenset([ECHO])):
-        from cuprum.context import allow
-
         reg = allow(LS)
         assert current_context().is_allowed(LS) is True
         reg.detach()
@@ -192,8 +193,6 @@ def test_allow_adds_programs_to_context() -> None:
 def test_allow_as_context_manager() -> None:
     """AllowRegistration can be used as a context manager."""
     with scoped(allowlist=frozenset([ECHO])):
-        from cuprum.context import allow
-
         with allow(LS):
             assert current_context().is_allowed(LS) is True
         assert current_context().is_allowed(LS) is False
@@ -206,8 +205,6 @@ def test_allow_as_context_manager() -> None:
 
 def test_before_hook_registration_and_detach() -> None:
     """before() registers a hook that can be detached."""
-    from cuprum.context import before
-
     hook: BeforeHook = mock.Mock()
     with scoped():
         reg = before(hook)
@@ -218,8 +215,6 @@ def test_before_hook_registration_and_detach() -> None:
 
 def test_after_hook_registration_and_detach() -> None:
     """after() registers a hook that can be detached."""
-    from cuprum.context import after
-
     hook: AfterHook = mock.Mock()
     with scoped():
         reg = after(hook)
@@ -230,8 +225,6 @@ def test_after_hook_registration_and_detach() -> None:
 
 def test_before_hook_as_context_manager() -> None:
     """before() can be used as a context manager."""
-    from cuprum.context import before
-
     hook: BeforeHook = mock.Mock()
     with scoped():
         with before(hook):
@@ -241,8 +234,6 @@ def test_before_hook_as_context_manager() -> None:
 
 def test_after_hook_as_context_manager() -> None:
     """after() can be used as a context manager."""
-    from cuprum.context import after
-
     hook: AfterHook = mock.Mock()
     with scoped():
         with after(hook):

--- a/cuprum/unittests/test_safe_cmd_run.py
+++ b/cuprum/unittests/test_safe_cmd_run.py
@@ -346,7 +346,7 @@ def test_run_raises_forbidden_when_program_not_in_allowlist(
     other_program = Program("cat")
     with (
         scoped(allowlist=frozenset([other_program])),
-        pytest.raises(ForbiddenProgramError),
+        pytest.raises(ForbiddenProgramError, match=r"echo"),
     ):
         execute(command, {})
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,7 @@ command execution.
 
 ### Step: context and hooks
 
-- [ ] Add `CuprumContext` backed by a `ContextVar`, supporting allowlist
+- [x] Add `CuprumContext` backed by a `ContextVar`, supporting allowlist
       narrowing plus before/after hooks with deterministic ordering and
       `.detach()`; test nesting across threads and async tasks.
 - [ ] Ship a basic logging hook emitting start/exit events compatible with

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -162,6 +162,12 @@ Cuprum provides `CuprumContext` to scope allowlists and execution hooks across
 your application. Contexts are backed by a `ContextVar`, giving you automatic
 isolation across threads and async tasks.
 
+> **Note:** Context integration with `SafeCmd.run()` is planned for a future
+> release. Currently, `CuprumContext` provides the infrastructure for scoped
+> allowlists and hooks, but `SafeCmd.run()` does not yet automatically check
+> allowlists or invoke hooks. You can manually call `ctx.check_allowed()` and
+> invoke hooks in your application code until full integration is available.
+
 ### Scoped contexts
 
 Use `scoped()` to establish a narrowed execution context within a code block:
@@ -338,3 +344,4 @@ try:
     ctx.check_allowed(LS)
 except ForbiddenProgramError as e:
     print(f"Access denied: {e}")
+```

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -162,11 +162,13 @@ Cuprum provides `CuprumContext` to scope allowlists and execution hooks across
 your application. Contexts are backed by a `ContextVar`, giving you automatic
 isolation across threads and async tasks.
 
-> **Note:** Context integration with `SafeCmd.run()` is planned for a future
-> release. Currently, `CuprumContext` provides the infrastructure for scoped
-> allowlists and hooks, but `SafeCmd.run()` does not yet automatically check
-> allowlists or invoke hooks. You can manually call `ctx.check_allowed()` and
-> invoke hooks in your application code until full integration is available.
+When you call `SafeCmd.run()` or `run_sync()`, Cuprum automatically:
+
+1. Checks the current context's allowlist and raises `ForbiddenProgramError` if
+   the program is not permitted.
+2. Invokes all registered before hooks (in FIFO order) before process execution.
+3. Invokes all registered after hooks (in LIFO order) after the process
+   completes.
 
 ### Scoped contexts
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -170,6 +170,11 @@ When you call `SafeCmd.run()` or `run_sync()`, Cuprum automatically:
 3. Invokes all registered after hooks (in LIFO order) after the process
    completes.
 
+**Empty allowlist behavior:** When no context is established (or the context has
+an empty allowlist), all programs are permitted. This permissive default enables
+gradual adoption—code runs without explicit context setup, and you can later
+introduce restrictions via `scoped()`.
+
 ### Scoped contexts
 
 Use `scoped()` to establish a narrowed execution context within a code block:

--- a/tests/behaviour/test_context_hooks.py
+++ b/tests/behaviour/test_context_hooks.py
@@ -1,0 +1,377 @@
+"""Behavioural tests for CuprumContext and hooks."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import typing as typ
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from cuprum.catalogue import ECHO, LS
+from cuprum.context import (
+    CuprumContext,
+    before,
+    current_context,
+    scoped,
+)
+
+if typ.TYPE_CHECKING:
+    from cuprum.context import BeforeHook
+    from cuprum.program import Program
+
+
+@scenario(
+    "../features/context_hooks.feature",
+    "Scoped context narrows allowlist",
+)
+def test_scoped_context_narrows_allowlist() -> None:
+    """Behavioural coverage for allowlist narrowing."""
+
+
+@scenario(
+    "../features/context_hooks.feature",
+    "Context restores after scope exits",
+)
+def test_context_restores_after_scope_exits() -> None:
+    """Behavioural coverage for context restoration."""
+
+
+@scenario(
+    "../features/context_hooks.feature",
+    "Before hooks execute in registration order",
+)
+def test_before_hooks_execute_in_order() -> None:
+    """Behavioural coverage for before hook ordering."""
+
+
+@scenario(
+    "../features/context_hooks.feature",
+    "After hooks execute in reverse order",
+)
+def test_after_hooks_execute_in_reverse() -> None:
+    """Behavioural coverage for after hook ordering."""
+
+
+@scenario(
+    "../features/context_hooks.feature",
+    "Hook registration can be detached",
+)
+def test_hook_registration_detach() -> None:
+    """Behavioural coverage for hook detachment."""
+
+
+@scenario(
+    "../features/context_hooks.feature",
+    "Context is isolated across threads",
+)
+def test_context_isolated_threads() -> None:
+    """Behavioural coverage for thread isolation."""
+
+
+@scenario(
+    "../features/context_hooks.feature",
+    "Context is isolated across async tasks",
+)
+def test_context_isolated_async_tasks() -> None:
+    """Behavioural coverage for async task isolation."""
+
+
+@pytest.fixture
+def behaviour_state() -> dict[str, object]:
+    """Shared mutable state for behaviour scenarios."""
+    return {}
+
+
+@given(
+    "a context that allows echo and ls",
+    target_fixture="outer_context",
+)
+def given_context_allows_echo_and_ls() -> CuprumContext:
+    """Set up an outer context allowing both ECHO and LS."""
+    return CuprumContext(allowlist=frozenset([ECHO, LS]))
+
+
+@when("I enter a scoped context allowing only echo")
+def when_enter_scoped_echo_only(
+    behaviour_state: dict[str, object],
+    outer_context: CuprumContext,
+) -> None:
+    """Enter a scoped context with narrowed allowlist."""
+    _ = outer_context  # Required fixture, used to establish scenario context
+    # Use the outer context as a base and narrow via scoped()
+    with (
+        scoped(allowlist=frozenset([ECHO, LS])),
+        scoped(allowlist=frozenset([ECHO])) as inner,
+    ):
+        behaviour_state["inner_context"] = inner
+
+
+@then("echo is allowed in the inner scope")
+def then_echo_allowed_inner(behaviour_state: dict[str, object]) -> None:
+    """Verify ECHO is allowed in inner scope."""
+    inner = typ.cast("CuprumContext", behaviour_state["inner_context"])
+    assert inner.is_allowed(ECHO) is True
+
+
+@then("ls is not allowed in the inner scope")
+def then_ls_not_allowed_inner(behaviour_state: dict[str, object]) -> None:
+    """Verify LS is not allowed in inner scope."""
+    inner = typ.cast("CuprumContext", behaviour_state["inner_context"])
+    assert inner.is_allowed(LS) is False
+
+
+@when("I enter and exit a scoped context allowing only echo")
+def when_enter_exit_scoped(
+    behaviour_state: dict[str, object],
+    outer_context: CuprumContext,
+) -> None:
+    """Enter and exit a nested scope."""
+    _ = outer_context  # Required fixture, used to establish scenario context
+    with scoped(allowlist=frozenset([ECHO, LS])):
+        behaviour_state["before_exit"] = current_context()
+        with scoped(allowlist=frozenset([ECHO])):
+            pass
+        behaviour_state["after_exit"] = current_context()
+
+
+@then("ls is allowed in the outer scope")
+def then_ls_allowed_outer(behaviour_state: dict[str, object]) -> None:
+    """Verify LS is allowed after exiting inner scope."""
+    after_exit = typ.cast("CuprumContext", behaviour_state["after_exit"])
+    assert after_exit.is_allowed(LS) is True
+
+
+@given(
+    "a context with multiple before hooks",
+    target_fixture="multi_before_context",
+)
+def given_multi_before_hooks(
+    behaviour_state: dict[str, object],
+) -> CuprumContext:
+    """Create context with multiple before hooks for ordering test."""
+    call_order: list[int] = []
+    behaviour_state["call_order"] = call_order
+
+    def hook1(cmd: object) -> None:
+        _ = cmd  # Unused
+        call_order.append(1)
+
+    def hook2(cmd: object) -> None:
+        _ = cmd  # Unused
+        call_order.append(2)
+
+    def hook3(cmd: object) -> None:
+        _ = cmd  # Unused
+        call_order.append(3)
+
+    return CuprumContext(
+        before_hooks=(
+            typ.cast("BeforeHook", hook1),
+            typ.cast("BeforeHook", hook2),
+            typ.cast("BeforeHook", hook3),
+        ),
+    )
+
+
+@when("I invoke the before hooks")
+def when_invoke_before_hooks(
+    multi_before_context: CuprumContext,
+) -> None:
+    """Execute all before hooks."""
+    for hook in multi_before_context.before_hooks:
+        hook(typ.cast("typ.Any", None))
+
+
+@then("they execute in registration order")
+def then_before_hooks_in_order(behaviour_state: dict[str, object]) -> None:
+    """Verify before hooks ran in order."""
+    call_order = typ.cast("list[int]", behaviour_state["call_order"])
+    assert call_order == [1, 2, 3]
+
+
+@given(
+    "a context with multiple after hooks",
+    target_fixture="multi_after_context",
+)
+def given_multi_after_hooks(
+    behaviour_state: dict[str, object],
+) -> CuprumContext:
+    """Create context with multiple after hooks for ordering test."""
+    call_order: list[int] = []
+    behaviour_state["after_call_order"] = call_order
+
+    def hook1(cmd: object, result: object) -> None:
+        _, _ = cmd, result  # Unused
+        call_order.append(1)
+
+    def hook2(cmd: object, result: object) -> None:
+        _, _ = cmd, result  # Unused
+        call_order.append(2)
+
+    def hook3(cmd: object, result: object) -> None:
+        _, _ = cmd, result  # Unused
+        call_order.append(3)
+
+    # After hooks are stored in reverse order (inner-to-outer)
+    return CuprumContext(
+        after_hooks=(
+            typ.cast("typ.Any", hook3),
+            typ.cast("typ.Any", hook2),
+            typ.cast("typ.Any", hook1),
+        ),
+    )
+
+
+@when("I invoke the after hooks")
+def when_invoke_after_hooks(
+    multi_after_context: CuprumContext,
+) -> None:
+    """Execute all after hooks."""
+    for hook in multi_after_context.after_hooks:
+        hook(typ.cast("typ.Any", None), typ.cast("typ.Any", None))
+
+
+@then("they execute in reverse registration order")
+def then_after_hooks_in_reverse(behaviour_state: dict[str, object]) -> None:
+    """Verify after hooks ran in reverse order (inner first)."""
+    call_order = typ.cast("list[int]", behaviour_state["after_call_order"])
+    assert call_order == [3, 2, 1]
+
+
+@given(
+    "a context with a registered before hook",
+    target_fixture="hook_context",
+)
+def given_context_with_hook(
+    behaviour_state: dict[str, object],
+) -> dict[str, object]:
+    """Set up a context with a hook that can be detached."""
+
+    def my_hook(cmd: object) -> None:
+        _ = cmd  # Unused
+
+    behaviour_state["test_hook"] = my_hook
+    return {"hook": my_hook}
+
+
+@when("I detach the hook registration")
+def when_detach_hook(
+    behaviour_state: dict[str, object],
+    hook_context: dict[str, object],
+) -> None:
+    """Register and detach a hook."""
+    hook = typ.cast("BeforeHook", hook_context["hook"])
+    with scoped():
+        reg = before(hook)
+        behaviour_state["hook_in_context_before"] = (
+            hook in current_context().before_hooks
+        )
+        reg.detach()
+        behaviour_state["hook_in_context_after"] = (
+            hook in current_context().before_hooks
+        )
+
+
+@then("the hook is no longer in the context")
+def then_hook_not_in_context(behaviour_state: dict[str, object]) -> None:
+    """Verify hook was removed after detach."""
+    assert behaviour_state["hook_in_context_before"] is True
+    assert behaviour_state["hook_in_context_after"] is False
+
+
+@given(
+    "two threads with different allowlists",
+    target_fixture="thread_setup",
+)
+def given_two_threads_different_allowlists() -> dict[str, frozenset[Program]]:
+    """Set up allowlists for two threads."""
+    return {
+        "thread1": frozenset([ECHO]),
+        "thread2": frozenset([LS]),
+    }
+
+
+@when("each thread checks its allowlist")
+def when_threads_check_allowlist(
+    behaviour_state: dict[str, object],
+    thread_setup: dict[str, frozenset[Program]],
+) -> None:
+    """Run threads that each set and check their context."""
+    results: dict[str, tuple[bool, bool]] = {}
+
+    def thread_worker(name: str, programs: frozenset[Program]) -> None:
+        with scoped(allowlist=programs):
+            ctx = current_context()
+            results[name] = (ctx.is_allowed(ECHO), ctx.is_allowed(LS))
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        f1 = executor.submit(thread_worker, "thread1", thread_setup["thread1"])
+        f2 = executor.submit(thread_worker, "thread2", thread_setup["thread2"])
+        f1.result()
+        f2.result()
+
+    behaviour_state["thread_results"] = results
+
+
+@then("each thread sees its own allowlist")
+def then_threads_see_own_allowlist(behaviour_state: dict[str, object]) -> None:
+    """Verify thread isolation."""
+    results = typ.cast(
+        "dict[str, tuple[bool, bool]]",
+        behaviour_state["thread_results"],
+    )
+    # thread1 allows ECHO only
+    assert results["thread1"] == (True, False)
+    # thread2 allows LS only
+    assert results["thread2"] == (False, True)
+
+
+@given(
+    "two async tasks with different allowlists",
+    target_fixture="async_setup",
+)
+def given_two_async_tasks_different_allowlists() -> dict[str, frozenset[Program]]:
+    """Set up allowlists for two async tasks."""
+    return {
+        "task1": frozenset([ECHO]),
+        "task2": frozenset([LS]),
+    }
+
+
+@when("each task checks its allowlist")
+def when_tasks_check_allowlist(
+    behaviour_state: dict[str, object],
+    async_setup: dict[str, frozenset[Program]],
+) -> None:
+    """Run async tasks that each set and check their context."""
+    results: dict[str, tuple[bool, bool]] = {}
+
+    async def task_worker(name: str, programs: frozenset[Program]) -> None:
+        with scoped(allowlist=programs):
+            await asyncio.sleep(0.01)  # Allow interleaving
+            ctx = current_context()
+            results[name] = (ctx.is_allowed(ECHO), ctx.is_allowed(LS))
+
+    async def run_tasks() -> None:
+        await asyncio.gather(
+            task_worker("task1", async_setup["task1"]),
+            task_worker("task2", async_setup["task2"]),
+        )
+
+    asyncio.run(run_tasks())
+    behaviour_state["async_results"] = results
+
+
+@then("each task sees its own allowlist")
+def then_tasks_see_own_allowlist(behaviour_state: dict[str, object]) -> None:
+    """Verify async task isolation."""
+    results = typ.cast(
+        "dict[str, tuple[bool, bool]]",
+        behaviour_state["async_results"],
+    )
+    # task1 allows ECHO only
+    assert results["task1"] == (True, False)
+    # task2 allows LS only
+    assert results["task2"] == (False, True)

--- a/tests/features/context_hooks.feature
+++ b/tests/features/context_hooks.feature
@@ -1,0 +1,38 @@
+Feature: Execution context and hooks
+  CuprumContext scopes allowlists and hooks for command execution.
+
+  Scenario: Scoped context narrows allowlist
+    Given a context that allows echo and ls
+    When I enter a scoped context allowing only echo
+    Then echo is allowed in the inner scope
+    And ls is not allowed in the inner scope
+
+  Scenario: Context restores after scope exits
+    Given a context that allows echo and ls
+    When I enter and exit a scoped context allowing only echo
+    Then ls is allowed in the outer scope
+
+  Scenario: Before hooks execute in registration order
+    Given a context with multiple before hooks
+    When I invoke the before hooks
+    Then they execute in registration order
+
+  Scenario: After hooks execute in reverse order
+    Given a context with multiple after hooks
+    When I invoke the after hooks
+    Then they execute in reverse registration order
+
+  Scenario: Hook registration can be detached
+    Given a context with a registered before hook
+    When I detach the hook registration
+    Then the hook is no longer in the context
+
+  Scenario: Context is isolated across threads
+    Given two threads with different allowlists
+    When each thread checks its allowlist
+    Then each thread sees its own allowlist
+
+  Scenario: Context is isolated across async tasks
+    Given two async tasks with different allowlists
+    When each task checks its allowlist
+    Then each task sees its own allowlist


### PR DESCRIPTION
## Summary
- Adds a complete CuprumContext system backed by ContextVar, with scoped allowlists, before/after hooks, and deterministic ordering. Includes API surface, tests (unit, behaviour, and features), and documentation updates to reflect usage and design decisions.

## Changes

### Core functionality
- Implemented cuprum/context.py introducing:
  - CuprumContext: immutable, ContextVar-backed context carrying an allowlist, before_hooks, and after_hooks.
  - Narrowing semantics:
    - When parent allowlist is empty, provided allowlist becomes the new base.
    - When parent allowlist is non-empty, provided allowlist is intersected (narrowing only).
  - Hook handling with deterministic ordering:
    - Before hooks execute in registration order (FIFO).
    - After hooks execute in reverse order (LIFO).
  - Context management:
    - scoped() context manager for entering a narrowed context.
    - _ScopedContext facilitating safe enter/exit with restoration.
  - Registration helpers:
    - AllowRegistration: dynamic extension and detachment of allowlists.
    - HookRegistration: registration and detachment for before/after hooks.
  - Utility API:
    - current_context(), get_context(), with_allowlist(), with_before_hook(), with_after_hook(), etc.
  - Exceptions:
    - ForbiddenProgramError raised when checking/entering a non-allowed program.
  - Type aliases for BeforeHook and AfterHook.

### API exposure
- Updated cuprum/__init__.py to export new context-related symbols:
  - AfterHook, BeforeHook, CuprumContext, ForbiddenProgramError, HookRegistration
  - after, before, allow, scoped, current_context, get_context

### Tests
- Added unit tests: cuprum/unittests/test_context.py
  - Verifies basic context behavior, narrowing semantics, hook ordering, and error handling.
- Added behavioural tests: tests/behaviour/test_context_hooks.py
  - Covers scoped narrowing, hook registration/detachment, and thread/async task isolation.
- Added feature file: tests/features/context_hooks.feature
  - Documents scenarios for context hooks and scoped behavior.
- Expanded design/test coverage to ensure deterministic hook ordering and safe context restoration across nested scopes and concurrent execution.

### Documentation
- Updated docs/cuprum-design.md with a dedicated CuprumContext Decisions section explaining:
  - Allowlist narrowing semantics
  - Hook ordering (FIFO for before, LIFO for after)
  - ContextVar usage and immutability guarantees
  - Registration and detachment semantics
- Updated docs/roadmap.md to reflect completion of the context/hook scope work
- Expanded docs/users-guide.md with:
  - Scoped contexts usage examples
  - Dynamic allowlist extension via allow()
  - Before/after hook usage examples and ordering
  - Thread and async task isolation notes

## Testing plan
- Run the full test suite locally:
  - pytest -q
  - pytest tests/behaviour -q
  - pytest cuprum/unittests/test_context.py -q
- Verify:
  - Scoped contexts correctly narrow and restore across nested blocks.
  - Before hooks run in registration order; after hooks run in reverse order.
  - Dynamic allowlist extension via AllowRegistration and detach() behaves correctly.
  - HookRegistration can be used as a context manager and detaches on exit.
  - Context isolation across threads and async tasks is preserved.
  - ForbiddenProgramError is raised for disallowed programs and passed for allowed ones.

## Usage highlights
- Scoped contexts:
-  from cuprum import ECHO, scoped
+  with scoped(allowlist=frozenset([ECHO])) as ctx:
+      assert ctx.is_allowed(ECHO)
+      # embed nested scopes to narrow further

- Dynamic allowlisting:
+  from cuprum import LS, allow, current_context, scoped
+  with scoped(allowlist=frozenset([ECHO])):
+      reg = allow(LS)
+      assert current_context().is_allowed(LS)
+      reg.detach()
+      assert not current_context().is_allowed(LS)
+
- Hooks:
+  from cuprum import before, after
+  with scoped(allowlist=frozenset([ECHO])):
+      with before(log_before), after(log_after):
+          # commands executed will trigger hooks
+
+### Breaking changes
+- None expected. The new CuprumContext API is additive and designed to be backward-compatible with existing usage patterns.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2dec09a9-6212-4091-ad25-8870a2e8ff68