### PR TITLE
Introduce streaming Pipeline API with Pipeline and PipelineResult

### DIFF
--- a/cuprum/__init__.py
+++ b/cuprum/__init__.py
@@ -42,7 +42,14 @@ from cuprum.context import (
 )
 from cuprum.logging_hooks import LoggingHookRegistration, logging_hook
 from cuprum.program import Program
-from cuprum.sh import CommandResult, ExecutionContext, SafeCmd, SafeCmdBuilder
+from cuprum.sh import (
+    CommandResult,
+    ExecutionContext,
+    Pipeline,
+    PipelineResult,
+    SafeCmd,
+    SafeCmdBuilder,
+)
 
 from . import sh
 
@@ -66,6 +73,8 @@ __all__ = [
     "ForbiddenProgramError",
     "HookRegistration",
     "LoggingHookRegistration",
+    "Pipeline",
+    "PipelineResult",
     "Program",
     "ProgramCatalogue",
     "ProgramEntry",

--- a/cuprum/unittests/test_pipeline.py
+++ b/cuprum/unittests/test_pipeline.py
@@ -8,8 +8,85 @@ import typing as typ
 import pytest
 
 from cuprum import ECHO, scoped, sh
-from cuprum.sh import _READ_SIZE, Pipeline, PipelineResult, _pump_stream
+from cuprum.sh import (
+    _READ_SIZE,
+    Pipeline,
+    PipelineResult,
+    _prepare_pipeline_config,
+    _pump_stream,
+    _spawn_pipeline_processes,
+)
 from tests.helpers.catalogue import python_catalogue
+
+
+class _StubPumpReader:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+        self.read_calls = 0
+
+    async def read(self, _: int) -> bytes:
+        self.read_calls += 1
+        await asyncio.sleep(0)
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+class _StubPumpWriter:
+    def __init__(self, *, fail_on_drain_call: int | None = None) -> None:
+        self.data = bytearray()
+        self.drain_calls = 0
+        self.write_calls = 0
+        self.closed = False
+        self.write_eof_calls = 0
+        self.wait_closed_calls = 0
+        self._fail_on_drain_call = fail_on_drain_call
+
+    def write(self, chunk: bytes) -> None:
+        self.write_calls += 1
+        self.data.extend(chunk)
+
+    async def drain(self) -> None:
+        self.drain_calls += 1
+        await asyncio.sleep(0)
+        if self._fail_on_drain_call is None:
+            return
+        if self.drain_calls == self._fail_on_drain_call:
+            raise BrokenPipeError
+
+    def write_eof(self) -> None:
+        self.write_eof_calls += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.wait_closed_calls += 1
+
+
+class _StubSpawnProcess:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+        self.returncode: int | None = None
+        self.stdout = None
+        self.stderr = None
+        self.stdin = None
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.wait_calls = 0
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    async def wait(self) -> int:
+        self.wait_calls += 1
+        await asyncio.sleep(0)
+        if self.returncode is None:
+            self.returncode = -15
+        return self.returncode
 
 
 def test_or_operator_composes_pipeline() -> None:
@@ -22,6 +99,33 @@ def test_or_operator_composes_pipeline() -> None:
 
     assert isinstance(pipeline, Pipeline)
     assert pipeline.parts == (first, second)
+
+
+def test_or_operator_composes_safe_cmd_with_pipeline() -> None:
+    """SafeCmd | Pipeline prepends the command to the pipeline."""
+    echo = sh.make(ECHO)
+    first = echo("-n", "hello")
+    second = echo("-n", "world")
+    third = echo("-n", "!")
+
+    pipeline = first | (second | third)
+
+    assert pipeline.parts == (first, second, third)
+
+
+def test_or_operator_composes_pipeline_with_pipeline() -> None:
+    """Pipeline | Pipeline concatenates stages in order."""
+    echo = sh.make(ECHO)
+    first = echo("-n", "one")
+    second = echo("-n", "two")
+    third = echo("-n", "three")
+    fourth = echo("-n", "four")
+
+    left_pipeline = first | second
+    right_pipeline = third | fourth
+    pipeline = left_pipeline | right_pipeline
+
+    assert pipeline.parts == (first, second, third, fourth)
 
 
 def test_pipeline_can_append_stages() -> None:
@@ -60,34 +164,34 @@ def test_pipeline_run_streams_stdout_between_stages() -> None:
     assert result.stages[1].pid > 0
 
 
+def test_pipeline_run_sync_failure_sets_ok_false_and_final_to_failed_stage() -> None:
+    """Pipeline.run_sync reports failure when a stage exits non-zero."""
+    catalogue, python_program = python_catalogue()
+    python = sh.make(python_program, catalogue=catalogue)
+
+    pipeline = python("-c", "import sys; sys.exit(0)") | python(
+        "-c",
+        "import sys; sys.exit(1)",
+    )
+
+    with scoped(allowlist=frozenset([python_program])):
+        result = pipeline.run_sync()
+
+    assert isinstance(result, PipelineResult)
+    assert result.ok is False
+    assert result.final is result.stages[-1]
+    assert result.final.exit_code == 1
+    assert len(result.stages) == 2
+    assert result.stages[0].exit_code == 0
+    assert result.stages[1].exit_code == 1
+
+
 def test_pump_stream_drains_per_chunk() -> None:
     """Streaming between stages awaits drain for backpressure."""
 
-    class StubWriter:
-        def __init__(self) -> None:
-            self.data = bytearray()
-            self.drain_calls = 0
-            self.write_calls = 0
-            self.closed = False
-            self.write_eof_calls = 0
-
-        def write(self, chunk: bytes) -> None:
-            self.write_calls += 1
-            self.data.extend(chunk)
-
-        async def drain(self) -> None:
-            self.drain_calls += 1
-            await asyncio.sleep(0)
-
-        def write_eof(self) -> None:
-            self.write_eof_calls += 1
-
-        def close(self) -> None:
-            self.closed = True
-
-    async def exercise() -> StubWriter:
+    async def exercise() -> _StubPumpWriter:
         reader = asyncio.StreamReader()
-        writer = StubWriter()
+        writer = _StubPumpWriter()
         task = asyncio.create_task(
             _pump_stream(reader, typ.cast("asyncio.StreamWriter", writer)),
         )
@@ -104,6 +208,66 @@ def test_pump_stream_drains_per_chunk() -> None:
     assert writer.drain_calls >= 2
     assert writer.write_eof_calls == 1
     assert writer.closed is True
+    assert writer.wait_closed_calls == 1
+
+
+def test_pump_stream_handles_downstream_close_without_hanging() -> None:
+    """_pump_stream drains stdout even if downstream closes mid-stream."""
+
+    async def exercise() -> tuple[_StubPumpReader, _StubPumpWriter]:
+        reader = _StubPumpReader([b"a" * _READ_SIZE, b"b" * _READ_SIZE, b"c"])
+        writer = _StubPumpWriter(fail_on_drain_call=2)
+        await _pump_stream(
+            typ.cast("asyncio.StreamReader", reader),
+            typ.cast("asyncio.StreamWriter", writer),
+        )
+        return reader, writer
+
+    reader, writer = asyncio.run(exercise())
+
+    assert reader.read_calls == 4  # 3 chunks + EOF
+    assert writer.write_calls == 2  # third chunk is drained but not written
+    assert writer.closed is True
+    assert writer.wait_closed_calls == 1
+
+
+def test_spawn_pipeline_processes_terminates_started_stages_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spawn failures should terminate any already-started pipeline stages."""
+    echo = sh.make(ECHO)
+    first = echo("-n", "hello")
+    second = echo("-n", "world")
+    config = _prepare_pipeline_config(capture=True, echo=False, context=None)
+
+    spawned: list[_StubSpawnProcess] = []
+    call_count = 0
+
+    async def fake_create_subprocess_exec(
+        *_: object,
+        **__: object,
+    ) -> _StubSpawnProcess:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0)
+        if call_count == 1:
+            proc = _StubSpawnProcess(pid=12345)
+            spawned.append(proc)
+            return proc
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    async def exercise() -> None:
+        with pytest.raises(FileNotFoundError):
+            await _spawn_pipeline_processes((first, second), config)
+
+    asyncio.run(exercise())
+
+    assert len(spawned) == 1
+    assert spawned[0].terminate_calls == 1
+    assert spawned[0].kill_calls == 0
+    assert spawned[0].wait_calls >= 1
 
 
 def test_pipeline_requires_at_least_two_stages() -> None:

--- a/cuprum/unittests/test_pipeline.py
+++ b/cuprum/unittests/test_pipeline.py
@@ -1,0 +1,115 @@
+"""Unit tests for Pipeline composition and execution."""
+
+from __future__ import annotations
+
+import asyncio
+import typing as typ
+
+import pytest
+
+from cuprum import ECHO, scoped, sh
+from cuprum.sh import _READ_SIZE, Pipeline, PipelineResult, _pump_stream
+from tests.helpers.catalogue import python_catalogue
+
+
+def test_or_operator_composes_pipeline() -> None:
+    """The | operator composes SafeCmd stages into a Pipeline."""
+    echo = sh.make(ECHO)
+    first = echo("-n", "hello")
+    second = echo("-n", "world")
+
+    pipeline = first | second
+
+    assert isinstance(pipeline, Pipeline)
+    assert pipeline.parts == (first, second)
+
+
+def test_pipeline_can_append_stages() -> None:
+    """Pipeline | SafeCmd extends the pipeline in order."""
+    echo = sh.make(ECHO)
+    first = echo("-n", "one")
+    second = echo("-n", "two")
+    third = echo("-n", "three")
+
+    pipeline = first | second | third
+
+    assert pipeline.parts == (first, second, third)
+
+
+def test_pipeline_run_streams_stdout_between_stages() -> None:
+    """Pipeline.run_sync streams stdout into the next stage stdin."""
+    catalogue, python_program = python_catalogue()
+    python = sh.make(python_program, catalogue=catalogue)
+    echo = sh.make(ECHO)
+
+    pipeline = echo("-n", "hello") | python(
+        "-c",
+        "import sys; sys.stdout.write(sys.stdin.read().upper())",
+    )
+
+    with scoped(allowlist=frozenset([ECHO, python_program])):
+        result = pipeline.run_sync()
+
+    assert isinstance(result, PipelineResult)
+    assert result.stdout == "HELLO"
+    assert len(result.stages) == 2
+    assert result.stages[0].stdout is None
+    assert result.stages[0].exit_code == 0
+    assert result.stages[1].exit_code == 0
+    assert result.stages[0].pid > 0
+    assert result.stages[1].pid > 0
+
+
+def test_pump_stream_drains_per_chunk() -> None:
+    """Streaming between stages awaits drain for backpressure."""
+
+    class StubWriter:
+        def __init__(self) -> None:
+            self.data = bytearray()
+            self.drain_calls = 0
+            self.write_calls = 0
+            self.closed = False
+            self.write_eof_calls = 0
+
+        def write(self, chunk: bytes) -> None:
+            self.write_calls += 1
+            self.data.extend(chunk)
+
+        async def drain(self) -> None:
+            self.drain_calls += 1
+            await asyncio.sleep(0)
+
+        def write_eof(self) -> None:
+            self.write_eof_calls += 1
+
+        def close(self) -> None:
+            self.closed = True
+
+    async def exercise() -> StubWriter:
+        reader = asyncio.StreamReader()
+        writer = StubWriter()
+        task = asyncio.create_task(
+            _pump_stream(reader, typ.cast("asyncio.StreamWriter", writer)),
+        )
+        payload = b"x" * (_READ_SIZE * 2 + 1)
+        reader.feed_data(payload)
+        reader.feed_eof()
+        await task
+        return writer
+
+    writer = asyncio.run(exercise())
+
+    assert bytes(writer.data) == b"x" * (_READ_SIZE * 2 + 1)
+    assert writer.write_calls == writer.drain_calls
+    assert writer.drain_calls >= 2
+    assert writer.write_eof_calls == 1
+    assert writer.closed is True
+
+
+def test_pipeline_requires_at_least_two_stages() -> None:
+    """Pipelines reject construction with fewer than two parts."""
+    echo = sh.make(ECHO)
+    only = echo("-n", "one")
+
+    with pytest.raises(ValueError, match="at least two stages"):
+        Pipeline((only,))

--- a/cuprum/unittests/test_pipeline.py
+++ b/cuprum/unittests/test_pipeline.py
@@ -226,7 +226,9 @@ def test_pump_stream_handles_downstream_close_without_hanging() -> None:
     reader, writer = asyncio.run(exercise())
 
     assert reader.read_calls == 4  # 3 chunks + EOF
-    assert writer.write_calls == 2  # third chunk is drained but not written
+    assert (
+        writer.write_calls == 2
+    )  # drain fails on second write; third chunk never written
     assert writer.closed is True
     assert writer.wait_closed_calls == 1
 

--- a/cuprum/unittests/test_public_api.py
+++ b/cuprum/unittests/test_public_api.py
@@ -18,6 +18,8 @@ def test_public_exports_are_available() -> None:
     assert c.ProgramEntry is not None, "ProgramEntry must be exported"
     assert c.ProjectSettings is not None, "ProjectSettings must be exported"
     assert c.UnknownProgramError is not None, "UnknownProgramError must be exported"
+    assert c.Pipeline is not None, "Pipeline must be exported"
+    assert c.PipelineResult is not None, "PipelineResult must be exported"
 
 
 def test_public_catalogue_behaviour_via_reexports() -> None:

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -369,14 +369,14 @@ class Pipeline(Generic[Out]):
     async def run(
         self,
         *,
-        capture: bool = True,
-        echo: bool = False,
+        capture: bool = True,  # capture final stage stdout and all stderr
+        echo: bool = False,    # echo captured streams to configured sinks
     ) -> PipelineResult: ...
     def run_sync(
         self,
         *,
-        capture: bool = True,
-        echo: bool = False,
+        capture: bool = True,  # capture final stage stdout and all stderr
+        echo: bool = False,    # echo captured streams to configured sinks
     ) -> PipelineResult: ...
 ```
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -385,7 +385,7 @@ For the public design, the exact generic parameters are kept simple: we do
 
 #### 6.1.5 `PipelineResult`
 
-Pipelines return a structured result so callers can inspect per-stage exit
+Pipelines return a structured result, so callers can inspect per-stage exit
 metadata alongside the final output:
 
 ```python
@@ -399,6 +399,11 @@ class PipelineResult:
     @property
     def stdout(self) -> str | None: ...
 ```
+
+Contract notes:
+
+- When `capture=True`, `PipelineResult.stdout` contains the final stage stdout.
+- When `capture=False`, `PipelineResult.stdout` is `None`.
 
 ### 6.2 `cuprum.sh` – Safe Facade
 
@@ -478,6 +483,7 @@ grep = sh.make(GREP)
 pipeline = ls("-l", "/var/log") | grep("ERROR")
 result = pipeline.run_sync(echo=True)
 text = result.stdout
+assert text is not None
 ```
 
 ##### Implementation notes for the first iteration

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,7 @@ Focus: provide pipeline execution, richer events, and concurrency helpers.
 
 ### Step: pipeline execution
 
-- [ ] Implement `Pipeline` composition via the `|` operator with streaming
+- [x] Implement `Pipeline` composition via the `|` operator with streaming
       between stages and backpressure handling; expose exit metadata per stage.
 - [ ] Define and implement failure policy (fail fast, terminate downstream,
       surface failing stage) and cover with tests for early, middle, and late

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -141,7 +141,8 @@ Notes:
 
 - Only the final stage's stdout is captured; intermediate stage stdout is
   streamed and represented as `None` in `result.stages`.
-- `echo=True` tees the final stage stdout and all stage stderr streams.
+- `echo=True` echoes the final stage stdout and all stage stderr streams to
+  their configured sinks.
 
 ## Execution runtime
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -96,6 +96,50 @@ Builders keep argv construction in one place, making it easier to validate
 inputs, document behaviour, and reuse the same allowlisted program across a
 codebase.
 
+## Pipeline execution
+
+Compose `SafeCmd` instances into a `Pipeline` via the `|` operator. Pipelines
+stream data from each stage's stdout into the next stage's stdin and apply
+backpressure using `asyncio`'s pipe `drain()` semantics.
+
+Running a pipeline returns a `PipelineResult` that exposes:
+
+- The captured output of the final stage (via `result.stdout`).
+- Per-stage exit metadata (via `result.stages`).
+
+```python
+from cuprum import ECHO, Program, ProgramCatalogue, ProjectSettings, scoped, sh
+
+PYTHON = Program("python")
+project = ProjectSettings(
+    name="pipeline-example",
+    programs=(ECHO, PYTHON),
+    documentation_locations=(),
+    noise_rules=(),
+)
+catalogue = ProgramCatalogue(projects=(project,))
+
+echo = sh.make(ECHO, catalogue=catalogue)
+python = sh.make(PYTHON, catalogue=catalogue)
+
+pipeline = echo("-n", "hello") | python(
+    "-c",
+    "import sys; sys.stdout.write(sys.stdin.read().upper())",
+)
+
+with scoped(allowlist=catalogue.allowlist):
+    result = pipeline.run_sync()
+
+print(result.stdout)  # "HELLO"
+print([stage.exit_code for stage in result.stages])  # per-stage exit codes
+```
+
+Notes:
+
+- Only the final stage's stdout is captured; intermediate stage stdout is
+  streamed and represented as `None` in `result.stages`.
+- `echo=True` tees the final stage stdout and all stage stderr streams.
+
 ## Execution runtime
 
 `SafeCmd.run` executes curated commands asynchronously with predictable capture

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -108,9 +108,12 @@ Running a pipeline returns a `PipelineResult` that exposes:
 - Per-stage exit metadata (via `result.stages`).
 
 ```python
+import sys
+from pathlib import Path
+
 from cuprum import ECHO, Program, ProgramCatalogue, ProjectSettings, scoped, sh
 
-PYTHON = Program("python")
+PYTHON = Program(str(Path(sys.executable)))
 project = ProjectSettings(
     name="pipeline-example",
     programs=(ECHO, PYTHON),

--- a/tests/behaviour/test_pipeline_execution.py
+++ b/tests/behaviour/test_pipeline_execution.py
@@ -88,6 +88,7 @@ def _make_test_pipeline(
     catalogue, python_program = python_catalogue()
 
     # Map ECHO and python_program to command builders
+    # ECHO uses the default catalogue where it's registered; Python uses the custom one
     builders: dict[Program, typ.Any] = {
         ECHO: sh.make(ECHO),
         python_program: sh.make(python_program, catalogue=catalogue),

--- a/tests/behaviour/test_pipeline_execution.py
+++ b/tests/behaviour/test_pipeline_execution.py
@@ -9,6 +9,7 @@ import typing as typ
 from pytest_bdd import given, scenario, then, when
 
 from cuprum import ECHO, scoped, sh
+from cuprum.catalogue import ProgramCatalogue, ProjectSettings
 from tests.helpers.catalogue import python_catalogue
 
 if typ.TYPE_CHECKING:
@@ -85,12 +86,20 @@ def _make_test_pipeline(
         A _ScenarioPipeline ready for execution with appropriate allowlist.
 
     """
-    catalogue, python_program = python_catalogue()
+    _, python_program = python_catalogue()
 
-    # Map ECHO and python_program to command builders
-    # ECHO uses the default catalogue where it's registered; Python uses the custom one
+    # Build a combined catalogue containing both ECHO and Python
+    project = ProjectSettings(
+        name="pipeline-tests",
+        programs=(ECHO, python_program),
+        documentation_locations=(),
+        noise_rules=(),
+    )
+    catalogue = ProgramCatalogue(projects=(project,))
+
+    # Map programs to command builders using the combined catalogue
     builders: dict[Program, typ.Any] = {
-        ECHO: sh.make(ECHO),
+        ECHO: sh.make(ECHO, catalogue=catalogue),
         python_program: sh.make(python_program, catalogue=catalogue),
     }
 

--- a/tests/behaviour/test_pipeline_execution.py
+++ b/tests/behaviour/test_pipeline_execution.py
@@ -1,0 +1,85 @@
+"""Behavioural tests for Pipeline execution."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses as dc
+import typing as typ
+
+from pytest_bdd import given, scenario, then, when
+
+from cuprum import ECHO, scoped, sh
+from tests.helpers.catalogue import python_catalogue
+
+if typ.TYPE_CHECKING:
+    from cuprum.program import Program
+    from cuprum.sh import Pipeline, PipelineResult
+
+
+@scenario(
+    "../features/pipeline_execution.feature",
+    "Pipeline streams output between stages",
+)
+def test_pipeline_streams_between_stages() -> None:
+    """Behavioural coverage for pipeline streaming semantics."""
+
+
+@scenario(
+    "../features/pipeline_execution.feature",
+    "Pipeline can run asynchronously",
+)
+def test_pipeline_runs_async() -> None:
+    """Behavioural coverage for async pipeline execution."""
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _ScenarioPipeline:
+    pipeline: Pipeline
+    allowlist: frozenset[Program]
+
+
+@given("a simple two stage pipeline", target_fixture="simple_pipeline")
+def given_simple_pipeline() -> _ScenarioPipeline:
+    """Create a two stage pipeline that uppercases its input."""
+    catalogue, python_program = python_catalogue()
+    python = sh.make(python_program, catalogue=catalogue)
+    echo = sh.make(ECHO)
+
+    pipeline = echo("-n", "behaviour") | python(
+        "-c",
+        "import sys; sys.stdout.write(sys.stdin.read().upper())",
+    )
+    allowlist = frozenset([ECHO, python_program])
+    return _ScenarioPipeline(pipeline=pipeline, allowlist=allowlist)
+
+
+@when("I run the pipeline synchronously", target_fixture="pipeline_result")
+def when_run_pipeline_sync(simple_pipeline: _ScenarioPipeline) -> PipelineResult:
+    """Execute the pipeline via run_sync()."""
+    with scoped(allowlist=simple_pipeline.allowlist):
+        return simple_pipeline.pipeline.run_sync()
+
+
+@when("I run the pipeline asynchronously", target_fixture="pipeline_result")
+def when_run_pipeline_async(simple_pipeline: _ScenarioPipeline) -> PipelineResult:
+    """Execute the pipeline via run()."""
+
+    async def run() -> PipelineResult:
+        with scoped(allowlist=simple_pipeline.allowlist):
+            return await simple_pipeline.pipeline.run()
+
+    return asyncio.run(run())
+
+
+@then("the pipeline output is transformed")
+def then_pipeline_output_transformed(pipeline_result: PipelineResult) -> None:
+    """Return transformed stdout from the final stage."""
+    assert pipeline_result.stdout == "BEHAVIOUR"
+
+
+@then("the pipeline exposes per stage exit metadata")
+def then_pipeline_exposes_stage_metadata(pipeline_result: PipelineResult) -> None:
+    """Stage results include exit codes and process identifiers."""
+    assert len(pipeline_result.stages) == 2
+    assert all(stage.exit_code == 0 for stage in pipeline_result.stages)
+    assert all(stage.pid > 0 for stage in pipeline_result.stages)

--- a/tests/features/pipeline_execution.feature
+++ b/tests/features/pipeline_execution.feature
@@ -12,3 +12,7 @@ Feature: Pipeline execution
     When I run the pipeline asynchronously
     Then the pipeline output is transformed
 
+  Scenario: Pipeline reports metadata when a stage fails
+    Given a two stage pipeline with a failing first stage
+    When I run the pipeline synchronously
+    Then the pipeline exposes per stage exit metadata when a stage fails

--- a/tests/features/pipeline_execution.feature
+++ b/tests/features/pipeline_execution.feature
@@ -1,0 +1,14 @@
+Feature: Pipeline execution
+  Pipelines connect safe commands via stdout/stdin streaming.
+
+  Scenario: Pipeline streams output between stages
+    Given a simple two stage pipeline
+    When I run the pipeline synchronously
+    Then the pipeline output is transformed
+    And the pipeline exposes per stage exit metadata
+
+  Scenario: Pipeline can run asynchronously
+    Given a simple two stage pipeline
+    When I run the pipeline asynchronously
+    Then the pipeline output is transformed
+


### PR DESCRIPTION
## Summary
- Adds a streaming Pipeline API surface with per-stage metadata and composition capabilities.
- Refactors internal wait/run paths to support streaming, backpressure, and async/sync execution paths.
- Exposes Pipeline and PipelineResult as first-class public API surfaces.
- Updates tests, docs, and public API exports to reflect the new pipeline capabilities.

## Changes
### Core functionality
- Introduced Pipeline and PipelineResult types:
  - Pipeline(parts: SafeCmd, ...): a sequence of stages connected by pipes.
  - PipelineResult(stages: tuple[CommandResult, ...], final stdout available at result.stdout)
- SafeCmd enhancements:
  - SafeCmd.__or__(self, other): enable composing a SafeCmd with another SafeCmd or Pipeline, producing a Pipeline.
- Pipeline composition:
  - Pipeline.__or__(self, other): append stages left-to-right, returning a new Pipeline.
- Execution flow:
  - Pipeline.run(...) executes the pipeline asynchronously with streaming and backpressure.
  - Pipeline.run_sync(...) executes synchronously via asyncio.run.
  - Only the final stage’s stdout is captured; intermediate stages stream stdout to the next stage and have None in their corresponding PipelineResult entries.
- Streaming and backpressure:
  - Implemented streaming between adjacent stages with _pump_stream and _write_to_stream_writer.
  - Handles downstream pipe closure and backpressure via drain() semantics.
- Runtime helpers and data flow:
  - Internal structures (_PipelineRunConfig, _StageStreamConfig) normalise runtime options and collect per-stage data.
  - _spawn_pipeline_processes wires up stdin/stdout/stderr for all stages, including capturing streams when needed.
  - _wait_for_pipeline, _collect_pipeline_streams, _build_pipeline_stage_results assemble final CommandResult objects for each stage.
- Hooks:
  - After-hook support invoked for each stage after results are produced.

### Public API
- Expose Pipeline and PipelineResult in cuprum/__init__.py and __all__ so they are importable from cuprum.
- Update tests and docs to reflect new API surface.

### Tests
- Added cuprum/unittests/test_pipeline.py with:
  - test_or_operator_composes_pipeline
  - test_pipeline_can_append_stages
  - test_pipeline_run_streams_stdout_between_stages
  - test_pump_stream_drains_per_chunk
  - test_pipeline_requires_at_least_two_stages
- Updated cuprum/unittests/test_public_api.py to assert Pipeline and PipelineResult are exported.
- Behaviour tests in tests/behaviour/test_pipeline_execution.py cover:
  - Pipeline streams output between stages (sync and async variants)
  - Per-stage exit metadata availability
- Behaviour feature file tests/features/pipeline_execution.feature added with scenarios for streaming and async execution.

### Documentation
- docs/cuprum-design.md updated to reflect PipelineResult, streaming semantics, and final stdout capture behavior.
- docs/users-guide.md adds a section on Pipeline execution with example usage and notes about intermediate stage stdout being None in per-stage results.
- docs/roadmap.md marks the pipeline execution step as complete.

### Migration / compatibility
- This introduces a new Pipeline API surface; existing SafeCmd usage remains compatible.
- Pipeline requires at least two stages; this is enforced at construction time.
- The design captures only the final stage stdout; upstream stages stream to downstream and appear as None in per-stage results.

### Rationale
- Enables robust, streaming-based composition of shell-like commands with backpressure and per-stage metadata, aligning with modern async orchestration needs and improving debuggability and observability of pipelines.

📎 **Task**: https://www.terragonlabs.com/task/bbe4052f-aa89-4bb3-afcc-83a24c89fc12