### PR TITLE
Add structured telemetry adapters with in-memory references and tests

### DIFF
--- a/cuprum/adapters/__init__.py
+++ b/cuprum/adapters/__init__.py
@@ -1,0 +1,40 @@
+"""Example telemetry adapters for Cuprum's structured execution events.
+
+This package provides reference implementations showing how to integrate
+Cuprum's observe hook system with common telemetry backends:
+
+- ``logging_adapter``: Enhanced structured logging via the standard library
+- ``metrics_adapter``: Prometheus-style metrics (counters, histograms)
+- ``tracing_adapter``: OpenTelemetry-style distributed tracing
+
+All adapters are optional and non-blocking; they do not introduce runtime
+dependencies on external telemetry libraries. Instead, they define protocols
+and provide reference implementations that can be copied, adapted, or used
+as inspiration for project-specific integrations.
+
+Example usage::
+
+    from cuprum import scoped, sh
+    from cuprum.adapters.logging_adapter import structured_logging_hook
+    from cuprum.adapters.metrics_adapter import MetricsHook, InMemoryMetrics
+    from cuprum.adapters.tracing_adapter import TracingHook, InMemoryTracer
+
+    # Structured logging
+    with scoped(allowlist=my_allowlist), sh.observe(structured_logging_hook()):
+        cmd.run_sync()
+
+    # Metrics collection
+    metrics = InMemoryMetrics()
+    with scoped(allowlist=my_allowlist), sh.observe(MetricsHook(metrics)):
+        cmd.run_sync()
+
+    # Distributed tracing
+    tracer = InMemoryTracer()
+    with scoped(allowlist=my_allowlist), sh.observe(TracingHook(tracer)):
+        cmd.run_sync()
+
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/cuprum/adapters/logging_adapter.py
+++ b/cuprum/adapters/logging_adapter.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import dataclasses
+import json
 import logging
 import typing as typ
 
@@ -183,8 +184,6 @@ class JsonLoggingFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         """Format the log record as a JSON string."""
-        import json
-
         output: dict[str, object] = {
             "timestamp": self.formatTime(record),
             "level": record.levelname,

--- a/cuprum/adapters/logging_adapter.py
+++ b/cuprum/adapters/logging_adapter.py
@@ -1,0 +1,198 @@
+"""Structured logging adapter for Cuprum execution events.
+
+This module provides an observe hook that emits structured log records for
+each execution event phase. Unlike the simpler ``logging_hook()`` which logs
+only start/exit with before/after hooks, this adapter leverages the full
+``ExecEvent`` stream for fine-grained observability.
+
+The adapter demonstrates how to transform ``ExecEvent`` values into structured
+log records suitable for log aggregation systems (ELK, Splunk, etc.).
+
+Example::
+
+    import logging
+    from cuprum import scoped, sh
+    from cuprum.adapters.logging_adapter import structured_logging_hook
+
+    logging.basicConfig(level=logging.DEBUG)
+
+    with scoped(allowlist=my_allowlist), sh.observe(structured_logging_hook()):
+        sh.make(ECHO)("hello").run_sync()
+
+"""
+
+from __future__ import annotations
+
+import collections.abc as cabc
+import logging
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from cuprum.events import ExecEvent, ExecHook
+
+_DEFAULT_LOGGER_NAME = "cuprum.exec"
+
+
+def structured_logging_hook(  # noqa: PLR0913
+    *,
+    logger: logging.Logger | None = None,
+    plan_level: int = logging.DEBUG,
+    start_level: int = logging.INFO,
+    output_level: int = logging.DEBUG,
+    exit_level: int = logging.INFO,
+) -> ExecHook:
+    """Create an observe hook that logs execution events with structured data.
+
+    Parameters
+    ----------
+    logger:
+        Logger instance for event emission. Defaults to
+        ``logging.getLogger("cuprum.exec")``.
+    plan_level:
+        Log level for ``plan`` events (intent to execute). Default DEBUG.
+    start_level:
+        Log level for ``start`` events (process spawned). Default INFO.
+    output_level:
+        Log level for ``stdout``/``stderr`` events. Default DEBUG.
+    exit_level:
+        Log level for ``exit`` events (process completed). Default INFO.
+
+    Returns
+    -------
+    ExecHook
+        A hook suitable for use with ``sh.observe()``.
+
+    Notes
+    -----
+    This hook is synchronous and non-blocking. Log emission happens inline
+    with event processing. For high-throughput scenarios, consider using an
+    async handler or buffered logging configuration.
+
+    The hook attaches structured ``extra`` data to log records including:
+
+    - ``cuprum_phase``: Event phase (plan, start, stdout, stderr, exit)
+    - ``cuprum_program``: Program being executed
+    - ``cuprum_argv``: Full argument vector
+    - ``cuprum_pid``: Process ID (when available)
+    - ``cuprum_exit_code``: Exit code (for exit events)
+    - ``cuprum_duration_s``: Duration in seconds (for exit events)
+    - ``cuprum_tags``: Event tags as a dict
+
+    """
+    log = logger or logging.getLogger(_DEFAULT_LOGGER_NAME)
+    levels: dict[str, int] = {
+        "plan": plan_level,
+        "start": start_level,
+        "stdout": output_level,
+        "stderr": output_level,
+        "exit": exit_level,
+    }
+
+    def hook(event: ExecEvent) -> None:
+        level = levels.get(event.phase, logging.DEBUG)
+        if not log.isEnabledFor(level):
+            return
+
+        extra = _build_extra(event)
+        message = _format_message(event)
+        log.log(level, message, extra=extra)
+
+    return hook
+
+
+def _build_extra(event: ExecEvent) -> dict[str, object]:
+    """Build structured extra data for a log record."""
+    extra: dict[str, object] = {
+        "cuprum_phase": event.phase,
+        "cuprum_program": str(event.program),
+        "cuprum_argv": event.argv,
+        "cuprum_tags": dict(event.tags),
+    }
+    if event.pid is not None:
+        extra["cuprum_pid"] = event.pid
+    if event.cwd is not None:
+        extra["cuprum_cwd"] = str(event.cwd)
+    if event.exit_code is not None:
+        extra["cuprum_exit_code"] = event.exit_code
+    if event.duration_s is not None:
+        extra["cuprum_duration_s"] = event.duration_s
+    if event.line is not None:
+        extra["cuprum_line"] = event.line
+    return extra
+
+
+def _format_message(event: ExecEvent) -> str:
+    """Format a human-readable log message for the event."""
+    program = event.program
+    match event.phase:
+        case "plan":
+            return f"cuprum.plan program={program} argv={event.argv!r}"
+        case "start":
+            return f"cuprum.start program={program} pid={event.pid}"
+        case "stdout":
+            return f"cuprum.stdout pid={event.pid} line={event.line!r}"
+        case "stderr":
+            return f"cuprum.stderr pid={event.pid} line={event.line!r}"
+        case "exit":
+            duration = (
+                f"{event.duration_s:.6f}" if event.duration_s is not None else "unknown"
+            )
+            return (
+                f"cuprum.exit program={program} pid={event.pid} "
+                f"exit_code={event.exit_code} duration_s={duration}"
+            )
+        case _:
+            return f"cuprum.{event.phase} program={program}"
+
+
+class JsonLoggingFormatter(logging.Formatter):
+    """A JSON formatter for structured log output.
+
+    This formatter serialises log records as JSON objects, suitable for
+    log aggregation systems. It includes all ``cuprum_*`` extra fields.
+
+    Example::
+
+        import logging
+        from cuprum.adapters.logging_adapter import JsonLoggingFormatter
+
+        handler = logging.StreamHandler()
+        handler.setFormatter(JsonLoggingFormatter())
+        logger = logging.getLogger("cuprum.exec")
+        logger.addHandler(handler)
+
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the log record as a JSON string."""
+        import json
+
+        output: dict[str, object] = {
+            "timestamp": self.formatTime(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        for key, value in vars(record).items():
+            if key.startswith("cuprum_"):
+                output[key] = _json_serializable(value)
+
+        return json.dumps(output, default=str)
+
+
+def _json_serializable(value: object) -> object:
+    """Ensure a value is JSON-serializable."""
+    if isinstance(value, cabc.Mapping):
+        return {str(k): _json_serializable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_serializable(v) for v in value]
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    return str(value)
+
+
+__all__ = [
+    "JsonLoggingFormatter",
+    "structured_logging_hook",
+]

--- a/cuprum/adapters/metrics_adapter.py
+++ b/cuprum/adapters/metrics_adapter.py
@@ -1,0 +1,276 @@
+"""Prometheus-style metrics adapter for Cuprum execution events.
+
+This module provides an observe hook that collects metrics about command
+execution in a format compatible with Prometheus client libraries. The
+adapter demonstrates how to collect:
+
+- **Counters**: Total executions, failures, output lines
+- **Histograms**: Execution duration distribution
+
+The implementation uses protocol classes to remain decoupled from specific
+metrics libraries. Projects can implement the protocols with their preferred
+backend (prometheus_client, statsd, OpenTelemetry metrics, etc.).
+
+Example with the in-memory reference implementation::
+
+    from cuprum import scoped, sh
+    from cuprum.adapters.metrics_adapter import MetricsHook, InMemoryMetrics
+
+    metrics = InMemoryMetrics()
+
+    with scoped(allowlist=my_allowlist), sh.observe(MetricsHook(metrics)):
+        sh.make(ECHO)("hello").run_sync()
+
+    print(metrics.counters)  # {'cuprum_executions_total': 1, ...}
+    print(metrics.histograms)  # {'cuprum_duration_seconds': [...]}
+
+Example with prometheus_client::
+
+    from prometheus_client import Counter, Histogram
+    from cuprum.adapters.metrics_adapter import MetricsCollector, MetricsHook
+
+    class PrometheusMetrics:
+        def __init__(self):
+            self._exec_total = Counter(
+                "cuprum_executions_total",
+                "Total command executions",
+                ["program", "project"],
+            )
+            self._duration = Histogram(
+                "cuprum_duration_seconds",
+                "Execution duration",
+                ["program", "project"],
+            )
+
+        def inc_counter(self, name, value, labels):
+            if name == "cuprum_executions_total":
+                self._exec_total.labels(**labels).inc(value)
+
+        def observe_histogram(self, name, value, labels):
+            if name == "cuprum_duration_seconds":
+                self._duration.labels(**labels).observe(value)
+
+    hook = MetricsHook(PrometheusMetrics())
+
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import threading
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+    from cuprum.events import ExecEvent, ExecHook
+
+
+class MetricsCollector(typ.Protocol):
+    """Protocol for metrics collection backends.
+
+    Implementations must be thread-safe; hooks may be invoked from multiple
+    threads or async tasks concurrently.
+    """
+
+    def inc_counter(
+        self,
+        name: str,
+        value: float,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Increment a counter metric.
+
+        Parameters
+        ----------
+        name:
+            Metric name (e.g., ``cuprum_executions_total``).
+        value:
+            Amount to increment (usually 1.0).
+        labels:
+            Label key-value pairs for metric dimensions.
+
+        """
+        ...
+
+    def observe_histogram(
+        self,
+        name: str,
+        value: float,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record a histogram observation.
+
+        Parameters
+        ----------
+        name:
+            Metric name (e.g., ``cuprum_duration_seconds``).
+        value:
+            Observed value (e.g., duration in seconds).
+        labels:
+            Label key-value pairs for metric dimensions.
+
+        """
+        ...
+
+
+@dc.dataclass
+class InMemoryMetrics:
+    """Reference in-memory metrics collector for testing and examples.
+
+    This collector stores metrics in memory for inspection. It is thread-safe
+    and suitable for unit testing but not for production use.
+
+    Attributes
+    ----------
+    counters:
+        Dict mapping metric names to accumulated counter values.
+    histograms:
+        Dict mapping metric names to lists of observed values.
+
+    """
+
+    counters: dict[str, float] = dc.field(default_factory=dict)
+    histograms: dict[str, list[float]] = dc.field(default_factory=dict)
+    _lock: threading.Lock = dc.field(default_factory=threading.Lock, repr=False)
+
+    def inc_counter(
+        self,
+        name: str,
+        value: float,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Increment a counter, ignoring labels for simplicity."""
+        with self._lock:
+            self.counters[name] = self.counters.get(name, 0.0) + value
+
+    def observe_histogram(
+        self,
+        name: str,
+        value: float,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record a histogram observation, ignoring labels for simplicity."""
+        with self._lock:
+            if name not in self.histograms:
+                self.histograms[name] = []
+            self.histograms[name].append(value)
+
+    def reset(self) -> None:
+        """Clear all collected metrics."""
+        with self._lock:
+            self.counters.clear()
+            self.histograms.clear()
+
+
+class MetricsHook:
+    """Observe hook that collects Prometheus-style metrics.
+
+    The hook emits the following metrics:
+
+    - ``cuprum_executions_total``: Counter incremented on each ``start`` event
+    - ``cuprum_failures_total``: Counter incremented on non-zero exit
+    - ``cuprum_duration_seconds``: Histogram of execution durations
+    - ``cuprum_stdout_lines_total``: Counter of stdout lines emitted
+    - ``cuprum_stderr_lines_total``: Counter of stderr lines emitted
+
+    All metrics include ``program`` and ``project`` labels.
+
+    Parameters
+    ----------
+    collector:
+        A :class:`MetricsCollector` implementation for the target backend.
+
+    Example
+    -------
+    ::
+
+        metrics = InMemoryMetrics()
+        hook = MetricsHook(metrics)
+
+        with sh.observe(hook):
+            cmd.run_sync()
+
+        assert metrics.counters["cuprum_executions_total"] == 1.0
+
+    """
+
+    __slots__ = ("_collector",)
+
+    def __init__(self, collector: MetricsCollector) -> None:
+        """Initialize the metrics hook with a collector."""
+        self._collector = collector
+
+    def __call__(self, event: ExecEvent) -> None:
+        """Process an execution event and update metrics."""
+        labels = self._extract_labels(event)
+
+        match event.phase:
+            case "start":
+                self._collector.inc_counter(
+                    "cuprum_executions_total",
+                    1.0,
+                    labels,
+                )
+            case "stdout":
+                self._collector.inc_counter(
+                    "cuprum_stdout_lines_total",
+                    1.0,
+                    labels,
+                )
+            case "stderr":
+                self._collector.inc_counter(
+                    "cuprum_stderr_lines_total",
+                    1.0,
+                    labels,
+                )
+            case "exit":
+                if event.exit_code is not None and event.exit_code != 0:
+                    self._collector.inc_counter(
+                        "cuprum_failures_total",
+                        1.0,
+                        labels,
+                    )
+                if event.duration_s is not None:
+                    self._collector.observe_histogram(
+                        "cuprum_duration_seconds",
+                        event.duration_s,
+                        labels,
+                    )
+
+    @staticmethod
+    def _extract_labels(event: ExecEvent) -> dict[str, str]:
+        """Extract label values from an event."""
+        project = str(event.tags.get("project", "unknown"))
+        return {
+            "program": str(event.program),
+            "project": project,
+        }
+
+
+def metrics_hook(collector: MetricsCollector) -> ExecHook:
+    """Create a metrics observe hook for the given collector.
+
+    This is a convenience factory that returns a :class:`MetricsHook` instance
+    cast to the :class:`~cuprum.events.ExecHook` type.
+
+    Parameters
+    ----------
+    collector:
+        A :class:`MetricsCollector` implementation.
+
+    Returns
+    -------
+    ExecHook
+        A hook suitable for use with ``sh.observe()``.
+
+    """
+    return MetricsHook(collector)
+
+
+__all__ = [
+    "InMemoryMetrics",
+    "MetricsCollector",
+    "MetricsHook",
+    "metrics_hook",
+]

--- a/cuprum/adapters/tracing_adapter.py
+++ b/cuprum/adapters/tracing_adapter.py
@@ -39,7 +39,7 @@ Example with OpenTelemetry::
         def add_event(self, name, attributes=None):
             self._span.add_event(name, attributes=attributes or {})
 
-        def set_status(self, ok):
+        def set_status(self, *, ok):
             from opentelemetry.trace import StatusCode
             code = StatusCode.OK if ok else StatusCode.ERROR
             self._span.set_status(code)

--- a/cuprum/adapters/tracing_adapter.py
+++ b/cuprum/adapters/tracing_adapter.py
@@ -1,0 +1,387 @@
+"""OpenTelemetry-style tracing adapter for Cuprum execution events.
+
+This module provides an observe hook that creates distributed traces for
+command execution. The adapter demonstrates how to:
+
+- Create spans for command execution lifecycle
+- Attach structured attributes to spans
+- Handle parent-child span relationships for pipelines
+- Record span events for output lines
+
+The implementation uses protocol classes to remain decoupled from specific
+tracing libraries. Projects can implement the protocols with their preferred
+backend (OpenTelemetry, Jaeger, Zipkin, etc.).
+
+Example with the in-memory reference implementation::
+
+    from cuprum import scoped, sh
+    from cuprum.adapters.tracing_adapter import TracingHook, InMemoryTracer
+
+    tracer = InMemoryTracer()
+
+    with scoped(allowlist=my_allowlist), sh.observe(TracingHook(tracer)):
+        sh.make(ECHO)("hello").run_sync()
+
+    print(tracer.spans)  # [Span(name='cuprum.exec echo', ...)]
+
+Example with OpenTelemetry::
+
+    from opentelemetry import trace
+    from cuprum.adapters.tracing_adapter import Tracer, Span, TracingHook
+
+    class OTelSpan:
+        def __init__(self, otel_span):
+            self._span = otel_span
+
+        def set_attribute(self, key, value):
+            self._span.set_attribute(key, value)
+
+        def add_event(self, name, attributes=None):
+            self._span.add_event(name, attributes=attributes or {})
+
+        def set_status(self, ok):
+            from opentelemetry.trace import StatusCode
+            code = StatusCode.OK if ok else StatusCode.ERROR
+            self._span.set_status(code)
+
+        def end(self):
+            self._span.end()
+
+    class OTelTracer:
+        def __init__(self, tracer):
+            self._tracer = tracer
+
+        def start_span(self, name, attributes=None):
+            span = self._tracer.start_span(name, attributes=attributes)
+            return OTelSpan(span)
+
+    otel_tracer = trace.get_tracer("cuprum")
+    hook = TracingHook(OTelTracer(otel_tracer))
+
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import threading
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+    from cuprum.events import ExecEvent, ExecHook
+
+
+class Span(typ.Protocol):
+    """Protocol for a tracing span.
+
+    Spans represent a unit of work (in this case, command execution) and
+    can be enriched with attributes and events.
+    """
+
+    def set_attribute(self, key: str, value: object) -> None:
+        """Set a span attribute.
+
+        Parameters
+        ----------
+        key:
+            Attribute name (e.g., ``cuprum.program``).
+        value:
+            Attribute value (string, int, float, bool, or list thereof).
+
+        """
+        ...
+
+    def add_event(
+        self,
+        name: str,
+        attributes: cabc.Mapping[str, object] | None = None,
+    ) -> None:
+        """Add an event to the span.
+
+        Parameters
+        ----------
+        name:
+            Event name (e.g., ``cuprum.stdout``).
+        attributes:
+            Optional attributes for the event.
+
+        """
+        ...
+
+    def set_status(self, *, ok: bool) -> None:
+        """Set the span status.
+
+        Parameters
+        ----------
+        ok:
+            True if the operation succeeded, False otherwise.
+
+        """
+        ...
+
+    def end(self) -> None:
+        """End the span, recording its duration."""
+        ...
+
+
+class Tracer(typ.Protocol):
+    """Protocol for a tracing backend.
+
+    Implementations must be thread-safe; hooks may be invoked from multiple
+    threads or async tasks concurrently.
+    """
+
+    def start_span(
+        self,
+        name: str,
+        attributes: cabc.Mapping[str, object] | None = None,
+    ) -> Span:
+        """Start a new span.
+
+        Parameters
+        ----------
+        name:
+            Span name (e.g., ``cuprum.exec echo``).
+        attributes:
+            Initial span attributes.
+
+        Returns
+        -------
+        Span
+            A span that must be ended by calling :meth:`Span.end`.
+
+        """
+        ...
+
+
+@dc.dataclass
+class InMemorySpan:
+    """Reference in-memory span for testing and examples."""
+
+    name: str
+    attributes: dict[str, object] = dc.field(default_factory=dict)
+    events: list[tuple[str, dict[str, object]]] = dc.field(default_factory=list)
+    status_ok: bool | None = None
+    ended: bool = False
+
+    def set_attribute(self, key: str, value: object) -> None:
+        """Set a span attribute."""
+        self.attributes[key] = value
+
+    def add_event(
+        self,
+        name: str,
+        attributes: cabc.Mapping[str, object] | None = None,
+    ) -> None:
+        """Add an event to the span."""
+        self.events.append((name, dict(attributes) if attributes else {}))
+
+    def set_status(self, *, ok: bool) -> None:
+        """Set the span status."""
+        self.status_ok = ok
+
+    def end(self) -> None:
+        """End the span."""
+        self.ended = True
+
+
+@dc.dataclass
+class InMemoryTracer:
+    """Reference in-memory tracer for testing and examples.
+
+    This tracer stores spans in memory for inspection. It is thread-safe
+    and suitable for unit testing but not for production use.
+
+    Attributes
+    ----------
+    spans:
+        List of all spans created by this tracer.
+
+    """
+
+    spans: list[InMemorySpan] = dc.field(default_factory=list)
+    _lock: threading.Lock = dc.field(default_factory=threading.Lock, repr=False)
+
+    def start_span(
+        self,
+        name: str,
+        attributes: cabc.Mapping[str, object] | None = None,
+    ) -> InMemorySpan:
+        """Start a new in-memory span."""
+        span = InMemorySpan(
+            name=name,
+            attributes=dict(attributes) if attributes else {},
+        )
+        with self._lock:
+            self.spans.append(span)
+        return span
+
+    def reset(self) -> None:
+        """Clear all collected spans."""
+        with self._lock:
+            self.spans.clear()
+
+
+class TracingHook:
+    """Observe hook that creates OpenTelemetry-style traces.
+
+    The hook creates a span for each command execution, starting at the
+    ``start`` event and ending at the ``exit`` event. Output lines are
+    recorded as span events.
+
+    Span attributes include:
+
+    - ``cuprum.program``: The program being executed
+    - ``cuprum.argv``: Full argument vector
+    - ``cuprum.pid``: Process ID
+    - ``cuprum.exit_code``: Exit code (set on exit)
+    - ``cuprum.duration_s``: Duration in seconds (set on exit)
+    - ``cuprum.project``: Project name from tags
+    - ``cuprum.pipeline_stage_index``: Pipeline stage index (if applicable)
+
+    Parameters
+    ----------
+    tracer:
+        A :class:`Tracer` implementation for the target backend.
+    record_output:
+        If True, record stdout/stderr lines as span events. Default True.
+
+    Example
+    -------
+    ::
+
+        tracer = InMemoryTracer()
+        hook = TracingHook(tracer)
+
+        with sh.observe(hook):
+            cmd.run_sync()
+
+        assert len(tracer.spans) == 1
+        assert tracer.spans[0].attributes["cuprum.program"] == "echo"
+
+    """
+
+    __slots__ = ("_active_spans", "_lock", "_record_output", "_tracer")
+
+    def __init__(self, tracer: Tracer, *, record_output: bool = True) -> None:
+        """Initialize the tracing hook with a tracer."""
+        self._tracer = tracer
+        self._record_output = record_output
+        self._active_spans: dict[int, Span] = {}
+        self._lock = threading.Lock()
+
+    def __call__(self, event: ExecEvent) -> None:
+        """Process an execution event and update tracing."""
+        match event.phase:
+            case "plan":
+                pass
+            case "start":
+                self._handle_start(event)
+            case "stdout" | "stderr":
+                if self._record_output:
+                    self._handle_output(event)
+            case "exit":
+                self._handle_exit(event)
+
+    def _handle_start(self, event: ExecEvent) -> None:
+        """Start a new span for command execution."""
+        if event.pid is None:
+            return
+
+        attributes = self._build_attributes(event)
+        span_name = f"cuprum.exec {event.program}"
+        span = self._tracer.start_span(span_name, attributes)
+
+        with self._lock:
+            self._active_spans[event.pid] = span
+
+    def _handle_output(self, event: ExecEvent) -> None:
+        """Record output as a span event."""
+        if event.pid is None:
+            return
+
+        with self._lock:
+            span = self._active_spans.get(event.pid)
+
+        if span is None:
+            return
+
+        event_name = f"cuprum.{event.phase}"
+        event_attrs: dict[str, object] = {}
+        if event.line is not None:
+            event_attrs["line"] = event.line
+        span.add_event(event_name, event_attrs)
+
+    def _handle_exit(self, event: ExecEvent) -> None:
+        """End the span for command execution."""
+        if event.pid is None:
+            return
+
+        with self._lock:
+            span = self._active_spans.pop(event.pid, None)
+
+        if span is None:
+            return
+
+        if event.exit_code is not None:
+            span.set_attribute("cuprum.exit_code", event.exit_code)
+        if event.duration_s is not None:
+            span.set_attribute("cuprum.duration_s", event.duration_s)
+
+        ok = event.exit_code == 0 if event.exit_code is not None else True
+        span.set_status(ok=ok)
+        span.end()
+
+    @staticmethod
+    def _build_attributes(event: ExecEvent) -> dict[str, object]:
+        """Build initial span attributes from an event."""
+        attrs: dict[str, object] = {
+            "cuprum.program": str(event.program),
+            "cuprum.argv": list(event.argv),
+        }
+        if event.pid is not None:
+            attrs["cuprum.pid"] = event.pid
+        if event.cwd is not None:
+            attrs["cuprum.cwd"] = str(event.cwd)
+
+        if "project" in event.tags:
+            attrs["cuprum.project"] = str(event.tags["project"])
+        if "pipeline_stage_index" in event.tags:
+            attrs["cuprum.pipeline_stage_index"] = event.tags["pipeline_stage_index"]
+        if "pipeline_stages" in event.tags:
+            attrs["cuprum.pipeline_stages"] = event.tags["pipeline_stages"]
+
+        return attrs
+
+
+def tracing_hook(tracer: Tracer, *, record_output: bool = True) -> ExecHook:
+    """Create a tracing observe hook for the given tracer.
+
+    This is a convenience factory that returns a :class:`TracingHook` instance
+    cast to the :class:`~cuprum.events.ExecHook` type.
+
+    Parameters
+    ----------
+    tracer:
+        A :class:`Tracer` implementation.
+    record_output:
+        If True, record stdout/stderr lines as span events. Default True.
+
+    Returns
+    -------
+    ExecHook
+        A hook suitable for use with ``sh.observe()``.
+
+    """
+    return TracingHook(tracer, record_output=record_output)
+
+
+__all__ = [
+    "InMemorySpan",
+    "InMemoryTracer",
+    "Span",
+    "Tracer",
+    "TracingHook",
+    "tracing_hook",
+]

--- a/cuprum/adapters/tracing_adapter.py
+++ b/cuprum/adapters/tracing_adapter.py
@@ -155,7 +155,7 @@ class Tracer(typ.Protocol):
         ...
 
 
-@dc.dataclass
+@dc.dataclass(slots=True)
 class InMemorySpan:
     """Reference in-memory span for testing and examples."""
 
@@ -186,7 +186,7 @@ class InMemorySpan:
         self.ended = True
 
 
-@dc.dataclass
+@dc.dataclass(slots=True)
 class InMemoryTracer:
     """Reference in-memory tracer for testing and examples.
 

--- a/cuprum/unittests/test_adapters.py
+++ b/cuprum/unittests/test_adapters.py
@@ -1,0 +1,411 @@
+"""Unit tests for telemetry adapter modules."""
+
+# ruff: noqa: PLR6301,SIM117
+
+from __future__ import annotations
+
+import logging
+import sys
+import typing as typ
+from pathlib import Path
+
+from cuprum import sh
+from cuprum.adapters.logging_adapter import (
+    JsonLoggingFormatter,
+    structured_logging_hook,
+)
+from cuprum.adapters.metrics_adapter import InMemoryMetrics, MetricsHook, metrics_hook
+from cuprum.adapters.tracing_adapter import (
+    InMemoryTracer,
+    TracingHook,
+    tracing_hook,
+)
+from cuprum.catalogue import ProgramCatalogue, ProjectSettings
+from cuprum.context import scoped
+from cuprum.program import Program
+
+if typ.TYPE_CHECKING:
+    import pytest
+
+
+def _python_builder(
+    *, project_name: str = "adapter-tests"
+) -> tuple[typ.Callable[..., sh.SafeCmd], ProgramCatalogue]:
+    python_program = Program(str(Path(sys.executable)))
+    project = ProjectSettings(
+        name=project_name,
+        programs=(python_program,),
+        documentation_locations=("docs/users-guide.md",),
+        noise_rules=(),
+    )
+    catalogue = ProgramCatalogue(projects=(project,))
+    return sh.make(python_program, catalogue=catalogue), catalogue
+
+
+class TestStructuredLoggingHook:
+    """Tests for structured_logging_hook."""
+
+    def test_logs_all_phases(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Hook logs plan, start, stdout, stderr, and exit events."""
+        builder, catalogue = _python_builder(project_name="logging-test")
+        cmd = builder(
+            "-c",
+            "\n".join(
+                (
+                    "import sys",
+                    "print('out1')",
+                    "print('err1', file=sys.stderr)",
+                ),
+            ),
+        )
+
+        logger = logging.getLogger("cuprum.exec.test")
+        logger.setLevel(logging.DEBUG)
+        hook = structured_logging_hook(logger=logger)
+
+        with caplog.at_level(logging.DEBUG, logger="cuprum.exec.test"):
+            with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+                result = cmd.run_sync()
+
+        assert result.exit_code == 0
+
+        messages = [r.message for r in caplog.records]
+        assert any("cuprum.plan" in m for m in messages)
+        assert any("cuprum.start" in m for m in messages)
+        assert any("cuprum.stdout" in m and "out1" in m for m in messages)
+        assert any("cuprum.stderr" in m and "err1" in m for m in messages)
+        assert any("cuprum.exit" in m for m in messages)
+
+    def test_includes_extra_fields(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Hook attaches cuprum_* extra fields to log records."""
+        builder, catalogue = _python_builder(project_name="extra-fields")
+        cmd = builder("-c", "print('hello')")
+
+        logger = logging.getLogger("cuprum.exec.extras")
+        logger.setLevel(logging.DEBUG)
+        hook = structured_logging_hook(logger=logger)
+
+        with caplog.at_level(logging.DEBUG, logger="cuprum.exec.extras"):
+            with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+                cmd.run_sync()
+
+        start_record = next(r for r in caplog.records if "cuprum.start" in r.message)
+        assert hasattr(start_record, "cuprum_phase")
+        assert start_record.cuprum_phase == "start"
+        assert hasattr(start_record, "cuprum_program")
+        assert hasattr(start_record, "cuprum_pid")
+
+    def test_respects_log_levels(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Hook respects configured log levels for each phase."""
+        builder, catalogue = _python_builder()
+        cmd = builder("-c", "print('x')")
+
+        logger = logging.getLogger("cuprum.exec.levels")
+        logger.setLevel(logging.INFO)
+        hook = structured_logging_hook(
+            logger=logger,
+            plan_level=logging.DEBUG,
+            start_level=logging.INFO,
+            output_level=logging.DEBUG,
+            exit_level=logging.WARNING,
+        )
+
+        with caplog.at_level(logging.INFO, logger="cuprum.exec.levels"):
+            with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+                cmd.run_sync()
+
+        messages = [r.message for r in caplog.records]
+        assert not any("cuprum.plan" in m for m in messages)
+        assert any("cuprum.start" in m for m in messages)
+        assert not any("cuprum.stdout" in m for m in messages)
+        assert any("cuprum.exit" in m for m in messages)
+
+
+class TestJsonLoggingFormatter:
+    """Tests for JsonLoggingFormatter."""
+
+    def test_formats_as_json(self) -> None:
+        """Formatter outputs valid JSON with structured fields."""
+        import json
+
+        formatter = JsonLoggingFormatter()
+        record = logging.LogRecord(
+            name="cuprum.exec",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="cuprum.start program=echo",
+            args=(),
+            exc_info=None,
+        )
+        record.cuprum_phase = "start"
+        record.cuprum_program = "echo"
+        record.cuprum_pid = 12345
+
+        output = formatter.format(record)
+        data = json.loads(output)
+
+        assert data["level"] == "INFO"
+        assert data["logger"] == "cuprum.exec"
+        assert data["cuprum_phase"] == "start"
+        assert data["cuprum_program"] == "echo"
+        assert data["cuprum_pid"] == 12345
+
+
+class TestMetricsHook:
+    """Tests for MetricsHook and InMemoryMetrics."""
+
+    def test_increments_execution_counter(self) -> None:
+        """Hook increments cuprum_executions_total on start."""
+        builder, catalogue = _python_builder(project_name="metrics-counter")
+        cmd = builder("-c", "print('hello')")
+
+        metrics = InMemoryMetrics()
+        hook = MetricsHook(metrics)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        assert metrics.counters.get("cuprum_executions_total") == 1.0
+
+    def test_counts_output_lines(self) -> None:
+        """Hook counts stdout and stderr lines."""
+        builder, catalogue = _python_builder(project_name="metrics-lines")
+        cmd = builder(
+            "-c",
+            "\n".join(
+                (
+                    "import sys",
+                    "print('out1')",
+                    "print('out2')",
+                    "print('err1', file=sys.stderr)",
+                ),
+            ),
+        )
+
+        metrics = InMemoryMetrics()
+        hook = MetricsHook(metrics)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        assert metrics.counters.get("cuprum_stdout_lines_total") == 2.0
+        assert metrics.counters.get("cuprum_stderr_lines_total") == 1.0
+
+    def test_records_duration_histogram(self) -> None:
+        """Hook records execution duration in histogram."""
+        builder, catalogue = _python_builder(project_name="metrics-duration")
+        cmd = builder("-c", "print('quick')")
+
+        metrics = InMemoryMetrics()
+        hook = MetricsHook(metrics)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        durations = metrics.histograms.get("cuprum_duration_seconds", [])
+        assert len(durations) == 1
+        assert durations[0] >= 0.0
+
+    def test_counts_failures(self) -> None:
+        """Hook increments failure counter on non-zero exit."""
+        builder, catalogue = _python_builder(project_name="metrics-failures")
+        cmd = builder("-c", "import sys; sys.exit(1)")
+
+        metrics = InMemoryMetrics()
+        hook = MetricsHook(metrics)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        assert metrics.counters.get("cuprum_failures_total") == 1.0
+
+    def test_factory_function_returns_hook(self) -> None:
+        """metrics_hook() factory returns a valid ExecHook."""
+        metrics = InMemoryMetrics()
+        hook = metrics_hook(metrics)
+
+        builder, catalogue = _python_builder()
+        cmd = builder("-c", "print('factory')")
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        assert metrics.counters.get("cuprum_executions_total") == 1.0
+
+    def test_inmemory_metrics_reset(self) -> None:
+        """InMemoryMetrics.reset() clears all metrics."""
+        metrics = InMemoryMetrics()
+        metrics.inc_counter("test", 1.0, {})
+        metrics.observe_histogram("test_hist", 0.5, {})
+
+        assert metrics.counters.get("test") == 1.0
+        assert len(metrics.histograms.get("test_hist", [])) == 1
+
+        metrics.reset()
+
+        assert metrics.counters == {}
+        assert metrics.histograms == {}
+
+
+class TestTracingHook:
+    """Tests for TracingHook and InMemoryTracer."""
+
+    def test_creates_span_for_execution(self) -> None:
+        """Hook creates a span from start to exit."""
+        builder, catalogue = _python_builder(project_name="tracing-span")
+        cmd = builder("-c", "print('traced')")
+
+        tracer = InMemoryTracer()
+        hook = TracingHook(tracer)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        assert len(tracer.spans) == 1
+        span = tracer.spans[0]
+        assert span.name.startswith("cuprum.exec")
+        assert span.ended is True
+        assert "cuprum.program" in span.attributes
+        assert "cuprum.pid" in span.attributes
+
+    def test_sets_exit_attributes(self) -> None:
+        """Hook sets exit_code and duration_s on span."""
+        builder, catalogue = _python_builder(project_name="tracing-exit")
+        cmd = builder("-c", "print('done')")
+
+        tracer = InMemoryTracer()
+        hook = TracingHook(tracer)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        span = tracer.spans[0]
+        assert span.attributes.get("cuprum.exit_code") == 0
+        assert span.attributes.get("cuprum.duration_s") is not None
+        assert span.status_ok is True
+
+    def test_sets_error_status_on_failure(self) -> None:
+        """Hook sets error status on non-zero exit."""
+        builder, catalogue = _python_builder(project_name="tracing-error")
+        cmd = builder("-c", "import sys; sys.exit(42)")
+
+        tracer = InMemoryTracer()
+        hook = TracingHook(tracer)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        span = tracer.spans[0]
+        assert span.attributes.get("cuprum.exit_code") == 42
+        assert span.status_ok is False
+
+    def test_records_output_events(self) -> None:
+        """Hook records stdout/stderr as span events."""
+        builder, catalogue = _python_builder(project_name="tracing-output")
+        cmd = builder(
+            "-c",
+            "\n".join(
+                (
+                    "import sys",
+                    "print('stdout-line')",
+                    "print('stderr-line', file=sys.stderr)",
+                ),
+            ),
+        )
+
+        tracer = InMemoryTracer()
+        hook = TracingHook(tracer, record_output=True)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        span = tracer.spans[0]
+        event_names = [name for name, _ in span.events]
+        assert "cuprum.stdout" in event_names
+        assert "cuprum.stderr" in event_names
+
+        stdout_event = next(
+            (attrs for name, attrs in span.events if name == "cuprum.stdout"),
+            None,
+        )
+        assert stdout_event is not None
+        assert stdout_event.get("line") == "stdout-line"
+
+    def test_disables_output_recording(self) -> None:
+        """Hook skips output events when record_output=False."""
+        builder, catalogue = _python_builder(project_name="tracing-no-output")
+        cmd = builder("-c", "print('skip')")
+
+        tracer = InMemoryTracer()
+        hook = TracingHook(tracer, record_output=False)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        span = tracer.spans[0]
+        assert len(span.events) == 0
+
+    def test_includes_project_tag(self) -> None:
+        """Hook includes project tag in span attributes."""
+        builder, catalogue = _python_builder(project_name="my-project")
+        cmd = builder("-c", "print('x')")
+
+        tracer = InMemoryTracer()
+        hook = TracingHook(tracer)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        span = tracer.spans[0]
+        assert span.attributes.get("cuprum.project") == "my-project"
+
+    def test_pipeline_creates_multiple_spans(self) -> None:
+        """Hook creates separate spans for each pipeline stage."""
+        builder, catalogue = _python_builder(project_name="tracing-pipeline")
+        stage1 = builder("-c", "print('hello')")
+        stage2 = builder(
+            "-c",
+            "\n".join(
+                (
+                    "import sys",
+                    "data = sys.stdin.read()",
+                    "sys.stdout.write(data.upper())",
+                ),
+            ),
+        )
+        pipeline = stage1 | stage2
+
+        tracer = InMemoryTracer()
+        hook = TracingHook(tracer)
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            pipeline.run_sync()
+
+        assert len(tracer.spans) == 2
+        assert all(span.ended for span in tracer.spans)
+
+    def test_factory_function_returns_hook(self) -> None:
+        """tracing_hook() factory returns a valid ExecHook."""
+        tracer = InMemoryTracer()
+        hook = tracing_hook(tracer, record_output=False)
+
+        builder, catalogue = _python_builder()
+        cmd = builder("-c", "print('factory')")
+
+        with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+            cmd.run_sync()
+
+        assert len(tracer.spans) == 1
+
+    def test_inmemory_tracer_reset(self) -> None:
+        """InMemoryTracer.reset() clears all spans."""
+        tracer = InMemoryTracer()
+        span = tracer.start_span("test")
+        span.end()
+
+        assert len(tracer.spans) == 1
+
+        tracer.reset()
+
+        assert tracer.spans == []

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1041,7 +1041,7 @@ design decisions guide these adapters:
   `cuprum_stdout_lines_total`, `cuprum_stderr_lines_total`) are incremented on
   the corresponding event phases.
 - Histogram metrics (`cuprum_duration_seconds`) are observed on `exit` events.
-- All metrics include `program` and `project` labels for multi-dimensional
+- All metrics include `program` and `project` labels for multi‑dimensional
   analysis.
 
 **Tracing adapter specifics:**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,7 +54,7 @@ Focus: provide pipeline execution, richer events, and concurrency helpers.
 
 - [x] Expand execution events to include stdout/stderr line emissions, timings,
       and tag metadata; add `sh.observe` (or equivalent) registration.
-- [ ] Provide example adapters for `logging`, Prometheus-style metrics, and
+- [x] Provide example adapters for `logging`, Prometheus-style metrics, and
       OpenTelemetry traces, ensuring hooks remain optional and non-blocking.
 
 ### Step: concurrency helpers

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -466,3 +466,209 @@ try:
 except ForbiddenProgramError as e:
     print(f"Access denied: {e}")
 ```
+
+## Telemetry adapters
+
+Cuprum provides example adapters in `cuprum.adapters` that demonstrate how to
+integrate execution events with common observability backends. These adapters
+are optional and non-blocking; they do not depend on external telemetry
+libraries but define protocols that can be implemented with any backend.
+
+### Structured logging adapter
+
+The `logging_adapter` module provides an observe hook that emits structured log
+records for each execution phase. Unlike the simpler `logging_hook()`, this
+adapter uses the full `ExecEvent` stream for fine-grained observability.
+
+```python
+import logging
+
+from cuprum import ECHO, scoped, sh
+from cuprum.adapters.logging_adapter import structured_logging_hook
+
+logging.basicConfig(level=logging.DEBUG)
+
+with scoped(allowlist=frozenset([ECHO])):
+    hook = structured_logging_hook()
+    with sh.observe(hook):
+        sh.make(ECHO)("hello").run_sync()
+```
+
+The hook attaches `cuprum_*` prefixed extra fields to log records:
+
+- `cuprum_phase`: Event phase (plan, start, stdout, stderr, exit)
+- `cuprum_program`: Program being executed
+- `cuprum_argv`: Full argument vector
+- `cuprum_pid`: Process ID (when available)
+- `cuprum_exit_code`: Exit code (for exit events)
+- `cuprum_duration_s`: Duration in seconds (for exit events)
+- `cuprum_tags`: Event tags as a dict
+
+For JSON output suitable for log aggregation systems, use the
+`JsonLoggingFormatter`:
+
+```python
+import logging
+
+from cuprum.adapters.logging_adapter import JsonLoggingFormatter
+
+handler = logging.StreamHandler()
+handler.setFormatter(JsonLoggingFormatter())
+logger = logging.getLogger("cuprum.exec")
+logger.addHandler(handler)
+```
+
+### Metrics adapter
+
+The `metrics_adapter` module provides a Prometheus-style metrics hook that
+collects counters and histograms. It uses a protocol class so you can implement
+the backend with your preferred metrics library.
+
+```python
+from cuprum import ECHO, scoped, sh
+from cuprum.adapters.metrics_adapter import InMemoryMetrics, MetricsHook
+
+metrics = InMemoryMetrics()
+
+with scoped(allowlist=frozenset([ECHO])):
+    with sh.observe(MetricsHook(metrics)):
+        sh.make(ECHO)("hello").run_sync()
+
+print(metrics.counters)  # {'cuprum_executions_total': 1.0, ...}
+print(metrics.histograms)  # {'cuprum_duration_seconds': [...]}
+```
+
+The hook collects:
+
+- `cuprum_executions_total`: Counter incremented on each command start
+- `cuprum_failures_total`: Counter incremented on non-zero exit
+- `cuprum_duration_seconds`: Histogram of execution durations
+- `cuprum_stdout_lines_total`: Counter of stdout lines emitted
+- `cuprum_stderr_lines_total`: Counter of stderr lines emitted
+
+All metrics include `program` and `project` labels.
+
+To integrate with a real metrics library like `prometheus_client`, implement
+the `MetricsCollector` protocol:
+
+```python
+from prometheus_client import Counter, Histogram
+
+from cuprum.adapters.metrics_adapter import MetricsCollector, MetricsHook
+
+
+class PrometheusMetrics:
+    def __init__(self) -> None:
+        self._exec_total = Counter(
+            "cuprum_executions_total",
+            "Total command executions",
+            ["program", "project"],
+        )
+        self._duration = Histogram(
+            "cuprum_duration_seconds",
+            "Execution duration",
+            ["program", "project"],
+        )
+
+    def inc_counter(self, name, value, labels):
+        if name == "cuprum_executions_total":
+            self._exec_total.labels(**labels).inc(value)
+
+    def observe_histogram(self, name, value, labels):
+        if name == "cuprum_duration_seconds":
+            self._duration.labels(**labels).observe(value)
+
+
+hook = MetricsHook(PrometheusMetrics())
+```
+
+### Tracing adapter
+
+The `tracing_adapter` module provides an OpenTelemetry-style tracing hook that
+creates spans for command execution. It uses protocol classes so you can
+implement the backend with your preferred tracing library.
+
+```python
+from cuprum import ECHO, scoped, sh
+from cuprum.adapters.tracing_adapter import InMemoryTracer, TracingHook
+
+tracer = InMemoryTracer()
+
+with scoped(allowlist=frozenset([ECHO])):
+    with sh.observe(TracingHook(tracer)):
+        sh.make(ECHO)("hello").run_sync()
+
+span = tracer.spans[0]
+print(span.name)  # 'cuprum.exec echo'
+print(span.attributes)  # {'cuprum.program': 'echo', ...}
+```
+
+The hook creates spans with these attributes:
+
+- `cuprum.program`: The program being executed
+- `cuprum.argv`: Full argument vector
+- `cuprum.pid`: Process ID
+- `cuprum.exit_code`: Exit code (set on span end)
+- `cuprum.duration_s`: Duration in seconds (set on span end)
+- `cuprum.project`: Project name from tags
+- `cuprum.pipeline_stage_index`: Pipeline stage index (if applicable)
+
+Output lines (stdout/stderr) are recorded as span events when
+`record_output=True` (the default).
+
+To integrate with OpenTelemetry, implement the `Tracer` and `Span` protocols:
+
+```python
+from opentelemetry import trace
+
+from cuprum.adapters.tracing_adapter import Span, Tracer, TracingHook
+
+
+class OTelSpan:
+    def __init__(self, otel_span) -> None:
+        self._span = otel_span
+
+    def set_attribute(self, key, value):
+        self._span.set_attribute(key, value)
+
+    def add_event(self, name, attributes=None):
+        self._span.add_event(name, attributes=attributes or {})
+
+    def set_status(self, ok):
+        from opentelemetry.trace import StatusCode
+
+        code = StatusCode.OK if ok else StatusCode.ERROR
+        self._span.set_status(code)
+
+    def end(self):
+        self._span.end()
+
+
+class OTelTracer:
+    def __init__(self, tracer) -> None:
+        self._tracer = tracer
+
+    def start_span(self, name, attributes=None):
+        span = self._tracer.start_span(name, attributes=attributes)
+        return OTelSpan(span)
+
+
+otel_tracer = trace.get_tracer("cuprum")
+hook = TracingHook(OTelTracer(otel_tracer))
+```
+
+### Design principles for adapters
+
+The adapters follow these design principles:
+
+1. **Optional dependencies**: Adapters do not import external telemetry
+   libraries. They define protocols that can be implemented with any backend.
+
+2. **Non-blocking execution**: Hooks are synchronous and complete quickly.
+   For high-throughput scenarios, consider buffering or async handlers.
+
+3. **Protocol-based integration**: Use Python's `Protocol` classes to define
+   the interface, making it easy to swap implementations without inheritance.
+
+4. **Reference implementations**: The `InMemoryMetrics` and `InMemoryTracer`
+   classes serve as both documentation and test utilities.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -521,8 +521,8 @@ logger.addHandler(handler)
 ### Metrics adapter
 
 The `metrics_adapter` module provides a Prometheus-style metrics hook that
-collects counters and histograms. It uses a protocol class so you can implement
-the backend with your preferred metrics library.
+collects counters and histograms. It uses a protocol class so the backend can
+be implemented with any preferred metrics library.
 
 ```python
 from cuprum import ECHO, scoped, sh
@@ -634,7 +634,7 @@ class OTelSpan:
     def add_event(self, name, attributes=None):
         self._span.add_event(name, attributes=attributes or {})
 
-    def set_status(self, ok):
+    def set_status(self, *, ok):
         from opentelemetry.trace import StatusCode
 
         code = StatusCode.OK if ok else StatusCode.ERROR

--- a/tests/behaviour/test_telemetry_adapters.py
+++ b/tests/behaviour/test_telemetry_adapters.py
@@ -18,7 +18,7 @@ from tests.helpers.catalogue import python_catalogue
 
 @scenario(
     "../features/telemetry_adapters.feature",
-    "Structured logging hook emits JSON-compatible records",
+    "Structured logging hook emits structured records",
 )
 def test_structured_logging_hook_emits_records() -> None:
     """Behavioural coverage for structured logging adapter."""

--- a/tests/behaviour/test_telemetry_adapters.py
+++ b/tests/behaviour/test_telemetry_adapters.py
@@ -1,0 +1,310 @@
+"""Behavioural tests for telemetry adapter modules."""
+
+from __future__ import annotations
+
+import logging
+import typing as typ
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from cuprum import sh
+from cuprum.adapters.logging_adapter import structured_logging_hook
+from cuprum.adapters.metrics_adapter import InMemoryMetrics, MetricsHook
+from cuprum.adapters.tracing_adapter import InMemoryTracer, TracingHook
+from cuprum.context import scoped
+from tests.helpers.catalogue import python_catalogue
+
+
+@scenario(
+    "../features/telemetry_adapters.feature",
+    "Structured logging hook emits JSON-compatible records",
+)
+def test_structured_logging_hook_emits_records() -> None:
+    """Behavioural coverage for structured logging adapter."""
+
+
+@scenario(
+    "../features/telemetry_adapters.feature",
+    "Metrics hook collects execution counters and histograms",
+)
+def test_metrics_hook_collects_counters_histograms() -> None:
+    """Behavioural coverage for metrics adapter success path."""
+
+
+@scenario(
+    "../features/telemetry_adapters.feature",
+    "Metrics hook tracks failure counts",
+)
+def test_metrics_hook_tracks_failures() -> None:
+    """Behavioural coverage for metrics adapter failure path."""
+
+
+@scenario(
+    "../features/telemetry_adapters.feature",
+    "Tracing hook creates spans with attributes",
+)
+def test_tracing_hook_creates_spans() -> None:
+    """Behavioural coverage for tracing adapter success path."""
+
+
+@scenario(
+    "../features/telemetry_adapters.feature",
+    "Tracing hook sets error status on failure",
+)
+def test_tracing_hook_error_status() -> None:
+    """Behavioural coverage for tracing adapter failure path."""
+
+
+@pytest.fixture
+def behaviour_state() -> dict[str, object]:
+    """Shared mutable state for behaviour scenarios."""
+    return {}
+
+
+@given("a curated Python command for testing", target_fixture="python_cmd_fixture")
+def given_python_command() -> dict[str, object]:
+    """Set up a Python command builder and catalogue."""
+    catalogue, python_program = python_catalogue()
+    return {
+        "catalogue": catalogue,
+        "python_program": python_program,
+        "builder": sh.make(python_program, catalogue=catalogue),
+    }
+
+
+@given(
+    "a structured logging hook with a test logger",
+    target_fixture="logging_hook_fixture",
+)
+def given_structured_logging_hook(
+    behaviour_state: dict[str, object],
+) -> dict[str, object]:
+    """Set up a structured logging hook with a dedicated test logger."""
+    logger = logging.getLogger("cuprum.test.adapters.bdd")
+    logger.setLevel(logging.DEBUG)
+    logger.handlers.clear()
+
+    class RecordCapture(logging.Handler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.records: list[logging.LogRecord] = []
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self.records.append(record)
+
+    handler = RecordCapture()
+    logger.addHandler(handler)
+
+    hook = structured_logging_hook(logger=logger)
+    behaviour_state["log_handler"] = handler
+
+    return {"logger": logger, "hook": hook, "handler": handler}
+
+
+@given("an in-memory metrics collector", target_fixture="metrics_fixture")
+def given_metrics_collector(behaviour_state: dict[str, object]) -> dict[str, object]:
+    """Set up an in-memory metrics collector."""
+    metrics = InMemoryMetrics()
+    hook = MetricsHook(metrics)
+    behaviour_state["metrics"] = metrics
+    return {"metrics": metrics, "hook": hook}
+
+
+@given("an in-memory tracer", target_fixture="tracer_fixture")
+def given_tracer(behaviour_state: dict[str, object]) -> dict[str, object]:
+    """Set up an in-memory tracer."""
+    tracer = InMemoryTracer()
+    hook = TracingHook(tracer, record_output=True)
+    behaviour_state["tracer"] = tracer
+    return {"tracer": tracer, "hook": hook}
+
+
+@when("I run a command that writes to stdout and stderr")
+def when_run_stdout_stderr(
+    behaviour_state: dict[str, object],
+    python_cmd_fixture: dict[str, object],
+    logging_hook_fixture: dict[str, object],
+) -> None:
+    """Run a command that writes to both streams."""
+    catalogue = typ.cast("typ.Any", python_cmd_fixture["catalogue"])
+    builder = typ.cast("typ.Any", python_cmd_fixture["builder"])
+    hook = typ.cast("typ.Any", logging_hook_fixture["hook"])
+
+    script = "\n".join(
+        (
+            "import sys",
+            "print('stdout-line')",
+            "print('stderr-line', file=sys.stderr)",
+        ),
+    )
+    cmd = builder("-c", script)
+
+    with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+        result = cmd.run_sync()
+
+    behaviour_state["result"] = result
+
+
+@when("I run a command that succeeds")
+def when_run_success(
+    behaviour_state: dict[str, object],
+    python_cmd_fixture: dict[str, object],
+    metrics_fixture: dict[str, object],
+) -> None:
+    """Run a command that exits with code 0."""
+    catalogue = typ.cast("typ.Any", python_cmd_fixture["catalogue"])
+    builder = typ.cast("typ.Any", python_cmd_fixture["builder"])
+    hook = typ.cast("typ.Any", metrics_fixture["hook"])
+
+    cmd = builder("-c", "print('ok')")
+
+    with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+        result = cmd.run_sync()
+
+    behaviour_state["result"] = result
+
+
+@when("I run a command that fails with non-zero exit")
+def when_run_failure(
+    behaviour_state: dict[str, object],
+    python_cmd_fixture: dict[str, object],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Run a failing command with either metrics or tracer hook."""
+    catalogue = typ.cast("typ.Any", python_cmd_fixture["catalogue"])
+    builder = typ.cast("typ.Any", python_cmd_fixture["builder"])
+
+    # Determine which hook to use based on which fixture is available
+    if "metrics_fixture" in request.fixturenames:
+        hook = typ.cast("typ.Any", request.getfixturevalue("metrics_fixture")["hook"])
+    elif "tracer_fixture" in request.fixturenames:
+        hook = typ.cast("typ.Any", request.getfixturevalue("tracer_fixture")["hook"])
+    else:
+        msg = "Neither metrics_fixture nor tracer_fixture available"
+        raise RuntimeError(msg)
+
+    cmd = builder("-c", "import sys; sys.exit(1)")
+
+    with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+        result = cmd.run_sync()
+
+    behaviour_state["result"] = result
+
+
+@when("I run a command that writes output")
+def when_run_with_output(
+    behaviour_state: dict[str, object],
+    python_cmd_fixture: dict[str, object],
+    tracer_fixture: dict[str, object],
+) -> None:
+    """Run a command with output for tracing."""
+    catalogue = typ.cast("typ.Any", python_cmd_fixture["catalogue"])
+    builder = typ.cast("typ.Any", python_cmd_fixture["builder"])
+    hook = typ.cast("typ.Any", tracer_fixture["hook"])
+
+    script = "\n".join(
+        (
+            "import sys",
+            "print('traced-output')",
+            "print('traced-error', file=sys.stderr)",
+        ),
+    )
+    cmd = builder("-c", script)
+
+    with scoped(allowlist=catalogue.allowlist), sh.observe(hook):
+        result = cmd.run_sync()
+
+    behaviour_state["result"] = result
+
+
+@then("the logger receives records for all execution phases")
+def then_all_phases_logged(
+    behaviour_state: dict[str, object],
+    logging_hook_fixture: dict[str, object],
+) -> None:
+    """Verify all execution phases are logged."""
+    handler = typ.cast("typ.Any", logging_hook_fixture["handler"])
+    records = handler.records
+
+    messages = [r.message for r in records]
+    assert any("cuprum.plan" in m for m in messages), "Missing plan event"
+    assert any("cuprum.start" in m for m in messages), "Missing start event"
+    assert any("cuprum.stdout" in m for m in messages), "Missing stdout event"
+    assert any("cuprum.stderr" in m for m in messages), "Missing stderr event"
+    assert any("cuprum.exit" in m for m in messages), "Missing exit event"
+
+
+@then("each record contains cuprum-prefixed extra fields")
+def then_extra_fields_present(
+    logging_hook_fixture: dict[str, object],
+) -> None:
+    """Verify extra fields are attached to log records."""
+    handler = typ.cast("typ.Any", logging_hook_fixture["handler"])
+    records = handler.records
+
+    start_record = next(r for r in records if "cuprum.start" in r.message)
+    assert hasattr(start_record, "cuprum_phase")
+    assert start_record.cuprum_phase == "start"
+    assert hasattr(start_record, "cuprum_program")
+
+
+@then("the execution counter is incremented")
+def then_counter_incremented(behaviour_state: dict[str, object]) -> None:
+    """Verify execution counter was incremented."""
+    metrics = typ.cast("InMemoryMetrics", behaviour_state["metrics"])
+    assert metrics.counters.get("cuprum_executions_total") == 1.0
+
+
+@then("the duration histogram contains an observation")
+def then_histogram_observation(behaviour_state: dict[str, object]) -> None:
+    """Verify duration histogram has an observation."""
+    metrics = typ.cast("InMemoryMetrics", behaviour_state["metrics"])
+    durations = metrics.histograms.get("cuprum_duration_seconds", [])
+    assert len(durations) == 1
+    assert durations[0] >= 0.0
+
+
+@then("the failure counter is incremented")
+def then_failure_counter_incremented(behaviour_state: dict[str, object]) -> None:
+    """Verify failure counter was incremented."""
+    metrics = typ.cast("InMemoryMetrics", behaviour_state["metrics"])
+    assert metrics.counters.get("cuprum_failures_total") == 1.0
+
+
+@then("a span is created and ended")
+def then_span_created(behaviour_state: dict[str, object]) -> None:
+    """Verify a span was created and properly ended."""
+    tracer = typ.cast("InMemoryTracer", behaviour_state["tracer"])
+    assert len(tracer.spans) == 1
+    span = tracer.spans[0]
+    assert span.ended is True
+
+
+@then("the span has program and exit code attributes")
+def then_span_attributes(behaviour_state: dict[str, object]) -> None:
+    """Verify span has expected attributes."""
+    tracer = typ.cast("InMemoryTracer", behaviour_state["tracer"])
+    span = tracer.spans[0]
+    assert "cuprum.program" in span.attributes
+    assert "cuprum.exit_code" in span.attributes
+    assert span.attributes["cuprum.exit_code"] == 0
+
+
+@then("the span records output as events")
+def then_span_events(behaviour_state: dict[str, object]) -> None:
+    """Verify span has output events."""
+    tracer = typ.cast("InMemoryTracer", behaviour_state["tracer"])
+    span = tracer.spans[0]
+    event_names = [name for name, _ in span.events]
+    assert "cuprum.stdout" in event_names
+    assert "cuprum.stderr" in event_names
+
+
+@then("the span status indicates an error")
+def then_span_error_status(behaviour_state: dict[str, object]) -> None:
+    """Verify span status indicates failure."""
+    tracer = typ.cast("InMemoryTracer", behaviour_state["tracer"])
+    span = tracer.spans[0]
+    assert span.status_ok is False
+    assert span.attributes.get("cuprum.exit_code") == 1

--- a/tests/behaviour/test_telemetry_adapters.py
+++ b/tests/behaviour/test_telemetry_adapters.py
@@ -249,7 +249,8 @@ def then_extra_fields_present(
     handler = typ.cast("typ.Any", logging_hook_fixture["handler"])
     records = handler.records
 
-    start_record = next(r for r in records if "cuprum.start" in r.message)
+    start_record = next((r for r in records if "cuprum.start" in r.message), None)
+    assert start_record is not None, "No start record found in log records"
     assert hasattr(start_record, "cuprum_phase")
     assert start_record.cuprum_phase == "start"
     assert hasattr(start_record, "cuprum_program")

--- a/tests/behaviour/test_telemetry_adapters.py
+++ b/tests/behaviour/test_telemetry_adapters.py
@@ -1,4 +1,14 @@
-"""Behavioural tests for telemetry adapter modules."""
+"""Behavioural tests for telemetry adapter modules.
+
+Note on type casting
+--------------------
+This module uses ``typ.cast("typ.Any", ...)`` extensively when accessing
+pytest-bdd fixture values from dictionaries. This pattern is necessary because
+pytest-bdd fixtures return ``object`` types, and the dict-based fixture approach
+used here (returning ``dict[str, object]``) loses type information. The casts
+reduce type safety but are confined to test code where runtime behavior is
+verified by assertions.
+"""
 
 from __future__ import annotations
 

--- a/tests/behaviour/test_telemetry_adapters.py
+++ b/tests/behaviour/test_telemetry_adapters.py
@@ -184,23 +184,27 @@ def when_run_success(
     _execute_python_command(behaviour_state, python_cmd_fixture, hook, "print('ok')")
 
 
-@when("I run a command that fails with non-zero exit")
-def when_run_failure(
+@when("I run a command that fails with metrics tracking")
+def when_run_failure_with_metrics(
     behaviour_state: dict[str, object],
     python_cmd_fixture: dict[str, object],
-    request: pytest.FixtureRequest,
+    metrics_fixture: dict[str, object],
 ) -> None:
-    """Run a failing command with either metrics or tracer hook."""
-    # Determine which hook to use based on which fixture is available
-    hook: ExecHook
-    if "metrics_fixture" in request.fixturenames:
-        hook = typ.cast("ExecHook", request.getfixturevalue("metrics_fixture")["hook"])
-    elif "tracer_fixture" in request.fixturenames:
-        hook = typ.cast("ExecHook", request.getfixturevalue("tracer_fixture")["hook"])
-    else:
-        msg = "Neither metrics_fixture nor tracer_fixture available"
-        raise RuntimeError(msg)
+    """Run a failing command with metrics hook."""
+    hook = typ.cast("ExecHook", metrics_fixture["hook"])
+    _execute_python_command(
+        behaviour_state, python_cmd_fixture, hook, "import sys; sys.exit(1)"
+    )
 
+
+@when("I run a command that fails with tracing")
+def when_run_failure_with_tracer(
+    behaviour_state: dict[str, object],
+    python_cmd_fixture: dict[str, object],
+    tracer_fixture: dict[str, object],
+) -> None:
+    """Run a failing command with tracer hook."""
+    hook = typ.cast("ExecHook", tracer_fixture["hook"])
     _execute_python_command(
         behaviour_state, python_cmd_fixture, hook, "import sys; sys.exit(1)"
     )

--- a/tests/features/telemetry_adapters.feature
+++ b/tests/features/telemetry_adapters.feature
@@ -5,7 +5,7 @@ Feature: Telemetry adapters for structured execution events
   Background:
     Given a curated Python command for testing
 
-  Scenario: Structured logging hook emits JSON-compatible records
+  Scenario: Structured logging hook emits structured records
     Given a structured logging hook with a test logger
     When I run a command that writes to stdout and stderr
     Then the logger receives records for all execution phases

--- a/tests/features/telemetry_adapters.feature
+++ b/tests/features/telemetry_adapters.feature
@@ -19,7 +19,7 @@ Feature: Telemetry adapters for structured execution events
 
   Scenario: Metrics hook tracks failure counts
     Given an in-memory metrics collector
-    When I run a command that fails with non-zero exit
+    When I run a command that fails with metrics tracking
     Then the failure counter is incremented
 
   Scenario: Tracing hook creates spans with attributes
@@ -31,5 +31,5 @@ Feature: Telemetry adapters for structured execution events
 
   Scenario: Tracing hook sets error status on failure
     Given an in-memory tracer
-    When I run a command that fails with non-zero exit
+    When I run a command that fails with tracing
     Then the span status indicates an error

--- a/tests/features/telemetry_adapters.feature
+++ b/tests/features/telemetry_adapters.feature
@@ -1,0 +1,35 @@
+Feature: Telemetry adapters for structured execution events
+  Cuprum provides example adapters that integrate execution events with common
+  telemetry backends. These adapters remain optional and non-blocking.
+
+  Background:
+    Given a curated Python command for testing
+
+  Scenario: Structured logging hook emits JSON-compatible records
+    Given a structured logging hook with a test logger
+    When I run a command that writes to stdout and stderr
+    Then the logger receives records for all execution phases
+    And each record contains cuprum-prefixed extra fields
+
+  Scenario: Metrics hook collects execution counters and histograms
+    Given an in-memory metrics collector
+    When I run a command that succeeds
+    Then the execution counter is incremented
+    And the duration histogram contains an observation
+
+  Scenario: Metrics hook tracks failure counts
+    Given an in-memory metrics collector
+    When I run a command that fails with non-zero exit
+    Then the failure counter is incremented
+
+  Scenario: Tracing hook creates spans with attributes
+    Given an in-memory tracer
+    When I run a command that writes output
+    Then a span is created and ended
+    And the span has program and exit code attributes
+    And the span records output as events
+
+  Scenario: Tracing hook sets error status on failure
+    Given an in-memory tracer
+    When I run a command that fails with non-zero exit
+    Then the span status indicates an error


### PR DESCRIPTION
## Summary
- Introduces structured telemetry adapters for Cuprum: logging, metrics, and tracing.
- Adds protocol-based abstractions plus in-memory reference implementations for testing and examples.
- Includes unit tests, behavioural tests, and documentation updates.
- Adapters are optional, non-blocking, and thread-safe; designed to integrate with a variety of backends without hard dependencies.

## Changes
### Adapters
- cuprum/adapters/__init__.py
  - New module providing example adapters for structured execution events (logging, metrics, tracing).
- cuprum/adapters/logging_adapter.py
  - structured_logging_hook(): emits structured log records for ExecEvent phases with configurable log levels.
  - JsonLoggingFormatter: JSON formatter for cuprum_ prefixed fields to ease log aggregation.
- cuprum/adapters/metrics_adapter.py
  - MetricsCollector protocol: abstract backend for counters and histograms.
  - InMemoryMetrics: thread-safe in-memory metrics store for testing/examples.
  - MetricsHook: observe hook updating metrics per ExecEvent (start, stdout, stderr, exit).
  - metrics_hook(): convenience factory returning a MetricsHook.
- cuprum/adapters/tracing_adapter.py
  - Span and Tracer protocols: minimal abstraction for a tracing backend.
  - InMemorySpan and InMemoryTracer: in-memory reference implementations.
  - TracingHook: observe hook creating/ending spans, attaching attributes, and recording output as events.
  - tracing_hook(): convenience factory returning a TracingHook.

### Tests
- cuprum/unittests/test_adapters.py: Unit tests for the new adapters (logging, metrics, tracing).
- tests/behaviour/test_telemetry_adapters.py: Behavioural tests for the adapters (BDD style).
- tests/features/telemetry_adapters.feature: Gherkin scenarios covering logging, metrics, and tracing behaviors.

### Documentation
- docs/cuprum-design.md: Telemetry Adapter Design Decisions detailing protocol-based design, non-blocking hooks, thread-safety, and adapter specifics.
- docs/users-guide.md: Telemetry adapters section with examples for structured logging, metrics, and tracing, plus formatter guidance.

## Why
- Provides a robust, extensible way to observe Cuprum command execution via common telemetry backends without introducing runtime dependencies.
- Encourages users to plug in their preferred backends while Cuprum exposes rich, structured event data through unified hooks.

## How to use
- Structured logging (example):
  - from cuprum.adapters.logging_adapter import structured_logging_hook
  - hook = structured_logging_hook(logger=my_logger, plan_level=logging.DEBUG, start_level=logging.INFO, output_level=logging.DEBUG, exit_level=logging.INFO)
  - with sh.observe(hook): ...
  - Optional: use JsonLoggingFormatter for JSON output:
    - from cuprum.adapters.logging_adapter import JsonLoggingFormatter
    - attach JsonLoggingFormatter to a StreamHandler

- Metrics (example):
  - from cuprum.adapters.metrics_adapter import InMemoryMetrics, MetricsHook
  - metrics = InMemoryMetrics()
  - hook = MetricsHook(metrics)
  - with sh.observe(hook): ...
  - Or implement your own MetricsCollector and use metrics_hook(metrics_collector)

- Tracing (example):
  - from cuprum.adapters.tracing_adapter import InMemoryTracer, TracingHook
  - tracer = InMemoryTracer()
  - hook = TracingHook(tracer, record_output=True)
  - with sh.observe(hook): ...
  - For real backends, implement Tracer and Span protocols and pass to tracing_hook()

## Testing
- Run tests with: pytest
- The suite includes unit tests, behavioural tests (pytest-bdd), and feature tests to validate end-to-end adapter behavior.

## Impact
- No breaking changes to existing Cuprum APIs.
- Adds optional observability capabilities that can be adopted incrementally.

If you want additional adapters (e.g., OpenTelemetry integration examples) or more metrics/trace backends, we can extend the protocols and provide additional reference implementations in follow-up PRs.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/69f5f0f8-22aa-4450-8e6b-c14ef28373bf

## Summary by Sourcery

Add optional telemetry adapters for structured logging, metrics, and tracing over Cuprum execution events, with protocol-based abstractions and in-memory reference implementations.

New Features:
- Introduce structured logging adapter that emits ExecEvent-based records with configurable log levels and a JsonLoggingFormatter for JSON output.
- Add metrics adapter with a MetricsCollector protocol, in-memory metrics collector, and hook that records execution counters, failures, durations, and output line counts.
- Add tracing adapter with Span and Tracer protocols, in-memory tracer/span implementations, and hook that creates spans with rich execution attributes and optional output events.
- Expose new telemetry adapter modules under the cuprum.adapters package.

Enhancements:
- Document telemetry adapter usage, design principles, and integration patterns in the user guide and design docs.
- Mark roadmap item for example logging, metrics, and tracing adapters as completed.

Tests:
- Add unit tests covering logging, metrics, and tracing adapters including factories and in-memory implementations.
- Add behaviour-driven tests and Gherkin feature scenarios validating end-to-end telemetry adapter behaviour.
