### PR TITLE
Add fun, friendly README for cuprum

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ For the full guide—including how to build your own programme catalogues, write
 project-specific builders, and control execution contexts—see the
 [users' guide](docs/users-guide.md).
 
+## Why "cuprum"?
+
+The name is a tip of the hat to [Plumbum](https://plumbum.readthedocs.io/), the
+library that showed us shell-like scripting in Python could actually be
+pleasant. "Cuprum" is Latin for copper—another metal used in pipes—and we hope
+to carry that spirit forward with a focus on type safety and explicit
+allowlists.
+
 ## Licence
 
 ISC

--- a/README.md
+++ b/README.md
@@ -1,3 +1,86 @@
 # cuprum
 
-Example package generated from this Copier template.
+Typed, async command execution for Python—so you can ditch the shell scripts
+without losing your mind.
+
+## What is this?
+
+If you've ever written a Python script that calls out to external commands,
+you've probably experienced the joys of `subprocess`: stringly-typed arguments,
+mysterious failures, and output that vanishes into the void. Cuprum is here to
+help.
+
+We give you a **typed, safe approach to running external programs**. Instead of
+passing arbitrary strings to a shell, you work with a curated catalogue of
+approved executables. Each command carries metadata about its project, so
+downstream tooling knows how to filter noise from logs or where to find
+documentation.
+
+Cuprum is async-first but provides synchronous wrappers for scripts that don't
+need the full async machinery. Whether you're building deployment helpers, CI
+glue, or maintenance scripts, we want "Python instead of Bash" to feel like an
+upgrade rather than a chore.
+
+## Quick taste
+
+```python
+from cuprum import ECHO, ExecutionContext, sh
+
+# Create a builder for a curated program
+echo = sh.make(ECHO)
+
+# Build a command with typed arguments
+cmd = echo("-n", "hello, cuprum!")
+
+# Run it (async)
+result = await cmd.run(echo=True)
+if result.ok:
+    print(f"Output: {result.stdout}")
+
+# Or run it synchronously
+result = cmd.run_sync()
+```
+
+## Features
+
+- **Catalogue-based safety** – Only approved programs can run; unknown
+  executables raise `UnknownProgramError`.
+- **Typed command building** – `sh.make()` returns builders that validate
+  arguments and carry project metadata.
+- **Async-first execution** – `await cmd.run()` with capture/echo toggles,
+  environment overlays, and working directory control.
+- **Synchronous convenience** – `cmd.run_sync()` when you don't need async.
+- **Graceful cancellation** – Cancelled tasks send `SIGTERM`, wait briefly,
+  then escalate to `SIGKILL`.
+- **Structured results** – `CommandResult` gives you exit code, pid, stdout,
+  stderr, and an `ok` helper.
+- **Zero dependencies** – Just Python 3.12+ and the standard library.
+
+## Installation
+
+```shell
+pip install cuprum
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```shell
+uv add cuprum
+```
+
+## Status
+
+Cuprum is in early development. The typed command core and execution runtime
+are complete (Phase 1 of the [roadmap](docs/roadmap.md)), but context-scoped
+allowlists and hooks are still on the way. The API may shift as we learn what
+works best.
+
+## Documentation
+
+For the full guide—including how to build your own programme catalogues, write
+project-specific builders, and control execution contexts—see the
+[users' guide](docs/users-guide.md).
+
+## Licence
+
+ISC

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ works best.
 
 ## Documentation
 
-For the full guide—including how to build your own programme catalogues, write
+For the full guide—including how to build your own program catalogues, write
 project-specific builders, and control execution contexts—see the
 [users' guide](docs/users-guide.md).
 

--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ allowlists.
 
 ## Licence
 
-ISC
+[ISC](LICENSE)


### PR DESCRIPTION
## Summary
- Adds a welcoming README for cuprum that explains the library's purpose and usage in a friendly tone.
- Replaces the previous minimal README with a full guide including quick taste, features, installation, status, docs, and license.

## Changes

### README
- Replaced placeholder with a complete README that covers:
  - What cuprum is and why it helps
  - Quick taste: how to build and run commands with typed builders
  - Features: catalogue-based safety, typed building, async-first execution, synchronous convenience, graceful cancellation, structured results, zero dependencies
  - Installation: pip install cuprum or uv add cuprum
  - Status: early development and roadmap reference
  - Documentation: users guide link
  - Licence: ISC

### Documentation
- Clarified language, improved onboarding, and added pointers to docs/roadmap and docs/users-guide

## Test plan
- [x] Review README sections for clarity
- [x] Ensure content aligns with current library capabilities
- [x] Validate that installation commands are correct and discoverable

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a9426569-c466-4567-bb30-d8ab4a03480b

## Summary by Sourcery

Documentation:
- Add a comprehensive, friendly README describing cuprum’s purpose, features, installation, status, documentation, and licensing.