### PR TITLE
Complete 4.3.4: property-based stream tests, exec plan, docs

### DIFF
--- a/cuprum/unittests/test_stream_property_based.py
+++ b/cuprum/unittests/test_stream_property_based.py
@@ -53,8 +53,11 @@ def payload_and_chunk_sizes(
     payload = draw(st.binary(min_size=min_size, max_size=max_size))
     payload_size = len(payload)
 
-    if payload_size <= 1 or max_cuts == 0:
-        return payload, (payload_size,) if payload_size == 1 else ()
+    if payload_size <= 1:
+        return payload, (payload_size,) if payload_size > 0 else ()
+
+    if max_cuts == 0:
+        return payload, (payload_size,)
 
     cut_ceiling = min(max_cuts, payload_size - 1)
     cut_points = draw(
@@ -84,7 +87,7 @@ def test_stream_preserves_random_payloads_across_random_chunk_boundaries(
     Parameters
     ----------
     stream_backend : str
-        Active stream backend from fixture parametrisation.
+        Active stream backend from fixture parameterization.
     case : tuple[bytes, tuple[int, ...]]
         Random payload and random chunk partition.
     """
@@ -120,7 +123,7 @@ def test_stream_preserves_random_payloads_around_python_read_size_boundary(
     Parameters
     ----------
     stream_backend : str
-        Active stream backend from fixture parametrisation.
+        Active stream backend from fixture parameterization.
     case : tuple[bytes, tuple[int, ...]]
         Random payload and random chunk partition.
     """

--- a/cuprum/unittests/test_stream_property_based.py
+++ b/cuprum/unittests/test_stream_property_based.py
@@ -95,10 +95,16 @@ def test_stream_preserves_random_payloads_across_random_chunk_boundaries(
     property_case = build_property_pipeline_case(payload, chunk_sizes)
     result = run_parity_pipeline(property_case.pipeline, property_case.allowlist)
 
-    assert result.ok is True
-    assert result.stdout == property_case.expected_hex
-    assert len(result.stages) == 2
-    assert all(stage.exit_code == 0 for stage in result.stages)
+    assert result.ok is True, f"expected result.ok to be True but got {result.ok}"
+    assert result.stdout == property_case.expected_hex, (
+        f"stdout mismatch: expected {property_case.expected_hex!r} but got "
+        f"{result.stdout!r}"
+    )
+    assert len(result.stages) == 2, f"expected 2 stages but got {len(result.stages)}"
+    assert all(stage.exit_code == 0 for stage in result.stages), (
+        "one or more stages had non-zero exit_code: "
+        f"{[stage.exit_code for stage in result.stages]}"
+    )
 
 
 @settings(
@@ -131,7 +137,13 @@ def test_stream_preserves_random_payloads_around_python_read_size_boundary(
     property_case = build_property_pipeline_case(payload, chunk_sizes)
     result = run_parity_pipeline(property_case.pipeline, property_case.allowlist)
 
-    assert result.ok is True
-    assert result.stdout == property_case.expected_hex
-    assert len(result.stages) == 2
-    assert all(stage.exit_code == 0 for stage in result.stages)
+    assert result.ok is True, f"expected result.ok to be True but got {result.ok}"
+    assert result.stdout == property_case.expected_hex, (
+        f"stdout mismatch: expected {property_case.expected_hex!r} but got "
+        f"{result.stdout!r}"
+    )
+    assert len(result.stages) == 2, f"expected 2 stages but got {len(result.stages)}"
+    assert all(stage.exit_code == 0 for stage in result.stages), (
+        "one or more stages had non-zero exit_code: "
+        f"{[stage.exit_code for stage in result.stages]}"
+    )

--- a/cuprum/unittests/test_stream_property_based.py
+++ b/cuprum/unittests/test_stream_property_based.py
@@ -26,7 +26,7 @@ if typ.TYPE_CHECKING:
 _GENERAL_MAX_EXAMPLES = 12
 _BOUNDARY_MAX_EXAMPLES = 6
 _BOUNDARY_DELTA = 512
-_BOUNDARY_MIN_SIZE = _READ_SIZE - _BOUNDARY_DELTA
+_BOUNDARY_MIN_SIZE = max(0, _READ_SIZE - _BOUNDARY_DELTA)
 _BOUNDARY_MAX_SIZE = _READ_SIZE + _BOUNDARY_DELTA
 
 
@@ -38,24 +38,7 @@ def _payload_and_chunk_sizes(
     max_size: int,
     max_cuts: int,
 ) -> tuple[bytes, tuple[int, ...]]:
-    """Generate random payload bytes and random chunk partitions.
-
-    Parameters
-    ----------
-    draw : st.DrawFn
-        Hypothesis draw function used by ``@st.composite``.
-    min_size : int
-        Minimum payload size in bytes.
-    max_size : int
-        Maximum payload size in bytes.
-    max_cuts : int
-        Maximum number of cut points used to partition the payload.
-
-    Returns
-    -------
-    tuple[bytes, tuple[int, ...]]
-        Random payload bytes and a tuple of chunk sizes.
-    """
+    """Generate random payload bytes and chunk sizes for tests."""
     payload = draw(st.binary(min_size=min_size, max_size=max_size))
     payload_size = len(payload)
 
@@ -66,7 +49,7 @@ def _payload_and_chunk_sizes(
         return payload, (payload_size,)
 
     cut_ceiling = min(max_cuts, payload_size - 1)
-    cut_points = draw(
+    cut_points: tuple[int, ...] = draw(
         st.lists(
             st.integers(min_value=1, max_value=payload_size - 1),
             min_size=1,

--- a/cuprum/unittests/test_stream_property_based.py
+++ b/cuprum/unittests/test_stream_property_based.py
@@ -1,0 +1,168 @@
+"""Property-based tests for stream content preservation across chunk boundaries.
+
+These tests use Hypothesis to generate random payloads and random chunk
+boundaries. The pipeline writes bytes in configured chunk sizes and verifies
+the downstream stage receives identical bytes by comparing hexadecimal output.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from cuprum import sh
+from tests.helpers.parity import (
+    chunk_sizes_from_cut_points,
+    chunked_writer_script,
+    hex_sink_script,
+    parity_catalogue,
+    payload_to_base64,
+    run_parity_pipeline,
+)
+
+if typ.TYPE_CHECKING:
+    from cuprum.program import Program
+    from cuprum.sh import Pipeline
+
+_GENERAL_MAX_EXAMPLES = 12
+_BOUNDARY_MAX_EXAMPLES = 6
+
+
+@st.composite
+def payload_and_chunk_sizes(
+    draw: st.DrawFn,
+    *,
+    min_size: int,
+    max_size: int,
+    max_cuts: int,
+) -> tuple[bytes, tuple[int, ...]]:
+    """Generate random payload bytes and random chunk partitions.
+
+    Parameters
+    ----------
+    draw : st.DrawFn
+        Hypothesis draw function used by ``@st.composite``.
+    min_size : int
+        Minimum payload size in bytes.
+    max_size : int
+        Maximum payload size in bytes.
+    max_cuts : int
+        Maximum number of cut points used to partition the payload.
+
+    Returns
+    -------
+    tuple[bytes, tuple[int, ...]]
+        Random payload bytes and a tuple of chunk sizes.
+    """
+    payload = draw(st.binary(min_size=min_size, max_size=max_size))
+    payload_size = len(payload)
+
+    if payload_size <= 1 or max_cuts == 0:
+        return payload, (payload_size,) if payload_size == 1 else ()
+
+    cut_ceiling = min(max_cuts, payload_size - 1)
+    cut_points = draw(
+        st.lists(
+            st.integers(min_value=1, max_value=payload_size - 1),
+            min_size=1,
+            max_size=cut_ceiling,
+            unique=True,
+        ).map(lambda points: tuple(sorted(points))),
+    )
+    return payload, chunk_sizes_from_cut_points(payload_size, cut_points)
+
+
+def _build_property_pipeline(
+    payload: bytes,
+    chunk_sizes: tuple[int, ...],
+) -> tuple[Pipeline, frozenset[Program], str]:
+    """Build the writer-to-hex pipeline for property tests.
+
+    Parameters
+    ----------
+    payload : bytes
+        Source bytes written by the upstream stage.
+    chunk_sizes : tuple[int, ...]
+        Chunk sizes used by the upstream writer.
+
+    Returns
+    -------
+    tuple[Pipeline, frozenset[Program], str]
+        Pipeline, execution allowlist, and expected lowercase hex output.
+    """
+    catalogue, python_prog, _, _ = parity_catalogue()
+    python_cmd = sh.make(python_prog, catalogue=catalogue)
+
+    chunk_spec = ",".join(str(value) for value in chunk_sizes)
+    upstream = python_cmd(
+        "-c",
+        chunked_writer_script(),
+        payload_to_base64(payload),
+        chunk_spec,
+    )
+    downstream = python_cmd("-c", hex_sink_script())
+    pipeline = upstream | downstream
+    allowlist = frozenset([python_prog])
+    return pipeline, allowlist, payload.hex()
+
+
+@settings(
+    max_examples=_GENERAL_MAX_EXAMPLES,
+    deadline=None,
+    derandomize=True,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(case=payload_and_chunk_sizes(min_size=0, max_size=1024, max_cuts=8))
+def test_stream_preserves_random_payloads_across_random_chunk_boundaries(
+    stream_backend: str,
+    case: tuple[bytes, tuple[int, ...]],
+) -> None:
+    """Property: random payload bytes are preserved for random chunk boundaries.
+
+    Parameters
+    ----------
+    stream_backend : str
+        Active stream backend from fixture parametrisation.
+    case : tuple[bytes, tuple[int, ...]]
+        Random payload and random chunk partition.
+    """
+    payload, chunk_sizes = case
+    pipeline, allowlist, expected_hex = _build_property_pipeline(payload, chunk_sizes)
+    result = run_parity_pipeline(pipeline, allowlist)
+
+    assert result.ok is True
+    assert result.stdout == expected_hex
+    assert len(result.stages) == 2
+    assert all(stage.exit_code == 0 for stage in result.stages)
+
+
+@settings(
+    max_examples=_BOUNDARY_MAX_EXAMPLES,
+    deadline=None,
+    derandomize=True,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(case=payload_and_chunk_sizes(min_size=3584, max_size=4608, max_cuts=16))
+def test_stream_preserves_random_payloads_around_python_read_size_boundary(
+    stream_backend: str,
+    case: tuple[bytes, tuple[int, ...]],
+) -> None:
+    """Property: random payloads around 4 KB are preserved across chunk splits.
+
+    Parameters
+    ----------
+    stream_backend : str
+        Active stream backend from fixture parametrisation.
+    case : tuple[bytes, tuple[int, ...]]
+        Random payload and random chunk partition.
+    """
+    payload, chunk_sizes = case
+    pipeline, allowlist, expected_hex = _build_property_pipeline(payload, chunk_sizes)
+    result = run_parity_pipeline(pipeline, allowlist)
+
+    assert result.ok is True
+    assert result.stdout == expected_hex
+    assert len(result.stages) == 2
+    assert all(stage.exit_code == 0 for stage in result.stages)

--- a/cuprum/unittests/test_stream_property_based.py
+++ b/cuprum/unittests/test_stream_property_based.py
@@ -121,7 +121,7 @@ def test_stream_preserves_random_payloads_around_python_read_size_boundary(
     stream_backend: str,
     case: tuple[bytes, tuple[int, ...]],
 ) -> None:
-    """Property: random payloads around 4 KB are preserved across chunk splits.
+    """Property: payloads around _READ_SIZE (+/- _BOUNDARY_DELTA) are preserved.
 
     Parameters
     ----------

--- a/cuprum/unittests/test_stream_property_based.py
+++ b/cuprum/unittests/test_stream_property_based.py
@@ -7,27 +7,21 @@ the downstream stage receives identical bytes by comparing hexadecimal output.
 
 from __future__ import annotations
 
-import typing as typ
-
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from cuprum import sh
+from cuprum._streams import _READ_SIZE
 from tests.helpers.parity import (
+    build_property_pipeline_case,
     chunk_sizes_from_cut_points,
-    chunked_writer_script,
-    hex_sink_script,
-    parity_catalogue,
-    payload_to_base64,
     run_parity_pipeline,
 )
 
-if typ.TYPE_CHECKING:
-    from cuprum.program import Program
-    from cuprum.sh import Pipeline
-
 _GENERAL_MAX_EXAMPLES = 12
 _BOUNDARY_MAX_EXAMPLES = 6
+_BOUNDARY_DELTA = 512
+_BOUNDARY_MIN_SIZE = _READ_SIZE - _BOUNDARY_DELTA
+_BOUNDARY_MAX_SIZE = _READ_SIZE + _BOUNDARY_DELTA
 
 
 @st.composite
@@ -74,40 +68,6 @@ def payload_and_chunk_sizes(
     return payload, chunk_sizes_from_cut_points(payload_size, cut_points)
 
 
-def _build_property_pipeline(
-    payload: bytes,
-    chunk_sizes: tuple[int, ...],
-) -> tuple[Pipeline, frozenset[Program], str]:
-    """Build the writer-to-hex pipeline for property tests.
-
-    Parameters
-    ----------
-    payload : bytes
-        Source bytes written by the upstream stage.
-    chunk_sizes : tuple[int, ...]
-        Chunk sizes used by the upstream writer.
-
-    Returns
-    -------
-    tuple[Pipeline, frozenset[Program], str]
-        Pipeline, execution allowlist, and expected lowercase hex output.
-    """
-    catalogue, python_prog, _, _ = parity_catalogue()
-    python_cmd = sh.make(python_prog, catalogue=catalogue)
-
-    chunk_spec = ",".join(str(value) for value in chunk_sizes)
-    upstream = python_cmd(
-        "-c",
-        chunked_writer_script(),
-        payload_to_base64(payload),
-        chunk_spec,
-    )
-    downstream = python_cmd("-c", hex_sink_script())
-    pipeline = upstream | downstream
-    allowlist = frozenset([python_prog])
-    return pipeline, allowlist, payload.hex()
-
-
 @settings(
     max_examples=_GENERAL_MAX_EXAMPLES,
     deadline=None,
@@ -129,11 +89,11 @@ def test_stream_preserves_random_payloads_across_random_chunk_boundaries(
         Random payload and random chunk partition.
     """
     payload, chunk_sizes = case
-    pipeline, allowlist, expected_hex = _build_property_pipeline(payload, chunk_sizes)
-    result = run_parity_pipeline(pipeline, allowlist)
+    property_case = build_property_pipeline_case(payload, chunk_sizes)
+    result = run_parity_pipeline(property_case.pipeline, property_case.allowlist)
 
     assert result.ok is True
-    assert result.stdout == expected_hex
+    assert result.stdout == property_case.expected_hex
     assert len(result.stages) == 2
     assert all(stage.exit_code == 0 for stage in result.stages)
 
@@ -144,7 +104,13 @@ def test_stream_preserves_random_payloads_across_random_chunk_boundaries(
     derandomize=True,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
-@given(case=payload_and_chunk_sizes(min_size=3584, max_size=4608, max_cuts=16))
+@given(
+    case=payload_and_chunk_sizes(
+        min_size=_BOUNDARY_MIN_SIZE,
+        max_size=_BOUNDARY_MAX_SIZE,
+        max_cuts=16,
+    ),
+)
 def test_stream_preserves_random_payloads_around_python_read_size_boundary(
     stream_backend: str,
     case: tuple[bytes, tuple[int, ...]],
@@ -159,10 +125,10 @@ def test_stream_preserves_random_payloads_around_python_read_size_boundary(
         Random payload and random chunk partition.
     """
     payload, chunk_sizes = case
-    pipeline, allowlist, expected_hex = _build_property_pipeline(payload, chunk_sizes)
-    result = run_parity_pipeline(pipeline, allowlist)
+    property_case = build_property_pipeline_case(payload, chunk_sizes)
+    result = run_parity_pipeline(property_case.pipeline, property_case.allowlist)
 
     assert result.ok is True
-    assert result.stdout == expected_hex
+    assert result.stdout == property_case.expected_hex
     assert len(result.stages) == 2
     assert all(stage.exit_code == 0 for stage in result.stages)

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1909,7 +1909,9 @@ Both pathways are tested as first-class implementations:
 - all stream-related tests are parametrized to run against both backends;
 - behavioural parity tests verify identical output for edge cases (empty
   streams, partial UTF-8, broken pipes);
-- property-based tests (hypothesis) verify stream content preservation;
+- property-based tests (hypothesis) verify byte-preservation across randomized
+  payloads and randomized chunk boundaries by asserting deterministic hex
+  output through real pipeline execution under both backends;
 - integration tests exercise pathway selection logic, including environment
   overrides, forced fallback when Rust FDs are unavailable, and `ImportError`
   propagation when Rust is explicitly requested but unavailable.

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1909,7 +1909,7 @@ Both pathways are tested as first-class implementations:
 - all stream-related tests are parametrized to run against both backends;
 - behavioural parity tests verify identical output for edge cases (empty
   streams, partial UTF-8, broken pipes);
-- property-based tests (hypothesis) verify byte-preservation across randomized
+- property-based tests (Hypothesis) verify byte-preservation across randomized
   payloads and randomized chunk boundaries by asserting deterministic hex
   output through real pipeline execution under both backends;
 - integration tests exercise pathway selection logic, including environment

--- a/docs/execplans/4-3-4-property-based-tests.md
+++ b/docs/execplans/4-3-4-property-based-tests.md
@@ -45,7 +45,7 @@ Hard invariants that must hold throughout implementation:
   - behavioural tests using `pytest-bdd` in `tests/behaviour/` and
     `tests/features/`.
 - Limit production-code changes unless tests reveal a real bug. This task is
-  expected to be test and documentation heavy.
+  expected to be test- and documentation-heavy.
 - Keep public APIs stable (`cuprum/__init__.py` exports and user-facing
   command/pipeline interfaces unchanged).
 - Do not add runtime dependencies. A dev dependency on `hypothesis` is allowed
@@ -114,7 +114,7 @@ Hard invariants that must hold throughout implementation:
   function-scoped `stream_backend` fixture in property tests. Evidence:
   targeted post-change run failed with `HealthCheck.function_scoped_fixture`.
   Impact: property tests now explicitly suppress that health check in
-  `@settings(...)` because backend parametrisation is intentional for this
+  `@settings(...)` because backend parameterization is intentional for this
   suite.
 
 - Observation: the generated writer script was invalid when the loop was
@@ -144,7 +144,7 @@ Hard invariants that must hold throughout implementation:
   2026-02-23 / Codex.
 
 - Decision: suppress `HealthCheck.function_scoped_fixture` for Hypothesis tests
-  using the `stream_backend` fixture. Rationale: backend parametrisation is
+  using the `stream_backend` fixture. Rationale: backend parameterization is
   required by roadmap scope and stable in this suite; fixtures intentionally do
   not reset between generated examples. Date/Author: 2026-02-23 / Codex.
 
@@ -188,7 +188,8 @@ Lessons learned:
 
 Current relevant state:
 
-- `conftest.py` provides `stream_backend` parametrization and cache clearing for
+- `conftest.py` provides `stream_backend` parameterization and cache clearing
+  for
   backend resolution.
 - `cuprum/unittests/test_stream_parity.py` and
   `tests/behaviour/test_stream_parity_behaviour.py` provide example-based

--- a/docs/execplans/4-3-4-property-based-tests.md
+++ b/docs/execplans/4-3-4-property-based-tests.md
@@ -1,0 +1,318 @@
+# Add hypothesis property-based stream preservation tests (4.3.4)
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+Roadmap reference: `docs/roadmap.md` item `4.3.4`.
+
+`PLANS.md` is not present in this repository, so this plan follows the
+`execplans` skill template and repository instructions in `AGENTS.md`.
+
+## Purpose / big picture
+
+Roadmap item `4.3.4` requires property-based coverage for stream content
+preservation across random payloads and chunk boundaries. The value is stronger
+assurance that both the Python and optional Rust pump pathways preserve byte
+content under many randomly generated input patterns, not only hand-picked
+fixtures.
+
+After this work, maintainers can run tests and observe that:
+
+- Hypothesis-driven unit tests generate random payloads and random chunk
+  boundaries, then verify output preservation through real pipeline execution
+  under both `python` and `rust` backends.
+- Behavioural tests (`pytest-bdd`) demonstrate consumer-visible parity for
+  deterministic random scenarios at chunk-boundary stress points.
+- Documentation explains the property tested, and the roadmap item is marked
+  done only after all quality gates pass.
+
+## Constraints
+
+Hard invariants that must hold throughout implementation:
+
+- Keep pure Python as a first-class pathway. New tests must pass with
+  `CUPRUM_STREAM_BACKEND=python`, and Rust variants must skip cleanly when the
+  extension is unavailable.
+- Follow test-first workflow:
+  - add or modify tests first;
+  - run targeted tests and capture an initial failure;
+  - then implement supporting code changes.
+- Provide both test types:
+  - unit tests using `pytest` in `cuprum/unittests/`;
+  - behavioural tests using `pytest-bdd` in `tests/behaviour/` and
+    `tests/features/`.
+- Limit production-code changes unless tests reveal a real bug. This task is
+  expected to be test and documentation heavy.
+- Keep public APIs stable (`cuprum/__init__.py` exports and user-facing
+  command/pipeline interfaces unchanged).
+- Do not add runtime dependencies. A dev dependency on `hypothesis` is allowed
+  because this roadmap item explicitly requires it.
+- Keep docs in sync:
+  `docs/cuprum-design.md`, `docs/users-guide.md`, and `docs/roadmap.md`.
+- Keep all Python changes compliant with `.rules/python-*.md`, Ruff, and
+  type-checking requirements.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires changes to more than 10 files, stop and
+  escalate.
+- Production code: if more than 2 production Python files need changes, stop
+  and escalate before proceeding.
+- Dependencies: if any dependency beyond `hypothesis` is required, stop and
+  escalate.
+- Interface: if any public API signature must change, stop and escalate.
+- Iterations: if the same failing test needs more than 3 fix attempts, stop
+  and escalate with options.
+- Ambiguity: if chunk-boundary expectations are unclear (byte-preservation vs
+  decoded-text preservation), stop and resolve the expected invariant before
+  continuing.
+
+## Risks
+
+- Risk: Property-based tests can be flaky or slow if strategies are too broad.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: bound payload sizes and hypothesis settings (`max_examples`,
+  health checks, and deadline controls) to keep runtime deterministic.
+
+- Risk: Command-line argument length limits may be exceeded if random payloads
+  are embedded directly in Python `-c` strings.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: encode payloads safely (for example, base64) and cap payload
+  size; where needed, generate large data inside subprocess code.
+
+- Risk: Random chunk boundaries might not actually cross meaningful boundary
+  points when generated naively.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: derive chunk-size partitions from generated cut points so every
+  example intentionally splits payload bytes in varied positions.
+
+## Progress
+
+- [x] (2026-02-23 12:51Z) Drafted ExecPlan for roadmap item `4.3.4`.
+- [ ] Stage A: Confirm exact invariants and test insertion points.
+- [ ] Stage B: Add fail-first unit and behavioural tests.
+- [ ] Stage C: Add minimal implementation/support changes.
+- [ ] Stage D: Update documentation and roadmap item.
+- [ ] Stage E: Run all required quality gates and record evidence.
+
+## Surprises & discoveries
+
+- Observation: `docs/cuprum-design.md` Section 13.9 already states that
+  property-based tests verify stream content preservation, but no Hypothesis
+  tests currently exist in the codebase.
+  Evidence: `rg -n "hypothesis|from hypothesis|strategies as st" .` returns no
+  Hypothesis imports in test modules.
+  Impact: this task closes a design/implementation drift and should update the
+  design doc with concrete test scope and file references.
+
+## Decision log
+
+- Decision: use byte-preservation as the primary invariant for property-based
+  tests, with pipeline output normalised through a deterministic representation
+  (for example, hex output).
+  Rationale: byte-preservation avoids false negatives from text-decoding
+  behaviour and directly validates transport integrity across chunk boundaries.
+  Date/Author: 2026-02-23 / Codex.
+
+- Decision: include a separate deterministic BDD layer in addition to
+  Hypothesis-driven unit tests.
+  Rationale: project policy requires behavioural tests for new functionality,
+  while BDD scenarios should remain stable and readable rather than fully
+  stochastic.
+  Date/Author: 2026-02-23 / Codex.
+
+## Outcomes & retrospective
+
+Pending implementation. This section will be updated with:
+
+- what shipped;
+- exact files changed;
+- quality-gate results;
+- lessons learned from property strategy tuning.
+
+## Context and orientation
+
+Current relevant state:
+
+- `conftest.py` provides `stream_backend` parametrisation and cache clearing for
+  backend resolution.
+- `cuprum/unittests/test_stream_parity.py` and
+  `tests/behaviour/test_stream_parity_behaviour.py` provide example-based parity
+  coverage, not property-based generation.
+- `tests/helpers/parity.py` already contains reusable parity utilities and is
+  the natural place for chunk-partition helpers shared by unit and BDD tests.
+- `pyproject.toml` dev dependencies currently do not include `hypothesis`.
+- `docs/cuprum-design.md` Section 13.9 claims property-based coverage exists.
+- `docs/users-guide.md` documents backend parity but does not describe
+  randomized property-validation scope.
+
+Working definition for this task:
+
+- Stream content preservation means that bytes emitted by an upstream stage are
+  identical to bytes observed downstream, even when writes are split across
+  random chunk boundaries.
+
+## Plan of work
+
+Stage A: confirm test shape and invariants.
+
+Identify exact insertion points and decide final strategy bounds. Keep this
+task bounded to test and docs updates unless failures reveal a genuine stream
+bug. Go/no-go: proceed only once the invariant and file map are explicit.
+
+Stage B: add tests first and confirm fail-first behaviour.
+
+Add a new property-based unit test module, plus BDD scenarios and step
+definitions for deterministic randomised cases. Run targeted tests before any
+supporting implementation updates and record initial failures.
+
+Stage C: add minimal supporting implementation.
+
+Add Hypothesis dev dependency and any helper functions required to construct
+chunk-boundary write plans safely. If property tests expose a production defect,
+apply the smallest possible fix and document why in `Decision Log`.
+
+Stage D: documentation and roadmap updates.
+
+Update design and user documentation with the final property coverage contract,
+then mark roadmap item `4.3.4` as done only after all quality gates pass.
+
+Stage E: full validation.
+
+Run required quality gates and capture log evidence.
+
+## Concrete steps
+
+1. Add test scaffolding first (fail-first workflow).
+
+   Planned files:
+   `cuprum/unittests/test_stream_property_based.py`
+   `tests/features/stream_property_preservation.feature`
+   `tests/behaviour/test_stream_property_preservation_behaviour.py`
+   `tests/helpers/parity.py` (helper additions only)
+
+   Unit scope:
+   - Hypothesis strategies for random payload bytes and random chunk boundaries.
+   - Backend-parametrised pipeline execution via `stream_backend`.
+   - Assertions that downstream-observed bytes match original bytes.
+
+   Behavioural scope:
+   - Deterministic seeded random scenarios that exercise chunk-boundary stress
+     and verify preserved output via user-visible pipeline results.
+
+2. Run targeted tests and capture initial failure.
+
+       set -o pipefail
+       UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run pytest -q \
+         cuprum/unittests/test_stream_property_based.py \
+         tests/behaviour/test_stream_property_preservation_behaviour.py \
+         2>&1 | tee /tmp/4-3-4-targeted-pre.log
+
+   Expected before dependency/support updates:
+
+       ERROR ... ModuleNotFoundError: No module named 'hypothesis'
+
+   If dependency is present already, expected pre-run should still fail because
+   new assertions are intentionally written before helper/implementation updates.
+
+3. Add or update support code with minimal scope.
+
+   Planned files:
+   `pyproject.toml` (dev dependency: `hypothesis`)
+   `uv.lock` (lockfile refresh)
+   `tests/helpers/parity.py` (shared chunk-plan/script helpers)
+
+4. Re-run targeted tests until green.
+
+       set -o pipefail
+       UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run pytest -q \
+         cuprum/unittests/test_stream_property_based.py \
+         tests/behaviour/test_stream_property_preservation_behaviour.py \
+         2>&1 | tee /tmp/4-3-4-targeted-post.log
+
+5. Update documentation and roadmap.
+
+   Planned files:
+   `docs/cuprum-design.md`
+   `docs/users-guide.md`
+   `docs/roadmap.md`
+
+   Documentation updates must include:
+   - design-level rationale for byte-preservation invariant and strategy bounds;
+   - users-guide note describing backend parity assurance from randomized tests;
+   - roadmap item `4.3.4` switched from `[ ]` to `[x]` only after successful
+     full validation.
+
+6. Run full quality gates with log capture.
+
+       set -o pipefail
+       make check-fmt 2>&1 | tee /tmp/4-3-4-check-fmt.log
+       make typecheck 2>&1 | tee /tmp/4-3-4-typecheck.log
+       make lint 2>&1 | tee /tmp/4-3-4-lint.log
+       make test 2>&1 | tee /tmp/4-3-4-test.log
+
+7. Run markdown validation gates for documentation changes.
+
+       set -o pipefail
+       make markdownlint 2>&1 | tee /tmp/4-3-4-markdownlint.log
+       make nixie 2>&1 | tee /tmp/4-3-4-nixie.log
+
+8. Record final evidence and close this ExecPlan.
+
+## Validation and acceptance
+
+Behavioural acceptance:
+
+- Randomized chunk-boundary scenarios in `pytest-bdd` complete successfully
+  under both backends (with Rust cases skipped when unavailable).
+- Property-based unit tests demonstrate content preservation for generated
+  payloads and chunk boundaries without flaky failures.
+
+Quality criteria:
+
+- `make check-fmt` passes.
+- `make typecheck` passes.
+- `make lint` passes.
+- `make test` passes, including new property-based and behavioural tests.
+- `make markdownlint` passes after documentation updates.
+- `make nixie` passes after documentation updates.
+- `docs/roadmap.md` marks `4.3.4` as done only after all checks above pass.
+
+## Idempotence and recovery
+
+- All test commands are safe to rerun.
+- If Hypothesis finds a failing example, preserve the falsifying seed/example in
+  this document and convert it into a stable regression test where appropriate.
+- If runtime is too high, reduce `max_examples` and document the trade-off in
+  `Decision Log`.
+- If command-line size failures occur, shift payload transport to encoded input
+  in subprocess code and rerun targeted tests.
+
+## Artifacts and notes
+
+Expected artefacts:
+
+- Targeted pre-change and post-change logs in `/tmp/4-3-4-targeted-*.log`.
+- Full quality-gate logs in `/tmp/4-3-4-*.log`.
+- Updated docs and roadmap entries tied to roadmap item `4.3.4`.
+
+## Interfaces and dependencies
+
+Existing interfaces to use:
+
+- `cuprum._backend.StreamBackend` and `get_stream_backend()` behaviour via the
+  existing `stream_backend` fixture.
+- Pipeline execution through `sh.make(...)`, pipeline composition (`|`), and
+  `run_sync()` inside scoped allowlists.
+- Shared helpers in `tests/helpers/parity.py`.
+
+Dependency policy for this task:
+
+- Add `hypothesis` as a dev dependency only.
+- No runtime dependency changes.

--- a/docs/execplans/4-3-4-property-based-tests.md
+++ b/docs/execplans/4-3-4-property-based-tests.md
@@ -95,7 +95,7 @@ Hard invariants that must hold throughout implementation:
   and captured expected `ModuleNotFoundError` for Hypothesis.
 - [x] (2026-02-23 16:50Z) Stage C: Added `hypothesis` dev dependency, lockfile
   update via `make build`, and helper support code.
-- [x] (2026-02-23 16:50Z) Stage D: Updated design docs, users guide, and
+- [x] (2026-02-23 16:50Z) Stage D: Updated design docs, user's guide, and
   roadmap entry `4.3.4`.
 - [x] (2026-02-23 16:52Z) Stage E: Full quality gates passed and evidence
   captured in `/tmp/4-3-4-*.log`.
@@ -188,9 +188,8 @@ Lessons learned:
 
 Current relevant state:
 
-- `conftest.py` provides `stream_backend` parameterization and cache clearing
-  for
-  backend resolution.
+- `conftest.py` provides `stream_backend` parameterization
+  and cache clearing for backend resolution.
 - `cuprum/unittests/test_stream_parity.py` and
   `tests/behaviour/test_stream_parity_behaviour.py` provide example-based
   parity coverage, not property-based generation.

--- a/docs/execplans/4-3-4-property-based-tests.md
+++ b/docs/execplans/4-3-4-property-based-tests.md
@@ -114,7 +114,7 @@ Hard invariants that must hold throughout implementation:
 ## Decision log
 
 - Decision: use byte-preservation as the primary invariant for property-based
-  tests, with pipeline output normalised through a deterministic representation
+  tests, with pipeline output normalized through a deterministic representation
   (for example, hex output).
   Rationale: byte-preservation avoids false negatives from text-decoding
   behaviour and directly validates transport integrity across chunk boundaries.
@@ -140,7 +140,7 @@ Pending implementation. This section will be updated with:
 
 Current relevant state:
 
-- `conftest.py` provides `stream_backend` parametrisation and cache clearing for
+- `conftest.py` provides `stream_backend` parametrization and cache clearing for
   backend resolution.
 - `cuprum/unittests/test_stream_parity.py` and
   `tests/behaviour/test_stream_parity_behaviour.py` provide example-based parity
@@ -169,7 +169,7 @@ bug. Go/no-go: proceed only once the invariant and file map are explicit.
 Stage B: add tests first and confirm fail-first behaviour.
 
 Add a new property-based unit test module, plus BDD scenarios and step
-definitions for deterministic randomised cases. Run targeted tests before any
+definitions for deterministic randomized cases. Run targeted tests before any
 supporting implementation updates and record initial failures.
 
 Stage C: add minimal supporting implementation.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -155,7 +155,7 @@ scenarios whilst maintaining pure Python as a first-class pathway.
 - [x] 4.3.3. Create integration tests for pathway selection logic including
   environment variable overrides, forced fallback, and error handling when Rust
   is requested but unavailable.
-- [ ] 4.3.4. Add property-based tests using hypothesis for stream content
+- [x] 4.3.4. Add property-based tests using hypothesis for stream content
   preservation across random payloads and chunk boundaries.
 
 ### 4.4. Benchmarking CI

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -155,7 +155,7 @@ scenarios whilst maintaining pure Python as a first-class pathway.
 - [x] 4.3.3. Create integration tests for pathway selection logic including
   environment variable overrides, forced fallback, and error handling when Rust
   is requested but unavailable.
-- [x] 4.3.4. Add property-based tests using hypothesis for stream content
+- [x] 4.3.4. Add property-based tests using Hypothesis for stream content
   preservation across random payloads and chunk boundaries.
 
 ### 4.4. Benchmarking CI

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -998,9 +998,9 @@ Cuprum cannot extract raw file descriptors from asyncio transports for a
 specific transfer, it falls back to the Python pump for that transfer. This
 fallback is automatic and transparent to callers.
 
-Forced Rust mode is intentionally strict. If
-`CUPRUM_STREAM_BACKEND=rust` is set and the Rust extension is unavailable,
-pipeline execution raises `ImportError` instead of silently falling back.
+Forced Rust mode is intentionally strict. If `CUPRUM_STREAM_BACKEND=rust` is
+set and the Rust extension is unavailable, pipeline execution raises
+`ImportError` instead of silently falling back.
 
 Choose the Rust backend for high-throughput workloads (for example,
 multi-megabyte outputs) where lower per-chunk overhead improves throughput. For
@@ -1015,6 +1015,12 @@ downstream stage exits before the upstream finishes), and backpressure under
 large payloads. The test suite verifies that pipeline output is identical
 regardless of which backend is active, so switching between backends does not
 change observable behaviour.
+
+The stream test suite also includes property-based coverage using Hypothesis.
+These tests generate randomized payload bytes and randomized chunk boundaries,
+run them through real pipelines, and assert byte-preservation by comparing
+deterministic hexadecimal output. This provides broad regression coverage for
+content integrity across both Python and Rust pumping pathways.
 
 ### Linux splice() optimization
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ Repository = "https://github.com/leynos/cuprum"
 
 [dependency-groups]
 dev = [
+    "hypothesis",
     "pytest",
     "pytest-bdd",
     "ruff",

--- a/tests/behaviour/test_stream_property_preservation_behaviour.py
+++ b/tests/behaviour/test_stream_property_preservation_behaviour.py
@@ -98,8 +98,14 @@ def then_hex_matches(
     pipeline_result : PipelineResult
         Actual execution result.
     """
-    assert property_scenario.chunk_count >= 2
-    assert pipeline_result.stdout == property_scenario.expected_hex
+    assert property_scenario.chunk_count >= 2, (
+        "Expected at least 2 chunks in property scenario; "
+        f"got chunk_count={property_scenario.chunk_count}"
+    )
+    assert pipeline_result.stdout == property_scenario.expected_hex, (
+        "Expected pipeline stdout to match hex-encoded source payload; "
+        f"got stdout={pipeline_result.stdout!r}"
+    )
 
 
 @then("the pipeline completes successfully")
@@ -113,6 +119,12 @@ def then_pipeline_succeeds(
     pipeline_result : PipelineResult
         Actual execution result.
     """
-    assert pipeline_result.ok is True
-    assert len(pipeline_result.stages) == 2
-    assert all(stage.exit_code == 0 for stage in pipeline_result.stages)
+    assert pipeline_result.ok is True, "Expected pipeline result to be successful"
+    assert len(pipeline_result.stages) == 2, (
+        "Expected exactly 2 pipeline stages; "
+        f"got stage_count={len(pipeline_result.stages)}"
+    )
+    assert all(stage.exit_code == 0 for stage in pipeline_result.stages), (
+        "Expected all pipeline stages to exit with code 0; "
+        f"got exit_codes={[stage.exit_code for stage in pipeline_result.stages]}"
+    )

--- a/tests/behaviour/test_stream_property_preservation_behaviour.py
+++ b/tests/behaviour/test_stream_property_preservation_behaviour.py
@@ -1,0 +1,158 @@
+"""Behavioural tests for deterministic random stream preservation cases."""
+
+from __future__ import annotations
+
+import dataclasses
+import typing as typ
+
+from pytest_bdd import given, parsers, scenario, then, when
+
+from cuprum import sh
+from tests.helpers.parity import (
+    chunked_writer_script,
+    deterministic_property_case,
+    hex_sink_script,
+    parity_catalogue,
+    payload_to_base64,
+    run_parity_pipeline,
+)
+
+if typ.TYPE_CHECKING:
+    from cuprum.program import Program
+    from cuprum.sh import Pipeline, PipelineResult
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PropertyScenario:
+    """Deterministic stream property test case."""
+
+    pipeline: Pipeline
+    allowlist: frozenset[Program]
+    expected_hex: str
+    chunk_count: int
+
+
+def _build_property_scenario(
+    *,
+    seed: int,
+    size: int,
+) -> PropertyScenario:
+    """Create a deterministic property scenario from a seed and payload size."""
+    payload, chunk_sizes = deterministic_property_case(seed=seed, payload_size=size)
+    catalogue, python_prog, _, _ = parity_catalogue()
+    python_cmd = sh.make(python_prog, catalogue=catalogue)
+
+    chunk_spec = ",".join(str(value) for value in chunk_sizes)
+    pipeline = python_cmd(
+        "-c",
+        chunked_writer_script(),
+        payload_to_base64(payload),
+        chunk_spec,
+    ) | python_cmd("-c", hex_sink_script())
+
+    return PropertyScenario(
+        pipeline=pipeline,
+        allowlist=frozenset([python_prog]),
+        expected_hex=payload.hex(),
+        chunk_count=len(chunk_sizes),
+    )
+
+
+@scenario(
+    "../features/stream_property_preservation.feature",
+    "Deterministic random payload preserves bytes across chunk boundaries",
+)
+def test_stream_property_preservation(stream_backend: str) -> None:
+    """Pipeline preserves deterministic random bytes for each example row.
+
+    Parameters
+    ----------
+    stream_backend : str
+        Active stream backend fixture parameter.
+    """
+
+
+@given(
+    parsers.parse(
+        "a deterministic random payload with seed {seed:d} and size {size:d}",
+    ),
+    target_fixture="property_scenario",
+)
+def given_deterministic_payload(
+    seed: int,
+    size: int,
+) -> PropertyScenario:
+    """Build a deterministic random payload pipeline case.
+
+    Parameters
+    ----------
+    seed : int
+        Random seed used to generate payload and chunk boundaries.
+    size : int
+        Payload size in bytes.
+
+    Returns
+    -------
+    PropertyScenario
+        Pipeline configuration and expected output for assertions.
+    """
+    return _build_property_scenario(seed=seed, size=size)
+
+
+@when(
+    "I run the stream property pipeline synchronously",
+    target_fixture="pipeline_result",
+)
+def when_run_property_pipeline(
+    property_scenario: PropertyScenario,
+) -> PipelineResult:
+    """Execute the deterministic stream property pipeline.
+
+    Parameters
+    ----------
+    property_scenario : PropertyScenario
+        Scenario data created in the Given step.
+
+    Returns
+    -------
+    PipelineResult
+        Synchronous pipeline execution result.
+    """
+    return run_parity_pipeline(
+        property_scenario.pipeline,
+        property_scenario.allowlist,
+    )
+
+
+@then("the stream property output matches the expected hex payload")
+def then_hex_matches(
+    property_scenario: PropertyScenario,
+    pipeline_result: PipelineResult,
+) -> None:
+    """Assert that downstream output preserves the original payload bytes.
+
+    Parameters
+    ----------
+    property_scenario : PropertyScenario
+        Scenario data containing the expected hex payload.
+    pipeline_result : PipelineResult
+        Actual execution result.
+    """
+    assert property_scenario.chunk_count >= 2
+    assert pipeline_result.stdout == property_scenario.expected_hex
+
+
+@then("the pipeline completes successfully")
+def then_pipeline_succeeds(
+    pipeline_result: PipelineResult,
+) -> None:
+    """Assert successful execution for all pipeline stages.
+
+    Parameters
+    ----------
+    pipeline_result : PipelineResult
+        Actual execution result.
+    """
+    assert pipeline_result.ok is True
+    assert len(pipeline_result.stages) == 2
+    assert all(stage.exit_code == 0 for stage in pipeline_result.stages)

--- a/tests/behaviour/test_stream_property_preservation_behaviour.py
+++ b/tests/behaviour/test_stream_property_preservation_behaviour.py
@@ -56,7 +56,12 @@ def given_deterministic_payload(
         Pipeline configuration and expected output for assertions.
     """
     payload, chunk_sizes = deterministic_property_case(seed=seed, payload_size=size)
-    return build_property_pipeline_case(payload, chunk_sizes)
+    property_scenario = build_property_pipeline_case(payload, chunk_sizes)
+    assert property_scenario.chunk_count >= 2, (
+        "Expected at least 2 chunks in property scenario; "
+        f"got chunk_count={property_scenario.chunk_count}"
+    )
+    return property_scenario
 
 
 @when(
@@ -98,10 +103,6 @@ def then_hex_matches(
     pipeline_result : PipelineResult
         Actual execution result.
     """
-    assert property_scenario.chunk_count >= 2, (
-        "Expected at least 2 chunks in property scenario; "
-        f"got chunk_count={property_scenario.chunk_count}"
-    )
     assert pipeline_result.stdout == property_scenario.expected_hex, (
         "Expected pipeline stdout to match hex-encoded source payload; "
         f"got stdout={pipeline_result.stdout!r}"

--- a/tests/features/stream_property_preservation.feature
+++ b/tests/features/stream_property_preservation.feature
@@ -1,0 +1,13 @@
+Feature: Stream property preservation
+  Cuprum preserves stream bytes across random payloads and chunk boundaries.
+
+  Scenario Outline: Deterministic random payload preserves bytes across chunk boundaries
+    Given a deterministic random payload with seed <seed> and size <size>
+    When I run the stream property pipeline synchronously
+    Then the stream property output matches the expected hex payload
+    And the pipeline completes successfully
+
+    Examples:
+      | seed  | size |
+      | 60217 | 257  |
+      | 60218 | 4352 |

--- a/tests/helpers/parity.py
+++ b/tests/helpers/parity.py
@@ -185,7 +185,7 @@ def deterministic_property_case(
     payload = rng.randbytes(payload_size)
 
     if payload_size <= 1 or max_cuts == 0:
-        return payload, (payload_size,) if payload_size == 1 else ()
+        return payload, (payload_size,) if payload_size > 0 else ()
 
     upper_bound = min(max_cuts, payload_size - 1)
     cut_count = rng.randint(1, upper_bound)

--- a/tests/helpers/parity.py
+++ b/tests/helpers/parity.py
@@ -33,7 +33,19 @@ _POOLS = (_ONE_BYTE, _TWO_BYTE, _THREE_BYTE, _FOUR_BYTE)
 
 @dc.dataclass(frozen=True, slots=True)
 class PropertyPipelineCase:
-    """Shared pipeline case for property-preservation tests."""
+    """Shared pipeline case for property-preservation tests.
+
+    Attributes
+    ----------
+    pipeline : Pipeline
+        Two-stage writer-to-hex pipeline used for property assertions.
+    allowlist : frozenset[Program]
+        Program allowlist required for scoped execution.
+    expected_hex : str
+        Expected downstream hexadecimal representation of payload bytes.
+    chunk_count : int
+        Number of configured upstream write chunks.
+    """
 
     pipeline: Pipeline
     allowlist: frozenset[Program]
@@ -181,7 +193,7 @@ def deterministic_property_case(
         msg = f"max_cuts must be non-negative, got {max_cuts}"
         raise ValueError(msg)
 
-    rng = random.Random(seed)  # noqa: S311 — deterministic test data only
+    rng = random.Random(seed)  # noqa: S311  # FIXME: deterministic test-data RNG, not for security use
     payload = rng.randbytes(payload_size)
 
     if payload_size <= 1 or max_cuts == 0:

--- a/tests/helpers/parity.py
+++ b/tests/helpers/parity.py
@@ -1,7 +1,8 @@
-"""Shared helpers for stream parity tests."""
+"""Shared helpers for stream parity and property-based stream tests."""
 
 from __future__ import annotations
 
+import base64
 import random
 import typing as typ
 
@@ -97,3 +98,125 @@ def utf8_stress_payload(n_chars: int = 32768) -> str:
         pool = _POOLS[i % len(_POOLS)]
         chars.append(rng.choice(pool))
     return "".join(chars)
+
+
+def chunk_sizes_from_cut_points(
+    payload_size: int,
+    cut_points: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Convert sorted cut points into sequential chunk sizes.
+
+    Parameters
+    ----------
+    payload_size : int
+        Total payload length in bytes.
+    cut_points : tuple[int, ...]
+        Strictly increasing byte offsets that split the payload.
+
+    Returns
+    -------
+    tuple[int, ...]
+        A tuple of positive chunk sizes that sums to ``payload_size``.
+    """
+    if payload_size < 0:
+        msg = f"payload_size must be non-negative, got {payload_size}"
+        raise ValueError(msg)
+
+    if not cut_points:
+        return (payload_size,) if payload_size > 0 else ()
+
+    previous = 0
+    sizes: list[int] = []
+    for cut in cut_points:
+        if cut <= previous or cut >= payload_size:
+            msg = (
+                "cut points must be strictly increasing and inside the payload, "
+                f"got {cut_points!r} for payload_size={payload_size}"
+            )
+            raise ValueError(msg)
+        sizes.append(cut - previous)
+        previous = cut
+
+    sizes.append(payload_size - previous)
+    return tuple(sizes)
+
+
+def deterministic_property_case(
+    *,
+    seed: int,
+    payload_size: int,
+    max_cuts: int = 8,
+) -> tuple[bytes, tuple[int, ...]]:
+    """Generate a deterministic random payload with chunk sizes.
+
+    Parameters
+    ----------
+    seed : int
+        Random seed for reproducible payload and cut-point generation.
+    payload_size : int
+        Payload length in bytes.
+    max_cuts : int
+        Maximum number of cut points used to split the payload.
+
+    Returns
+    -------
+    tuple[bytes, tuple[int, ...]]
+        The payload bytes and derived chunk sizes.
+    """
+    if payload_size < 0:
+        msg = f"payload_size must be non-negative, got {payload_size}"
+        raise ValueError(msg)
+    if max_cuts < 0:
+        msg = f"max_cuts must be non-negative, got {max_cuts}"
+        raise ValueError(msg)
+
+    rng = random.Random(seed)  # noqa: S311 — deterministic test data only
+    payload = rng.randbytes(payload_size)
+
+    if payload_size <= 1 or max_cuts == 0:
+        return payload, (payload_size,) if payload_size == 1 else ()
+
+    upper_bound = min(max_cuts, payload_size - 1)
+    cut_count = rng.randint(1, upper_bound)
+    cut_points = tuple(sorted(rng.sample(range(1, payload_size), cut_count)))
+    return payload, chunk_sizes_from_cut_points(payload_size, cut_points)
+
+
+def chunked_writer_script() -> str:
+    """Return Python code that writes payload bytes in configured chunks.
+
+    The script expects two argv entries:
+
+    - argv[1]: base64-encoded payload bytes;
+    - argv[2]: comma-separated chunk sizes, or an empty string.
+    """
+    return "\n".join(
+        [
+            "import base64",
+            "import sys",
+            "payload = base64.b64decode(sys.argv[1].encode('ascii'))",
+            "chunk_arg = sys.argv[2]",
+            (
+                "sizes = [int(part) for part in chunk_arg.split(',') if part] "
+                "if chunk_arg else []"
+            ),
+            "offset = 0",
+            "for size in sizes:",
+            "    end = offset + size",
+            "    sys.stdout.buffer.write(payload[offset:end])",
+            "    sys.stdout.buffer.flush()",
+            "    offset = end",
+            "sys.stdout.buffer.write(payload[offset:])",
+            "sys.stdout.buffer.flush()",
+        ],
+    )
+
+
+def payload_to_base64(payload: bytes) -> str:
+    """Encode payload bytes to an ASCII base64 string."""
+    return base64.b64encode(payload).decode("ascii")
+
+
+def hex_sink_script() -> str:
+    """Return Python code that reads stdin bytes and prints lowercase hex."""
+    return "import sys; data = sys.stdin.buffer.read(); sys.stdout.write(data.hex())"

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "maturin" },
     { name = "pyright" },
     { name = "pytest" },
@@ -33,6 +34,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis" },
     { name = "maturin", specifier = "==1.6.0" },
     { name = "pyright" },
     { name = "pytest" },
@@ -60,6 +62,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/d8/7a28537efd7638448f7512a0cce011d4e3bf1c7f4794ad4e9c87b3f1e98e/gherkin_official-29.0.0.tar.gz", hash = "sha256:dbea32561158f02280d7579d179b019160d072ce083197625e2f80a6776bb9eb", size = 32303, upload-time = "2024-08-12T09:41:09.595Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/fc/b86c22ad3b18d8324a9d6fe5a3b55403291d2bf7572ba6a16efa5aa88059/gherkin_official-29.0.0-py3-none-any.whl", hash = "sha256:26967b0d537a302119066742669e0e8b663e632769330be675457ae993e1d1bc", size = 37085, upload-time = "2024-08-12T09:41:07.954Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.151.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/e1/ef365ff480903b929d28e057f57b76cae51a30375943e33374ec9a165d9c/hypothesis-6.151.9.tar.gz", hash = "sha256:2f284428dda6c3c48c580de0e18470ff9c7f5ef628a647ee8002f38c3f9097ca", size = 463534, upload-time = "2026-02-16T22:59:23.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl", hash = "sha256:7b7220585c67759b1b1ef839b1e6e9e3d82ed468cfc1ece43c67184848d7edd9", size = 529307, upload-time = "2026-02-16T22:59:20.443Z" },
 ]
 
 [[package]]
@@ -329,6 +343,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Completed roadmap item 4.3.4: property-based tests for stream preservation using Hypothesis, plus deterministic behavioural tests to demonstrate parity. This work also ships an ExecPlan doc, design/docs updates, and related metadata to reflect completion and ongoing testing strategy.
- The changes introduce new test suites, behavioural tests, BDD scenarios, helper utilities, and documentation updates that establish comprehensive property-based coverage and parity validation for stream preservation.

## Changes
- Adds new unit tests:
  - cuprum/unittests/test_stream_property_based.py
- Adds new behavioural tests:
  - tests/behaviour/test_stream_property_preservation_behaviour.py
- Adds BDD scenarios:
  - tests/features/stream_property_preservation.feature
- Adds ExecPlan documentation:
  - docs/execplans/4-3-4-property-based-tests.md
- Updates design/docs references:
  - docs/cuprum-design.md (clarified approach to property-based tests and parity)
- Updates roadmap and guides:
  - docs/roadmap.md (4.3.4 status updated to reflect completion)
  - docs/users-guide.md (notes on property-based test coverage and backend parity)
- Dependency and tooling updates:
  - pyproject.toml (adds hypothesis as a dev dependency)
  - uv.lock (hypothesis and related dependencies added/updated)
- Enhances shared parity helpers:
  - tests/helpers/parity.py (extensions to support deterministic property cases and chunking utilities)
- Additional supporting artifacts:
  - New deterministic property-based helper logic and codegen for chunked streams (embedded in parity helpers and tests)

## Rationale
- Provides formal, repeatable coverage for stream preservation with randomized inputs and chunking, complementing existing example-based parity tests. The plan includes both property-based unit tests (Python-centric, with optional Rust backend support) and behavioural tests to ensure consumer-visible parity under realistic scenarios. This aligns with roadmap item 4.3.4 and lays groundwork for robust regression testing.

## What to expect in the ExecPlan
- Status: COMPLETE in the new ExecPlan doc, with Stage A–E progression reflected in the updated plan.
- Scope: Property-based coverage across randomized payloads and chunk boundaries; primary Python path with optional Rust fallback.
- Constraints: Python-focused tests as primary path; Hypothesis as dev dependency; no public API changes.
- Risks: Flaky tests, extended run times; mitigations include bounded payloads, max_examples, and deterministic seeds.
- Validation and acceptance criteria: Property-based tests exercise random payloads and boundaries; behavioural tests demonstrate deterministic parity for representative scenarios; all quality gates pass and docs updated.
- Interfaces and dependencies: Reuse existing stream_backend fixtures and parity helpers; Hypothesis as a dev dependency only.

## Validation and acceptance
- Property-based unit tests exercise random payloads and chunk boundaries; Rust paths skipped if unavailable.
- Behavioural tests demonstrate deterministic parity for representative scenarios.
- All quality gates pass (fmt, typecheck, lint, tests) and documentation updates are in place.
- Roadmap item 4.3.4 is updated to reflect completion after all gates pass.

## Notes for reviewers
- This PR ships both the property-based test scaffolding and the accompanying execution plan; follow-up PRs will refine edge cases and supporting code as described in the ExecPlan.
- Hypothesis is added as a dev dependency; a health-check suppression was used for the function-scoped backend fixture during property tests.

## Why this approach
- Establishes a clear, auditable path to property-based testing that complements existing example-based parity tests and aligns with governance for new testing strategies.

📎 **Task**: https://www.devboxer.com/task/126dbce6-624f-4565-aeab-2990ef16a66b