### PR TITLE
Add Python version matrix for CI typechecks, tests, and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
-    env:
-      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -40,8 +37,71 @@ jobs:
       - name: Run ruff
         run: make lint
 
+  typecheck-test:
+    name: Typecheck and test (Python ${{ matrix.python-label }})
+    continue-on-error: ${{ matrix.experimental }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: '3.12'
+            python-label: '3.12'
+            allow-prereleases: false
+            experimental: false
+          - python-version: '3.13'
+            python-label: '3.13'
+            allow-prereleases: false
+            experimental: false
+          - python-version: '3.14'
+            python-label: '3.14'
+            allow-prereleases: false
+            experimental: false
+          - python-version: '3.15'
+            python-label: '3.15a'
+            allow-prereleases: true
+            experimental: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ matrix.allow-prereleases }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
       - name: Run typechecker
         run: make typecheck
+
+      - name: Run tests
+        run: make test
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - lint-test
+      - typecheck-test
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Install code
+        run: make build
 
       - name: Run tests with coverage
         run: |

--- a/cuprum/unittests/test_concurrency.py
+++ b/cuprum/unittests/test_concurrency.py
@@ -189,12 +189,13 @@ def test_concurrency_limit_restricts_parallel_execution() -> None:
 
 def test_concurrency_none_allows_unlimited() -> None:
     """concurrency=None allows all commands to run in parallel."""
-    # Use longer sleeps with wider margin for max_elapsed to tolerate CI jitter
+    # Keep a relaxed upper bound so this remains stable under xdist/CI jitter
+    # while still proving the run is significantly below sequential timing.
     _assert_concurrent_timing(
         num_commands=4,
         sleep_seconds=0.2,
         concurrency=None,
-        timing=_TimingExpectation(min_elapsed=0.0, max_elapsed=0.6),
+        timing=_TimingExpectation(min_elapsed=0.0, max_elapsed=0.8),
     )
 
 

--- a/cuprum/unittests/test_concurrency.py
+++ b/cuprum/unittests/test_concurrency.py
@@ -189,13 +189,13 @@ def test_concurrency_limit_restricts_parallel_execution() -> None:
 
 def test_concurrency_none_allows_unlimited() -> None:
     """concurrency=None allows all commands to run in parallel."""
-    # Keep a relaxed upper bound so this remains stable under xdist/CI jitter
-    # while still proving the run is significantly below sequential timing.
+    # Keep the upper bound below sequential runtime (4 * 0.2s = 0.8s) while
+    # leaving headroom for xdist and scheduler jitter.
     _assert_concurrent_timing(
         num_commands=4,
         sleep_seconds=0.2,
         concurrency=None,
-        timing=_TimingExpectation(min_elapsed=0.0, max_elapsed=0.8),
+        timing=_TimingExpectation(min_elapsed=0.0, max_elapsed=0.7),
     )
 
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -144,9 +144,8 @@ restore_cmd = tar_extract(
 ```
 
 Relative paths require `allow_relative=True` on the relevant option objects
-(for example, `RsyncOptions`) or using
-`safe_path(..., allow_relative=True)` before passing the result into a
-builder.
+(for example, `RsyncOptions`) or using `safe_path(..., allow_relative=True)`
+before passing the result into a builder.
 
 ## Pipeline execution
 
@@ -977,7 +976,13 @@ using `uv_build` without any Rust dependencies.
 
 ### CI build commands
 
-The continuous integration (CI) workflows use two routes:
+The continuous integration (CI) workflows run the following checks:
+
+- Type checking and tests run in a Python version matrix. Required rows use
+  Python 3.12, 3.13, and 3.14. The Python 3.15a row is experimental and allowed
+  to fail.
+- Formatting and lint checks run on Python 3.13.
+- Coverage upload (artifact + optional CodeScene upload) runs on Python 3.13.
 
 - Pure Python wheel:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -144,7 +144,7 @@ restore_cmd = tar_extract(
 ```
 
 Relative paths require `allow_relative=True` on the relevant option objects
-(for example, `RsyncOptions`) or using `safe_path(..., allow_relative=True)`
+(for example, `RsyncOptions`) or use `safe_path(..., allow_relative=True)`
 before passing the result into a builder.
 
 ## Pipeline execution


### PR DESCRIPTION
## Summary
- Introduces a Python version matrix in CI to run type checks and tests across multiple Python versions (3.12, 3.13, 3.14; with 3.15a experimental) and adds a coverage pipeline.

## Changes

### CI Workflow
- Add typecheck-test job with a matrix over Python versions:
  - 3.12, 3.13, 3.14 (non-prerelease)
  - 3.15a (experimental)
- Steps include: checkout, setup Python, install uv, run typecheck, and run tests
- Add coverage job that depends on lint-test and typecheck-test; uses CodeScene/CODESCENE tokens; checks out repo, installs uv, builds, and runs tests with coverage

### Tests
- Relaxed timing bound in test_concurrency.py for the None-concurrency case to better tolerate CI jitter (max_elapsed from 0.6 to 0.7 seconds)

### Documentation
- docs/users-guide.md
  - CI build commands section updated to reflect the Python version matrix and the experimental 3.15a row (allowed to fail)
  - Clarified relative path handling in option builders (allow_relative=true) wording

## Test plan
- Trigger CI to verify:
  - typecheck-test and test jobs run across Python 3.12, 3.13, 3.14; 3.15a runs as experimental (may fail)
  - lint-test completes before coverage
  - coverage job runs after lint and typecheck, using Python 3.13
- Locally, ensure make typecheck and make test pass under the supported Python versions you actively test with

## Notes
- 3.15a is experimental and may fail; this is expected while validating the matrix setup
- No changes to public API; only CI/testing workflow and a minor test timing adjustment

📎 **Task**: https://www.devboxer.com/task/e41eb0e3-97f5-4e58-b745-c4b541316aa4