### PR TITLE
4.4.4: Python-vs-Rust benchmark report (Counter) and CI fetch refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,12 +269,38 @@ jobs:
           cp "${artifact_dir}/candidate-plan.json" "${artifact_dir}/main-plan.json"
           cp "${artifact_dir}/candidate-throughput.json" "${artifact_dir}/main-throughput.json"
 
+      - name: Generate benchmark comparison report
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/benchmark-ratchet"
+          UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run python \
+            benchmarks/python_vs_rust_comparison_report.py \
+            --plan "${artifact_dir}/candidate-plan.json" \
+            --throughput "${artifact_dir}/candidate-throughput.json" \
+            --ratchet-report "${artifact_dir}/ratchet-report.json" \
+            --output-json "${artifact_dir}/comparison-report.json" \
+            --output-markdown "${artifact_dir}/comparison-summary.md"
+
+      - name: Publish benchmark workflow summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/benchmark-ratchet"
+          if [[ -f "${artifact_dir}/comparison-summary.md" ]]; then
+            cat "${artifact_dir}/comparison-summary.md" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
       - name: Upload benchmark ratchet artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: benchmark-ratchet
-          path: ${{ runner.temp }}/benchmark-ratchet/**/*.json
+          path: |
+            ${{ runner.temp }}/benchmark-ratchet/**/*.json
+            ${{ runner.temp }}/benchmark-ratchet/**/*.md
 
       - name: Upload main benchmark baseline artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,13 +275,22 @@ jobs:
         run: |
           set -euo pipefail
           artifact_dir="${RUNNER_TEMP}/benchmark-ratchet"
-          UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run python \
-            benchmarks/python_vs_rust_comparison_report.py \
-            --plan "${artifact_dir}/candidate-plan.json" \
-            --throughput "${artifact_dir}/candidate-throughput.json" \
-            --ratchet-report "${artifact_dir}/ratchet-report.json" \
-            --output-json "${artifact_dir}/comparison-report.json" \
-            --output-markdown "${artifact_dir}/comparison-summary.md"
+
+          # Only generate report if all required input files exist
+          if [[ -f "${artifact_dir}/candidate-plan.json" ]] && \
+             [[ -f "${artifact_dir}/candidate-throughput.json" ]] && \
+             [[ -f "${artifact_dir}/ratchet-report.json" ]]; then
+            UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run python \
+              benchmarks/python_vs_rust_comparison_report.py \
+              --plan "${artifact_dir}/candidate-plan.json" \
+              --throughput "${artifact_dir}/candidate-throughput.json" \
+              --ratchet-report "${artifact_dir}/ratchet-report.json" \
+              --output-json "${artifact_dir}/comparison-report.json" \
+              --output-markdown "${artifact_dir}/comparison-summary.md"
+          else
+            echo "Skipping comparison report generation: required input files not found"
+            echo "This usually indicates the benchmark run failed before completing"
+          fi
 
       - name: Publish benchmark workflow summary
         if: always()

--- a/benchmarks/fetch_main_benchmark_baseline.py
+++ b/benchmarks/fetch_main_benchmark_baseline.py
@@ -106,9 +106,10 @@ class _ArtifactArchiveRedirectHandler(urllib.request.HTTPRedirectHandler):
         """Strip sensitive headers when a redirect crosses host boundaries."""
         source_host = urllib.parse.urlsplit(req.full_url).netloc
         destination_host = urllib.parse.urlsplit(redirected_request.full_url).netloc
-        if source_host != destination_host:
-            for header in _GITHUB_REDIRECT_HEADERS_TO_STRIP:
-                redirected_request.remove_header(header)
+        if source_host == destination_host:
+            return
+        for header in _GITHUB_REDIRECT_HEADERS_TO_STRIP:
+            redirected_request.remove_header(header)
 
     def redirect_request(
         self,

--- a/benchmarks/fetch_main_benchmark_baseline.py
+++ b/benchmarks/fetch_main_benchmark_baseline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import dataclasses as dc
-import http.client
 import io
 import json
 import os
@@ -21,6 +20,9 @@ from benchmarks._validation import (
     _require_mapping,
     _require_non_empty_string,
 )
+
+if typ.TYPE_CHECKING:
+    import http.client
 
 GITHUB_API_BASE_URL = "https://api.github.com"
 GITHUB_TOKEN_ENV_VAR = "GITHUB_TOKEN"  # noqa: S105 - env var name, not a credential
@@ -98,6 +100,23 @@ def _with_retry[T](
 class _ArtifactArchiveRedirectHandler(urllib.request.HTTPRedirectHandler):
     """Strip GitHub-only headers when following cross-origin archive redirects."""
 
+    @staticmethod
+    def _is_cross_origin(
+        req: urllib.request.Request,
+        redirected_request: urllib.request.Request,
+    ) -> bool:
+        """Return True when the redirect crosses host boundaries."""
+        return (
+            urllib.parse.urlsplit(req.full_url).netloc
+            != urllib.parse.urlsplit(redirected_request.full_url).netloc
+        )
+
+    @staticmethod
+    def _strip_sensitive_headers(request: urllib.request.Request) -> None:
+        """Remove GitHub-specific authentication headers from *request* in place."""
+        for header in _GITHUB_REDIRECT_HEADERS_TO_STRIP:
+            request.remove_header(header)
+
     def redirect_request(  # noqa: PLR0913, PLR0917
         self,
         req: urllib.request.Request,
@@ -117,12 +136,8 @@ class _ArtifactArchiveRedirectHandler(urllib.request.HTTPRedirectHandler):
         )
         if redirected_request is None:
             return None
-
-        source_host = urllib.parse.urlsplit(req.full_url).netloc
-        destination_host = urllib.parse.urlsplit(redirected_request.full_url).netloc
-        if source_host != destination_host:
-            for header in _GITHUB_REDIRECT_HEADERS_TO_STRIP:
-                redirected_request.remove_header(header)
+        if self._is_cross_origin(req, redirected_request):
+            self._strip_sensitive_headers(redirected_request)
         return redirected_request
 
 

--- a/benchmarks/fetch_main_benchmark_baseline.py
+++ b/benchmarks/fetch_main_benchmark_baseline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses as dc
+import http.client
 import io
 import json
 import os
@@ -20,9 +21,6 @@ from benchmarks._validation import (
     _require_mapping,
     _require_non_empty_string,
 )
-
-if typ.TYPE_CHECKING:
-    import http.client
 
 GITHUB_API_BASE_URL = "https://api.github.com"
 GITHUB_TOKEN_ENV_VAR = "GITHUB_TOKEN"  # noqa: S105 - env var name, not a credential
@@ -100,44 +98,30 @@ def _with_retry[T](
 class _ArtifactArchiveRedirectHandler(urllib.request.HTTPRedirectHandler):
     """Strip GitHub-only headers when following cross-origin archive redirects."""
 
-    @staticmethod
-    def _is_cross_origin(
-        req: urllib.request.Request,
-        redirected_request: urllib.request.Request,
-    ) -> bool:
-        """Return True when the redirect crosses host boundaries."""
-        return (
-            urllib.parse.urlsplit(req.full_url).netloc
-            != urllib.parse.urlsplit(redirected_request.full_url).netloc
-        )
-
-    @staticmethod
-    def _strip_sensitive_headers(request: urllib.request.Request) -> None:
-        """Remove GitHub-specific authentication headers from *request* in place."""
-        for header in _GITHUB_REDIRECT_HEADERS_TO_STRIP:
-            request.remove_header(header)
-
-    def redirect_request(  # noqa: PLR0913, PLR0917
+    def _strip_cross_origin_headers(  # noqa: PLR6301
         self,
         req: urllib.request.Request,
-        fp: typ.IO[bytes],
-        code: int,
-        msg: str,
-        headers: http.client.HTTPMessage,
-        newurl: str,
+        redirected_request: urllib.request.Request,
+    ) -> None:
+        """Strip sensitive headers when a redirect crosses host boundaries."""
+        source_host = urllib.parse.urlsplit(req.full_url).netloc
+        destination_host = urllib.parse.urlsplit(redirected_request.full_url).netloc
+        if source_host != destination_host:
+            for header in _GITHUB_REDIRECT_HEADERS_TO_STRIP:
+                redirected_request.remove_header(header)
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        *args: object,
+        **kwargs: object,
     ) -> urllib.request.Request | None:
-        redirected_request = super().redirect_request(
-            req=req,
-            fp=fp,
-            code=code,
-            msg=msg,
-            headers=headers,
-            newurl=newurl,
-        )
+        _ = isinstance(kwargs.get("headers"), http.client.HTTPMessage)
+        redirect_handler = typ.cast("typ.Any", super())
+        redirected_request = redirect_handler.redirect_request(req, *args, **kwargs)
         if redirected_request is None:
             return None
-        if self._is_cross_origin(req, redirected_request):
-            self._strip_sensitive_headers(redirected_request)
+        self._strip_cross_origin_headers(req, redirected_request)
         return redirected_request
 
 

--- a/benchmarks/fetch_main_benchmark_baseline.py
+++ b/benchmarks/fetch_main_benchmark_baseline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses as dc
+import http.client
 import io
 import json
 import os
@@ -29,6 +30,10 @@ _RETRY_DELAYS_SECONDS = (0.5, 1.0)
 _HTTP_TOO_MANY_REQUESTS = 429
 _HTTP_SERVER_ERROR_MIN = 500
 _HTTP_SERVER_ERROR_MAX = 600
+_GITHUB_REDIRECT_HEADERS_TO_STRIP = (
+    "Authorization",
+    "X-GitHub-Api-Version",
+)
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -90,6 +95,37 @@ def _with_retry[T](
     raise last_exc
 
 
+class _ArtifactArchiveRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Strip GitHub-only headers when following cross-origin archive redirects."""
+
+    def redirect_request(  # noqa: PLR0913, PLR0917
+        self,
+        req: urllib.request.Request,
+        fp: typ.IO[bytes],
+        code: int,
+        msg: str,
+        headers: http.client.HTTPMessage,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        redirected_request = super().redirect_request(
+            req=req,
+            fp=fp,
+            code=code,
+            msg=msg,
+            headers=headers,
+            newurl=newurl,
+        )
+        if redirected_request is None:
+            return None
+
+        source_host = urllib.parse.urlsplit(req.full_url).netloc
+        destination_host = urllib.parse.urlsplit(redirected_request.full_url).netloc
+        if source_host != destination_host:
+            for header in _GITHUB_REDIRECT_HEADERS_TO_STRIP:
+                redirected_request.remove_header(header)
+        return redirected_request
+
+
 def _load_json_response(*, url: str, token: str) -> typ.Mapping[str, object]:
     """Load a GitHub API JSON response."""
     request = urllib.request.Request(  # noqa: S310 - URL is selected by trusted caller
@@ -124,9 +160,10 @@ def _download_bytes(*, url: str, token: str) -> bytes:
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
+    opener = urllib.request.build_opener(_ArtifactArchiveRedirectHandler())
 
     def _open_archive() -> bytes:
-        with urllib.request.urlopen(  # noqa: S310 - authenticated GitHub artifact download
+        with opener.open(
             request,
             timeout=_REQUEST_TIMEOUT_SECONDS,
         ) as response:

--- a/benchmarks/fetch_main_benchmark_baseline.py
+++ b/benchmarks/fetch_main_benchmark_baseline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import dataclasses as dc
-import http.client
 import io
 import json
 import os
@@ -117,9 +116,7 @@ class _ArtifactArchiveRedirectHandler(urllib.request.HTTPRedirectHandler):
         *args: object,
         **kwargs: object,
     ) -> urllib.request.Request | None:
-        _ = isinstance(kwargs.get("headers"), http.client.HTTPMessage)
-        redirect_handler = typ.cast("typ.Any", super())
-        redirected_request = redirect_handler.redirect_request(req, *args, **kwargs)
+        redirected_request = super().redirect_request(req, *args, **kwargs)  # type: ignore[arg-type]
         if redirected_request is None:
             return None
         self._strip_cross_origin_headers(req, redirected_request)

--- a/benchmarks/fetch_main_benchmark_baseline.py
+++ b/benchmarks/fetch_main_benchmark_baseline.py
@@ -31,7 +31,7 @@ _HTTP_SERVER_ERROR_MIN = 500
 _HTTP_SERVER_ERROR_MAX = 600
 _GITHUB_REDIRECT_HEADERS_TO_STRIP = (
     "Authorization",
-    "X-GitHub-Api-Version",
+    "X-github-api-version",
 )
 
 
@@ -103,9 +103,11 @@ class _ArtifactArchiveRedirectHandler(urllib.request.HTTPRedirectHandler):
         redirected_request: urllib.request.Request,
     ) -> None:
         """Strip sensitive headers when a redirect crosses host boundaries."""
-        source_host = urllib.parse.urlsplit(req.full_url).netloc
-        destination_host = urllib.parse.urlsplit(redirected_request.full_url).netloc
-        if source_host == destination_host:
+        source_parts = urllib.parse.urlsplit(req.full_url)
+        destination_parts = urllib.parse.urlsplit(redirected_request.full_url)
+        source_origin = (source_parts.scheme, source_parts.netloc)
+        destination_origin = (destination_parts.scheme, destination_parts.netloc)
+        if source_origin == destination_origin:
             return
         for header in _GITHUB_REDIRECT_HEADERS_TO_STRIP:
             redirected_request.remove_header(header)

--- a/benchmarks/python_vs_rust_comparison_report.py
+++ b/benchmarks/python_vs_rust_comparison_report.py
@@ -1,0 +1,392 @@
+"""Generate a Python-versus-Rust benchmark comparison report.
+
+This module reads the filtered candidate benchmark plan plus throughput JSON
+produced by the benchmark-ratchet workflow, pairs Python and Rust results for
+the same scenario label, writes a structured JSON report, and renders Markdown
+summary content suitable for ``$GITHUB_STEP_SUMMARY``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses as dc
+import json
+import pathlib as pth
+import sys
+
+from benchmarks._validation import (
+    _require_list,
+    _require_mapping,
+    _require_non_empty_string,
+)
+from benchmarks.ratchet_rust_performance import (
+    _require_positive_float,
+    load_plan,
+    load_throughput,
+)
+
+_FLOAT_TOLERANCE = 1e-12
+_BOOTSTRAP_SKIP_REASON = "no_previous_main_benchmark_baseline"
+
+
+@dc.dataclass(frozen=True, slots=True)
+class BenchmarkComparisonRow:
+    """One matched Python-versus-Rust benchmark comparison row."""
+
+    comparison_id: str
+    python_scenario_name: str
+    rust_scenario_name: str
+    python_mean: float
+    rust_mean: float
+    speedup_ratio: float
+    faster_backend: str
+
+    def as_dict(self) -> dict[str, object]:
+        """Serialize the row for JSON output."""
+        return {
+            "comparison_id": self.comparison_id,
+            "python_scenario_name": self.python_scenario_name,
+            "rust_scenario_name": self.rust_scenario_name,
+            "python_mean": self.python_mean,
+            "rust_mean": self.rust_mean,
+            "speedup_ratio": self.speedup_ratio,
+            "faster_backend": self.faster_backend,
+        }
+
+
+@dc.dataclass(frozen=True, slots=True)
+class BenchmarkComparisonSummary:
+    """Aggregate counts for the comparison report."""
+
+    row_count: int
+    rust_wins: int
+    python_wins: int
+    ties: int
+
+    def as_dict(self) -> dict[str, object]:
+        """Serialize the summary for JSON output."""
+        return {
+            "row_count": self.row_count,
+            "rust_wins": self.rust_wins,
+            "python_wins": self.python_wins,
+            "ties": self.ties,
+        }
+
+
+@dc.dataclass(frozen=True, slots=True)
+class BenchmarkComparisonReport:
+    """Structured comparison report for candidate benchmark results."""
+
+    rows: tuple[BenchmarkComparisonRow, ...]
+    summary: BenchmarkComparisonSummary
+
+    def as_dict(self) -> dict[str, object]:
+        """Serialize the report for JSON output."""
+        return {
+            "rows": [row.as_dict() for row in self.rows],
+            "summary": self.summary.as_dict(),
+        }
+
+
+@dc.dataclass(frozen=True, slots=True)
+class RatchetStatus:
+    """Workflow-friendly summary of the Rust regression ratchet state."""
+
+    status: str
+    detail: str
+
+    def as_dict(self) -> dict[str, str]:
+        """Serialize the ratchet status for JSON output."""
+        return {
+            "status": self.status,
+            "detail": self.detail,
+        }
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _ScenarioEntry:
+    """Validated scenario result entry used for pairing backends."""
+
+    scenario_name: str
+    mean: float
+
+
+def _validate_backend(backend: str, *, index: int) -> None:
+    """Validate that *backend* is one of the supported benchmark backends."""
+    if backend not in {"python", "rust"}:
+        msg = (
+            f"scenarios[{index}].backend must be either 'python' or 'rust', "
+            f"got {backend!r}"
+        )
+        raise ValueError(msg)
+
+
+def _comparison_id_for_scenario(*, scenario_name: str, backend: str) -> str:
+    """Return the backend-independent comparison identifier for one scenario."""
+    prefix = f"{backend}-"
+    if not scenario_name.startswith(prefix):
+        msg = (
+            f"scenario name {scenario_name!r} must start with expected backend "
+            f"prefix {prefix!r}"
+        )
+        raise ValueError(msg)
+    comparison_id = scenario_name.removeprefix(prefix)
+    if not comparison_id:
+        msg = f"scenario name {scenario_name!r} must include a comparison label"
+        raise ValueError(msg)
+    return comparison_id
+
+
+def _build_row(
+    *,
+    comparison_id: str,
+    python_entry: _ScenarioEntry,
+    rust_entry: _ScenarioEntry,
+) -> BenchmarkComparisonRow:
+    """Build one comparison row from paired Python and Rust entries."""
+    speedup_ratio = python_entry.mean / rust_entry.mean
+    if abs(python_entry.mean - rust_entry.mean) <= _FLOAT_TOLERANCE:
+        faster_backend = "tie"
+    elif rust_entry.mean < python_entry.mean:
+        faster_backend = "rust"
+    else:
+        faster_backend = "python"
+    return BenchmarkComparisonRow(
+        comparison_id=comparison_id,
+        python_scenario_name=python_entry.scenario_name,
+        rust_scenario_name=rust_entry.scenario_name,
+        python_mean=python_entry.mean,
+        rust_mean=rust_entry.mean,
+        speedup_ratio=speedup_ratio,
+        faster_backend=faster_backend,
+    )
+
+
+def _extract_candidate_entry(
+    *,
+    index: int,
+    scenario_value: object,
+    result_value: object,
+) -> tuple[str, str, _ScenarioEntry]:
+    """Extract one validated backend entry for candidate comparison."""
+    scenario = _require_mapping(scenario_value, name=f"scenarios[{index}]")
+    result = _require_mapping(result_value, name=f"results[{index}]")
+    backend = _require_non_empty_string(
+        scenario.get("backend"), name=f"scenarios[{index}].backend"
+    )
+    _validate_backend(backend, index=index)
+    scenario_name = _require_non_empty_string(
+        scenario.get("name"), name=f"scenarios[{index}].name"
+    )
+    comparison_id = _comparison_id_for_scenario(
+        scenario_name=scenario_name,
+        backend=backend,
+    )
+    mean = _require_positive_float(result.get("mean"), name=f"results[{index}].mean")
+    return (
+        comparison_id,
+        backend,
+        _ScenarioEntry(scenario_name=scenario_name, mean=mean),
+    )
+
+
+def _build_report_from_grouped_entries(
+    grouped: dict[str, dict[str, _ScenarioEntry]],
+) -> BenchmarkComparisonReport:
+    """Build the final report from grouped backend entries."""
+    rows: list[BenchmarkComparisonRow] = []
+    rust_wins = 0
+    python_wins = 0
+    ties = 0
+    for comparison_id in sorted(grouped):
+        entries = grouped[comparison_id]
+        python_entry = entries.get("python")
+        if python_entry is None:
+            msg = f"comparison group {comparison_id!r} is missing Python scenario"
+            raise ValueError(msg)
+        rust_entry = entries.get("rust")
+        if rust_entry is None:
+            msg = f"comparison group {comparison_id!r} is missing Rust scenario"
+            raise ValueError(msg)
+        row = _build_row(
+            comparison_id=comparison_id,
+            python_entry=python_entry,
+            rust_entry=rust_entry,
+        )
+        rows.append(row)
+        if row.faster_backend == "rust":
+            rust_wins += 1
+        elif row.faster_backend == "python":
+            python_wins += 1
+        else:
+            ties += 1
+
+    return BenchmarkComparisonReport(
+        rows=tuple(rows),
+        summary=BenchmarkComparisonSummary(
+            row_count=len(rows),
+            rust_wins=rust_wins,
+            python_wins=python_wins,
+            ties=ties,
+        ),
+    )
+
+
+def compare_candidate_backend_results(
+    *,
+    plan_payload: dict[str, object],
+    throughput_payload: dict[str, object],
+) -> BenchmarkComparisonReport:
+    """Compare matched Python and Rust candidate benchmark results."""
+    scenarios = _require_list(plan_payload.get("scenarios"), name="scenarios")
+    results = _require_list(throughput_payload.get("results"), name="results")
+    if len(scenarios) != len(results):
+        msg = (
+            f"plan scenario count ({len(scenarios)}) must match throughput "
+            f"result count ({len(results)})"
+        )
+        raise ValueError(msg)
+
+    grouped: dict[str, dict[str, _ScenarioEntry]] = {}
+    for index, (scenario_value, result_value) in enumerate(
+        zip(scenarios, results, strict=True)
+    ):
+        comparison_id, backend, entry = _extract_candidate_entry(
+            index=index,
+            scenario_value=scenario_value,
+            result_value=result_value,
+        )
+        group = grouped.setdefault(comparison_id, {})
+        if backend in group:
+            msg = (
+                f"comparison group {comparison_id!r} contains duplicate "
+                f"{backend!r} scenario entries"
+            )
+            raise ValueError(msg)
+        group[backend] = entry
+
+    return _build_report_from_grouped_entries(grouped)
+
+
+def load_ratchet_report(path: pth.Path) -> RatchetStatus:
+    """Load the Rust regression ratchet report and summarize its status."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    report = _require_mapping(payload, name=f"ratchet report from {path}")
+
+    comparison_performed = report.get("comparison_performed")
+    baseline_available = report.get("baseline_available")
+    if comparison_performed is False or baseline_available is False:
+        reason = report.get("reason")
+        if reason == _BOOTSTRAP_SKIP_REASON:
+            detail = (
+                "Rust regression ratchet skipped: no previous successful main "
+                "baseline artefact."
+            )
+        else:
+            detail = "Rust regression ratchet skipped."
+        return RatchetStatus(status="skipped", detail=detail)
+
+    passed_value = report.get("passed")
+    if not isinstance(passed_value, bool):
+        msg = "ratchet report must include a boolean passed field"
+        raise TypeError(msg)
+    if passed_value:
+        return RatchetStatus(status="passed", detail="Rust regression ratchet passed.")
+    return RatchetStatus(status="failed", detail="Rust regression ratchet failed.")
+
+
+def render_summary_markdown(
+    *,
+    report: BenchmarkComparisonReport,
+    ratchet_status: RatchetStatus,
+) -> str:
+    """Render workflow-summary Markdown for the comparison report."""
+    lines = [
+        "## Python vs Rust benchmark comparison",
+        "",
+        "Candidate smoke benchmark results for the current workflow run.",
+        "",
+        ratchet_status.detail,
+        "",
+        "| Scenario | Python mean (s) | Rust mean (s) | Speedup | Faster backend |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ]
+    lines.extend(
+        (
+            f"| `{row.comparison_id}` | {row.python_mean:.6f} | "
+            f"{row.rust_mean:.6f} | {row.speedup_ratio:.2f}x | "
+            f"{row.faster_backend} |"
+        )
+        for row in report.rows
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_report_json(
+    *,
+    report: BenchmarkComparisonReport,
+    ratchet_status: RatchetStatus,
+    output_path: pth.Path,
+) -> None:
+    """Write the structured JSON comparison report."""
+    payload = report.as_dict()
+    payload["ratchet_status"] = ratchet_status.as_dict()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def write_summary_markdown(*, markdown: str, output_path: pth.Path) -> None:
+    """Write the Markdown summary file."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the comparison-report CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", type=pth.Path, required=True)
+    parser.add_argument("--throughput", type=pth.Path, required=True)
+    parser.add_argument("--ratchet-report", type=pth.Path, required=True)
+    parser.add_argument("--output-json", type=pth.Path, required=True)
+    parser.add_argument("--output-markdown", type=pth.Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Generate the benchmark comparison report and workflow summary markdown."""
+    args = _parse_args(argv)
+    try:
+        report = compare_candidate_backend_results(
+            plan_payload=load_plan(args.plan),
+            throughput_payload=load_throughput(args.throughput),
+        )
+        ratchet_status = load_ratchet_report(args.ratchet_report)
+        markdown = render_summary_markdown(
+            report=report,
+            ratchet_status=ratchet_status,
+        )
+        write_report_json(
+            report=report,
+            ratchet_status=ratchet_status,
+            output_path=args.output_json,
+        )
+        write_summary_markdown(markdown=markdown, output_path=args.output_markdown)
+    except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+        print(
+            f"benchmark comparison report failed to evaluate inputs: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        "benchmark comparison report generated: "
+        f"{report.summary.row_count} paired scenario rows",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/python_vs_rust_comparison_report.py
+++ b/benchmarks/python_vs_rust_comparison_report.py
@@ -13,6 +13,7 @@ import dataclasses as dc
 import json
 import pathlib as pth
 import sys
+import typing as typ
 from collections import Counter
 
 from benchmarks._validation import (
@@ -231,7 +232,7 @@ def _build_report_from_grouped_entries(
             row_count=len(rows),
             rust_wins=tally["rust"],
             python_wins=tally["python"],
-            ties=len(rows) - tally["rust"] - tally["python"],
+            ties=tally["tie"],
         ),
     )
 
@@ -272,38 +273,34 @@ def compare_candidate_backend_results(
     return _build_report_from_grouped_entries(grouped)
 
 
-def load_ratchet_report(path: pth.Path) -> RatchetStatus:
-    """Load the Rust regression ratchet report and summarize its status."""
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    report = _require_mapping(payload, name=f"ratchet report from {path}")
+def _require_optional_bool(
+    report: typ.Mapping[str, object],
+    field: str,
+    path: pth.Path,
+) -> bool | None:
+    """Return the boolean value of *field* from *report*, or None if absent.
 
-    comparison_performed = report.get("comparison_performed")
-    if comparison_performed is not None and not isinstance(comparison_performed, bool):
-        msg = (
-            f"ratchet report from {path} has non-boolean 'comparison_performed' "
-            f"field: {comparison_performed!r}"
-        )
+    Raise TypeError if the field is present but not a boolean.
+    """
+    value = report.get(field)
+    if value is not None and not isinstance(value, bool):
+        msg = f"ratchet report from {path} has non-boolean {field!r} field: {value!r}"
         raise TypeError(msg)
+    return value  # narrowed to bool | None
 
-    baseline_available = report.get("baseline_available")
-    if baseline_available is not None and not isinstance(baseline_available, bool):
-        msg = (
-            f"ratchet report from {path} has non-boolean 'baseline_available' "
-            f"field: {baseline_available!r}"
+
+def _ratchet_skip_detail(report: typ.Mapping[str, object]) -> str:
+    """Return the human-readable skip-reason string for a skipped ratchet run."""
+    if report.get("reason") == _BOOTSTRAP_SKIP_REASON:
+        return (
+            "Rust regression ratchet skipped: no previous successful main "
+            "baseline artefact."
         )
-        raise TypeError(msg)
+    return "Rust regression ratchet skipped."
 
-    if comparison_performed is False or baseline_available is False:
-        reason = report.get("reason")
-        if reason == _BOOTSTRAP_SKIP_REASON:
-            detail = (
-                "Rust regression ratchet skipped: no previous successful main "
-                "baseline artefact."
-            )
-        else:
-            detail = "Rust regression ratchet skipped."
-        return RatchetStatus(status="skipped", detail=detail)
 
+def _ratchet_passed_status(report: typ.Mapping[str, object]) -> RatchetStatus:
+    """Return a passed or failed RatchetStatus based on the *passed* field."""
     passed_value = report.get("passed")
     if not isinstance(passed_value, bool):
         msg = "ratchet report must include a boolean passed field"
@@ -311,6 +308,20 @@ def load_ratchet_report(path: pth.Path) -> RatchetStatus:
     if passed_value:
         return RatchetStatus(status="passed", detail="Rust regression ratchet passed.")
     return RatchetStatus(status="failed", detail="Rust regression ratchet failed.")
+
+
+def load_ratchet_report(path: pth.Path) -> RatchetStatus:
+    """Load the Rust regression ratchet report and summarize its status."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    report = _require_mapping(payload, name=f"ratchet report from {path}")
+
+    comparison_performed = _require_optional_bool(report, "comparison_performed", path)
+    baseline_available = _require_optional_bool(report, "baseline_available", path)
+
+    if comparison_performed is False or baseline_available is False:
+        return RatchetStatus(status="skipped", detail=_ratchet_skip_detail(report))
+
+    return _ratchet_passed_status(report)
 
 
 def render_summary_markdown(

--- a/benchmarks/python_vs_rust_comparison_report.py
+++ b/benchmarks/python_vs_rust_comparison_report.py
@@ -13,6 +13,7 @@ import dataclasses as dc
 import json
 import pathlib as pth
 import sys
+from collections import Counter
 
 from benchmarks._validation import (
     _require_list,
@@ -190,44 +191,47 @@ def _extract_candidate_entry(
     )
 
 
+def _get_required_entries(
+    comparison_id: str,
+    entries: dict[str, _ScenarioEntry],
+) -> tuple[_ScenarioEntry, _ScenarioEntry]:
+    """Return (python_entry, rust_entry) or raise ValueError if either is absent."""
+    python_entry = entries.get("python")
+    if python_entry is None:
+        msg = f"comparison group {comparison_id!r} is missing Python scenario"
+        raise ValueError(msg)
+    rust_entry = entries.get("rust")
+    if rust_entry is None:
+        msg = f"comparison group {comparison_id!r} is missing Rust scenario"
+        raise ValueError(msg)
+    return python_entry, rust_entry
+
+
 def _build_report_from_grouped_entries(
     grouped: dict[str, dict[str, _ScenarioEntry]],
 ) -> BenchmarkComparisonReport:
     """Build the final report from grouped backend entries."""
     rows: list[BenchmarkComparisonRow] = []
-    rust_wins = 0
-    python_wins = 0
-    ties = 0
+    tally: Counter[str] = Counter()
     for comparison_id in sorted(grouped):
-        entries = grouped[comparison_id]
-        python_entry = entries.get("python")
-        if python_entry is None:
-            msg = f"comparison group {comparison_id!r} is missing Python scenario"
-            raise ValueError(msg)
-        rust_entry = entries.get("rust")
-        if rust_entry is None:
-            msg = f"comparison group {comparison_id!r} is missing Rust scenario"
-            raise ValueError(msg)
+        python_entry, rust_entry = _get_required_entries(
+            comparison_id, grouped[comparison_id]
+        )
         row = _build_row(
             comparison_id=comparison_id,
             python_entry=python_entry,
             rust_entry=rust_entry,
         )
         rows.append(row)
-        if row.faster_backend == "rust":
-            rust_wins += 1
-        elif row.faster_backend == "python":
-            python_wins += 1
-        else:
-            ties += 1
+        tally[row.faster_backend] += 1
 
     return BenchmarkComparisonReport(
         rows=tuple(rows),
         summary=BenchmarkComparisonSummary(
             row_count=len(rows),
-            rust_wins=rust_wins,
-            python_wins=python_wins,
-            ties=ties,
+            rust_wins=tally["rust"],
+            python_wins=tally["python"],
+            ties=len(rows) - tally["rust"] - tally["python"],
         ),
     )
 

--- a/benchmarks/python_vs_rust_comparison_report.py
+++ b/benchmarks/python_vs_rust_comparison_report.py
@@ -278,7 +278,21 @@ def load_ratchet_report(path: pth.Path) -> RatchetStatus:
     report = _require_mapping(payload, name=f"ratchet report from {path}")
 
     comparison_performed = report.get("comparison_performed")
+    if comparison_performed is not None and not isinstance(comparison_performed, bool):
+        msg = (
+            f"ratchet report from {path} has non-boolean 'comparison_performed' "
+            f"field: {comparison_performed!r}"
+        )
+        raise TypeError(msg)
+
     baseline_available = report.get("baseline_available")
+    if baseline_available is not None and not isinstance(baseline_available, bool):
+        msg = (
+            f"ratchet report from {path} has non-boolean 'baseline_available' "
+            f"field: {baseline_available!r}"
+        )
+        raise TypeError(msg)
+
     if comparison_performed is False or baseline_available is False:
         reason = report.get("reason")
         if reason == _BOOTSTRAP_SKIP_REASON:

--- a/cuprum/unittests/test_benchmark_comparison_report.py
+++ b/cuprum/unittests/test_benchmark_comparison_report.py
@@ -1,0 +1,206 @@
+"""Unit tests for Python-versus-Rust benchmark comparison reporting."""
+
+from __future__ import annotations
+
+import json
+import typing as typ
+
+import pytest
+
+from benchmarks.python_vs_rust_comparison_report import (
+    BenchmarkComparisonRow,
+    RatchetStatus,
+    compare_candidate_backend_results,
+    load_ratchet_report,
+    render_summary_markdown,
+)
+
+if typ.TYPE_CHECKING:
+    import pathlib as pth
+
+
+def _scenario_payload(
+    *,
+    name: str,
+    backend: str,
+    payload_bytes: int = 1024,
+    stages: int = 2,
+    with_line_callbacks: bool = False,
+) -> dict[str, object]:
+    """Return a benchmark scenario payload."""
+    return {
+        "name": name,
+        "backend": backend,
+        "payload_bytes": payload_bytes,
+        "stages": stages,
+        "with_line_callbacks": with_line_callbacks,
+    }
+
+
+def _candidate_plan_payload() -> dict[str, object]:
+    """Return a filtered candidate plan payload with paired backends."""
+    return {
+        "dry_run": True,
+        "rust_available": True,
+        "command": ["hyperfine", "placeholder"],
+        "scenarios": [
+            _scenario_payload(name="python-small-single-nocb", backend="python"),
+            _scenario_payload(name="rust-small-single-nocb", backend="rust"),
+            _scenario_payload(
+                name="python-small-single-cb",
+                backend="python",
+                with_line_callbacks=True,
+            ),
+            _scenario_payload(
+                name="rust-small-single-cb",
+                backend="rust",
+                with_line_callbacks=True,
+            ),
+        ],
+    }
+
+
+def _candidate_throughput_payload() -> dict[str, object]:
+    """Return candidate throughput results aligned with the plan payload."""
+    return {
+        "results": [
+            {"command": "python-small-single-nocb", "mean": 0.42},
+            {"command": "rust-small-single-nocb", "mean": 0.21},
+            {"command": "python-small-single-cb", "mean": 0.66},
+            {"command": "rust-small-single-cb", "mean": 0.33},
+        ],
+    }
+
+
+def _write_json(
+    *,
+    tmp_path: pth.Path,
+    filename: str,
+    payload: dict[str, object],
+) -> pth.Path:
+    """Write one JSON fixture to a temp file."""
+    path = tmp_path / filename
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_compare_candidate_backend_results_builds_sorted_rows() -> None:
+    """Matched Python and Rust rows should produce deterministic comparisons."""
+    report = compare_candidate_backend_results(
+        plan_payload=_candidate_plan_payload(),
+        throughput_payload=_candidate_throughput_payload(),
+    )
+
+    assert [row.comparison_id for row in report.rows] == [
+        "small-single-cb",
+        "small-single-nocb",
+    ]
+    assert report.summary.row_count == 2
+    assert report.summary.rust_wins == 2
+    assert report.summary.python_wins == 0
+    assert report.summary.ties == 0
+
+    first_row = report.rows[0]
+    assert first_row == BenchmarkComparisonRow(
+        comparison_id="small-single-cb",
+        python_scenario_name="python-small-single-cb",
+        rust_scenario_name="rust-small-single-cb",
+        python_mean=0.66,
+        rust_mean=0.33,
+        speedup_ratio=2.0,
+        faster_backend="rust",
+    )
+
+
+def test_compare_candidate_backend_results_rejects_missing_rust_pair() -> None:
+    """Every comparison group must include both Python and Rust scenarios."""
+    plan_payload = _candidate_plan_payload()
+    scenarios = typ.cast("list[object]", plan_payload["scenarios"])
+    plan_payload["scenarios"] = [scenarios[0]]
+    throughput_results = typ.cast(
+        "list[object]",
+        _candidate_throughput_payload()["results"],
+    )
+    throughput_payload = {
+        "results": [throughput_results[0]],
+    }
+
+    with pytest.raises(ValueError, match="missing Rust scenario"):
+        compare_candidate_backend_results(
+            plan_payload=plan_payload,
+            throughput_payload=throughput_payload,
+        )
+
+
+@pytest.mark.parametrize(
+    ("ratchet_payload", "expected_status", "expected_fragment"),
+    [
+        (
+            {"passed": True, "comparison_performed": True, "baseline_available": True},
+            RatchetStatus(status="passed", detail="Rust regression ratchet passed."),
+            "Rust regression ratchet passed.",
+        ),
+        (
+            {"passed": False, "comparison_performed": True, "baseline_available": True},
+            RatchetStatus(status="failed", detail="Rust regression ratchet failed."),
+            "Rust regression ratchet failed.",
+        ),
+        (
+            {
+                "passed": True,
+                "comparison_performed": False,
+                "baseline_available": False,
+                "reason": "no_previous_main_benchmark_baseline",
+            },
+            RatchetStatus(
+                status="skipped",
+                detail=(
+                    "Rust regression ratchet skipped: no previous successful "
+                    "main baseline artefact."
+                ),
+            ),
+            "Rust regression ratchet skipped",
+        ),
+    ],
+)
+def test_load_ratchet_report_interprets_known_statuses(
+    tmp_path: pth.Path,
+    ratchet_payload: dict[str, object],
+    expected_status: RatchetStatus,
+    expected_fragment: str,
+) -> None:
+    """Ratchet report metadata should be mapped into a summary status."""
+    path = _write_json(
+        tmp_path=tmp_path,
+        filename="ratchet-report.json",
+        payload=ratchet_payload,
+    )
+
+    status = load_ratchet_report(path)
+
+    assert status == expected_status
+    assert expected_fragment in status.detail
+
+
+def test_render_summary_markdown_includes_table_and_ratchet_status() -> None:
+    """Rendered markdown should be suitable for the workflow summary."""
+    report = compare_candidate_backend_results(
+        plan_payload=_candidate_plan_payload(),
+        throughput_payload=_candidate_throughput_payload(),
+    )
+
+    markdown = render_summary_markdown(
+        report=report,
+        ratchet_status=RatchetStatus(
+            status="passed",
+            detail="Rust regression ratchet passed.",
+        ),
+    )
+
+    assert "## Python vs Rust benchmark comparison" in markdown
+    assert "Rust regression ratchet passed." in markdown
+    assert (
+        "| Scenario | Python mean (s) | Rust mean (s) | Speedup | Faster backend |"
+        in markdown
+    )
+    assert "| `small-single-nocb` | 0.420000 | 0.210000 | 2.00x | rust |" in markdown

--- a/cuprum/unittests/test_benchmark_comparison_report.py
+++ b/cuprum/unittests/test_benchmark_comparison_report.py
@@ -23,17 +23,19 @@ def _scenario_payload(
     *,
     name: str,
     backend: str,
-    payload_bytes: int = 1024,
-    stages: int = 2,
-    with_line_callbacks: bool = False,
+    **overrides: object,
 ) -> dict[str, object]:
     """Return a benchmark scenario payload."""
+    defaults: dict[str, object] = {
+        "payload_bytes": 1024,
+        "stages": 2,
+        "with_line_callbacks": False,
+    }
     return {
         "name": name,
         "backend": backend,
-        "payload_bytes": payload_bytes,
-        "stages": stages,
-        "with_line_callbacks": with_line_callbacks,
+        **defaults,
+        **overrides,
     }
 
 

--- a/cuprum/unittests/test_benchmark_comparison_report.py
+++ b/cuprum/unittests/test_benchmark_comparison_report.py
@@ -114,6 +114,28 @@ def test_compare_candidate_backend_results_builds_sorted_rows() -> None:
     )
 
 
+def test_compare_candidate_backend_results_treats_close_means_as_ties() -> None:
+    """Means within FLOAT_TOLERANCE should be treated as ties."""
+    plan_payload = _candidate_plan_payload()
+    throughput_payload = _candidate_throughput_payload()
+    results = typ.cast("list[dict[str, object]]", throughput_payload["results"])
+    # Make the first pair (python-small-single-nocb and rust-small-single-nocb) a tie
+    results[0]["mean"] = 0.42
+    results[1]["mean"] = 0.42 + 5e-13
+
+    report = compare_candidate_backend_results(
+        plan_payload=plan_payload,
+        throughput_payload=throughput_payload,
+    )
+
+    # Results sorted by comparison_id: small-single-cb before small-single-nocb
+    assert report.rows[1].comparison_id == "small-single-nocb"
+    assert report.rows[1].faster_backend == "tie"
+    assert report.summary.ties == 1
+    assert report.summary.rust_wins == 1
+    assert report.summary.python_wins == 0
+
+
 def test_compare_candidate_backend_results_rejects_missing_rust_pair() -> None:
     """Every comparison group must include both Python and Rust scenarios."""
     plan_payload = _candidate_plan_payload()
@@ -132,6 +154,98 @@ def test_compare_candidate_backend_results_rejects_missing_rust_pair() -> None:
             plan_payload=plan_payload,
             throughput_payload=throughput_payload,
         )
+
+
+def test_compare_candidate_backend_results_rejects_duplicate_backend() -> None:
+    """Each comparison group must not contain duplicate backend entries."""
+    plan_payload = _candidate_plan_payload()
+    scenarios = typ.cast("list[dict[str, object]]", plan_payload["scenarios"])
+    # Both scenarios should have the same comparison_id (after stripping backend prefix)
+    first_scenario = dict(scenarios[0])
+    # Keep the same name to ensure both map to the same comparison_id
+    plan_payload["scenarios"] = [scenarios[0], first_scenario]
+
+    throughput_payload = _candidate_throughput_payload()
+    results = typ.cast("list[dict[str, object]]", throughput_payload["results"])
+    first_result = dict(results[0])
+    throughput_payload["results"] = [results[0], first_result]
+
+    with pytest.raises(ValueError, match=r"duplicate.*python.*scenario"):
+        compare_candidate_backend_results(
+            plan_payload=plan_payload,
+            throughput_payload=throughput_payload,
+        )
+
+
+def test_compare_candidate_backend_results_rejects_invalid_backend() -> None:
+    """Scenario backend values must be 'python' or 'rust'."""
+    plan_payload = _candidate_plan_payload()
+    scenarios = typ.cast("list[dict[str, object]]", plan_payload["scenarios"])
+    invalid_scenario = dict(scenarios[0])
+    invalid_scenario["backend"] = "invalid-backend"
+    plan_payload["scenarios"] = [invalid_scenario]
+
+    throughput_payload = _candidate_throughput_payload()
+    results = typ.cast("list[dict[str, object]]", throughput_payload["results"])
+    throughput_payload["results"] = [results[0]]
+
+    with pytest.raises(ValueError, match="must be either 'python' or 'rust'"):
+        compare_candidate_backend_results(
+            plan_payload=plan_payload,
+            throughput_payload=throughput_payload,
+        )
+
+
+def test_load_ratchet_report_rejects_non_boolean_passed(tmp_path: pth.Path) -> None:
+    """Ratchet report must have a boolean 'passed' field."""
+    ratchet_path = _write_json(
+        tmp_path=tmp_path,
+        filename="ratchet-report.json",
+        payload={
+            "passed": "yes",
+            "comparison_performed": True,
+            "baseline_available": True,
+        },
+    )
+
+    with pytest.raises(TypeError, match="boolean passed field"):
+        load_ratchet_report(ratchet_path)
+
+
+def test_load_ratchet_report_rejects_non_boolean_comparison_performed(
+    tmp_path: pth.Path,
+) -> None:
+    """Ratchet report must have a boolean 'comparison_performed' field."""
+    ratchet_path = _write_json(
+        tmp_path=tmp_path,
+        filename="ratchet-report.json",
+        payload={
+            "passed": True,
+            "comparison_performed": "yes",
+            "baseline_available": True,
+        },
+    )
+
+    with pytest.raises(TypeError, match="non-boolean 'comparison_performed'"):
+        load_ratchet_report(ratchet_path)
+
+
+def test_load_ratchet_report_rejects_non_boolean_baseline_available(
+    tmp_path: pth.Path,
+) -> None:
+    """Ratchet report must have a boolean 'baseline_available' field."""
+    ratchet_path = _write_json(
+        tmp_path=tmp_path,
+        filename="ratchet-report.json",
+        payload={
+            "passed": True,
+            "comparison_performed": True,
+            "baseline_available": "yes",
+        },
+    )
+
+    with pytest.raises(TypeError, match="non-boolean 'baseline_available'"):
+        load_ratchet_report(ratchet_path)
 
 
 @pytest.mark.parametrize(

--- a/cuprum/unittests/test_benchmark_comparison_report.py
+++ b/cuprum/unittests/test_benchmark_comparison_report.py
@@ -196,55 +196,38 @@ def test_compare_candidate_backend_results_rejects_invalid_backend() -> None:
         )
 
 
-def test_load_ratchet_report_rejects_non_boolean_passed(tmp_path: pth.Path) -> None:
-    """Ratchet report must have a boolean 'passed' field."""
-    ratchet_path = _write_json(
-        tmp_path=tmp_path,
-        filename="ratchet-report.json",
-        payload={
-            "passed": "yes",
-            "comparison_performed": True,
-            "baseline_available": True,
-        },
-    )
-
-    with pytest.raises(TypeError, match="boolean passed field"):
-        load_ratchet_report(ratchet_path)
-
-
-def test_load_ratchet_report_rejects_non_boolean_comparison_performed(
+@pytest.mark.parametrize(
+    ("payload", "expected_match"),
+    [
+        pytest.param(
+            {"passed": "yes", "comparison_performed": True, "baseline_available": True},
+            "boolean passed field",
+            id="passed",
+        ),
+        pytest.param(
+            {"passed": True, "comparison_performed": "yes", "baseline_available": True},
+            "non-boolean 'comparison_performed'",
+            id="comparison_performed",
+        ),
+        pytest.param(
+            {"passed": True, "comparison_performed": True, "baseline_available": "yes"},
+            "non-boolean 'baseline_available'",
+            id="baseline_available",
+        ),
+    ],
+)
+def test_load_ratchet_report_rejects_non_boolean_field(
     tmp_path: pth.Path,
+    payload: dict[str, object],
+    expected_match: str,
 ) -> None:
-    """Ratchet report must have a boolean 'comparison_performed' field."""
+    """Ratchet report boolean fields must be booleans."""
     ratchet_path = _write_json(
         tmp_path=tmp_path,
         filename="ratchet-report.json",
-        payload={
-            "passed": True,
-            "comparison_performed": "yes",
-            "baseline_available": True,
-        },
+        payload=payload,
     )
-
-    with pytest.raises(TypeError, match="non-boolean 'comparison_performed'"):
-        load_ratchet_report(ratchet_path)
-
-
-def test_load_ratchet_report_rejects_non_boolean_baseline_available(
-    tmp_path: pth.Path,
-) -> None:
-    """Ratchet report must have a boolean 'baseline_available' field."""
-    ratchet_path = _write_json(
-        tmp_path=tmp_path,
-        filename="ratchet-report.json",
-        payload={
-            "passed": True,
-            "comparison_performed": True,
-            "baseline_available": "yes",
-        },
-    )
-
-    with pytest.raises(TypeError, match="non-boolean 'baseline_available'"):
+    with pytest.raises(TypeError, match=expected_match):
         load_ratchet_report(ratchet_path)
 
 

--- a/cuprum/unittests/test_fetch_main_benchmark_baseline.py
+++ b/cuprum/unittests/test_fetch_main_benchmark_baseline.py
@@ -316,7 +316,7 @@ def test_artifact_redirect_handler_strips_auth_on_cross_origin_redirect() -> Non
 
     assert redirected_request is not None
     assert redirected_request.get_header("Authorization") is None
-    assert redirected_request.get_header("X-GitHub-Api-Version") is None
+    assert redirected_request.get_header("X-github-api-version") is None
     assert redirected_request.get_header("Accept") == "application/vnd.github+json"
     assert redirected_request.get_header("User-agent") == "cuprum-benchmark-ratchet"
 

--- a/cuprum/unittests/test_fetch_main_benchmark_baseline.py
+++ b/cuprum/unittests/test_fetch_main_benchmark_baseline.py
@@ -264,6 +264,34 @@ def test_load_json_response_retries_transient_urlopen_failures(
     assert timeouts == [10.0, 10.0, 10.0]
 
 
+def test_artifact_redirect_handler_preserves_auth_on_same_origin_redirect() -> None:
+    """Same-origin redirects must preserve GitHub auth headers."""
+    handler = _ArtifactArchiveRedirectHandler()
+    request = urllib.request.Request(
+        "https://api.github.com/repos/leynos/cuprum/actions/artifacts/1/zip",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": "Bearer token",
+            "User-Agent": "cuprum-benchmark-ratchet",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+    redirected_request = handler.redirect_request(
+        request,
+        fp=io.BytesIO(),
+        code=302,
+        msg="Found",
+        headers=http.client.HTTPMessage(),
+        newurl="https://api.github.com/repos/leynos/cuprum/actions/artifacts/2/zip",
+    )
+
+    assert redirected_request is not None
+    assert redirected_request.get_header("Authorization") == "Bearer token"
+    assert redirected_request.get_header("X-github-api-version") == "2022-11-28"
+    assert redirected_request.get_header("Accept") == "application/vnd.github+json"
+
+
 def test_artifact_redirect_handler_strips_auth_on_cross_origin_redirect() -> None:
     """Cross-origin redirects must not forward GitHub auth headers."""
     handler = _ArtifactArchiveRedirectHandler()

--- a/cuprum/unittests/test_fetch_main_benchmark_baseline.py
+++ b/cuprum/unittests/test_fetch_main_benchmark_baseline.py
@@ -264,8 +264,36 @@ def test_load_json_response_retries_transient_urlopen_failures(
     assert timeouts == [10.0, 10.0, 10.0]
 
 
-def test_artifact_redirect_handler_preserves_auth_on_same_origin_redirect() -> None:
-    """Same-origin redirects must preserve GitHub auth headers."""
+@pytest.mark.parametrize(
+    ("newurl", "expected_headers"),
+    [
+        pytest.param(
+            "https://api.github.com/repos/leynos/cuprum/actions/artifacts/2/zip",
+            {
+                "Authorization": "Bearer token",
+                "X-github-api-version": "2022-11-28",
+                "Accept": "application/vnd.github+json",
+                "User-agent": "cuprum-benchmark-ratchet",
+            },
+            id="same-origin-preserves-auth",
+        ),
+        pytest.param(
+            "https://pipelines.actions.githubusercontent.com/archive.zip?sig=abc",
+            {
+                "Authorization": None,
+                "X-github-api-version": None,
+                "Accept": "application/vnd.github+json",
+                "User-agent": "cuprum-benchmark-ratchet",
+            },
+            id="cross-origin-strips-auth",
+        ),
+    ],
+)
+def test_artifact_redirect_handler_header_policy(
+    newurl: str,
+    expected_headers: dict[str, str | None],
+) -> None:
+    """Redirect handler must preserve auth on same-origin and strip on cross-origin."""
     handler = _ArtifactArchiveRedirectHandler()
     request = urllib.request.Request(
         "https://api.github.com/repos/leynos/cuprum/actions/artifacts/1/zip",
@@ -283,42 +311,12 @@ def test_artifact_redirect_handler_preserves_auth_on_same_origin_redirect() -> N
         code=302,
         msg="Found",
         headers=http.client.HTTPMessage(),
-        newurl="https://api.github.com/repos/leynos/cuprum/actions/artifacts/2/zip",
+        newurl=newurl,
     )
 
     assert redirected_request is not None
-    assert redirected_request.get_header("Authorization") == "Bearer token"
-    assert redirected_request.get_header("X-github-api-version") == "2022-11-28"
-    assert redirected_request.get_header("Accept") == "application/vnd.github+json"
-
-
-def test_artifact_redirect_handler_strips_auth_on_cross_origin_redirect() -> None:
-    """Cross-origin redirects must not forward GitHub auth headers."""
-    handler = _ArtifactArchiveRedirectHandler()
-    request = urllib.request.Request(
-        "https://api.github.com/repos/leynos/cuprum/actions/artifacts/1/zip",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": "Bearer token",
-            "User-Agent": "cuprum-benchmark-ratchet",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
-
-    redirected_request = handler.redirect_request(
-        request,
-        fp=io.BytesIO(),
-        code=302,
-        msg="Found",
-        headers=http.client.HTTPMessage(),
-        newurl="https://pipelines.actions.githubusercontent.com/archive.zip?sig=abc",
-    )
-
-    assert redirected_request is not None
-    assert redirected_request.get_header("Authorization") is None
-    assert redirected_request.get_header("X-github-api-version") is None
-    assert redirected_request.get_header("Accept") == "application/vnd.github+json"
-    assert redirected_request.get_header("User-agent") == "cuprum-benchmark-ratchet"
+    for header, expected_value in expected_headers.items():
+        assert redirected_request.get_header(header) == expected_value
 
 
 def test_download_bytes_uses_artifact_redirect_handler(

--- a/cuprum/unittests/test_fetch_main_benchmark_baseline.py
+++ b/cuprum/unittests/test_fetch_main_benchmark_baseline.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import http.client
 import io
+import math
 import typing as typ
 import urllib.error
+import urllib.request
 import zipfile
 
 import pytest
@@ -12,6 +15,8 @@ import pytest
 from benchmarks.fetch_main_benchmark_baseline import (
     MAIN_BASELINE_NOT_FOUND_EXIT_CODE,
     ArtifactQuery,
+    _ArtifactArchiveRedirectHandler,
+    _download_bytes,
     _load_json_response,
     extract_artifact_archive,
     find_latest_artifact_download_url,
@@ -257,6 +262,88 @@ def test_load_json_response_retries_transient_urlopen_failures(
     assert payload == {"workflow_runs": []}
     assert attempts == 3
     assert timeouts == [10.0, 10.0, 10.0]
+
+
+def test_artifact_redirect_handler_strips_auth_on_cross_origin_redirect() -> None:
+    """Cross-origin redirects must not forward GitHub auth headers."""
+    handler = _ArtifactArchiveRedirectHandler()
+    request = urllib.request.Request(
+        "https://api.github.com/repos/leynos/cuprum/actions/artifacts/1/zip",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": "Bearer token",
+            "User-Agent": "cuprum-benchmark-ratchet",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+    redirected_request = handler.redirect_request(
+        request,
+        fp=io.BytesIO(),
+        code=302,
+        msg="Found",
+        headers=http.client.HTTPMessage(),
+        newurl="https://pipelines.actions.githubusercontent.com/archive.zip?sig=abc",
+    )
+
+    assert redirected_request is not None
+    assert redirected_request.get_header("Authorization") is None
+    assert redirected_request.get_header("X-GitHub-Api-Version") is None
+    assert redirected_request.get_header("Accept") == "application/vnd.github+json"
+    assert redirected_request.get_header("User-agent") == "cuprum-benchmark-ratchet"
+
+
+def test_download_bytes_uses_artifact_redirect_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Artifact downloads should use the redirect policy that strips auth."""
+
+    class _Response:
+        def __enter__(self) -> _Response:
+            return self
+
+        def __exit__(
+            self,
+            exc_type: object,
+            exc: object,
+            traceback: object,
+        ) -> None:
+            return None
+
+        @staticmethod
+        def read() -> bytes:
+            return b"archive-bytes"
+
+    class _Opener:
+        @staticmethod
+        def open(
+            request: urllib.request.Request,
+            *,
+            timeout: float,
+        ) -> _Response:
+            assert request.get_header("Authorization") == "Bearer token"
+            assert math.isclose(timeout, 10.0)
+            return _Response()
+
+    def fake_build_opener(
+        *handlers: urllib.request.BaseHandler,
+    ) -> _Opener:
+        assert any(
+            isinstance(handler, _ArtifactArchiveRedirectHandler) for handler in handlers
+        )
+        return _Opener()
+
+    monkeypatch.setattr(
+        "benchmarks.fetch_main_benchmark_baseline.urllib.request.build_opener",
+        fake_build_opener,
+    )
+
+    archive_bytes = _download_bytes(
+        url="https://api.github.com/repos/leynos/cuprum/actions/artifacts/1/zip",
+        token="".join(("tok", "en")),
+    )
+
+    assert archive_bytes == b"archive-bytes"
 
 
 def test_find_latest_artifact_download_url_queries_workflow_and_artifacts(

--- a/cuprum/unittests/test_fetch_main_benchmark_baseline.py
+++ b/cuprum/unittests/test_fetch_main_benchmark_baseline.py
@@ -264,6 +264,19 @@ def test_load_json_response_retries_transient_urlopen_failures(
     assert timeouts == [10.0, 10.0, 10.0]
 
 
+def _make_github_artifact_request() -> urllib.request.Request:
+    """Build a GitHub artifact download request with standard auth headers."""
+    return urllib.request.Request(
+        "https://api.github.com/repos/leynos/cuprum/actions/artifacts/1/zip",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": "Bearer token",
+            "User-Agent": "cuprum-benchmark-ratchet",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+
 @pytest.mark.parametrize(
     ("newurl", "expected_headers"),
     [
@@ -293,17 +306,9 @@ def test_artifact_redirect_handler_header_policy(
     newurl: str,
     expected_headers: dict[str, str | None],
 ) -> None:
-    """Redirect handler must preserve auth on same-origin and strip on cross-origin."""
+    """Redirect handler strips auth on cross-origin, preserves on same-origin."""
     handler = _ArtifactArchiveRedirectHandler()
-    request = urllib.request.Request(
-        "https://api.github.com/repos/leynos/cuprum/actions/artifacts/1/zip",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": "Bearer token",
-            "User-Agent": "cuprum-benchmark-ratchet",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
+    request = _make_github_artifact_request()
 
     redirected_request = handler.redirect_request(
         request,
@@ -316,7 +321,9 @@ def test_artifact_redirect_handler_header_policy(
 
     assert redirected_request is not None
     for header, expected_value in expected_headers.items():
-        assert redirected_request.get_header(header) == expected_value
+        assert redirected_request.get_header(header) == expected_value, (
+            f"Header {header!r}: expected {expected_value!r}"
+        )
 
 
 def test_download_bytes_uses_artifact_redirect_handler(

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1957,6 +1957,10 @@ compares Rust scenario means against the latest successful `main` baseline
 artefact. On pushes to `main`, the new smoke benchmark output is uploaded as
 the next baseline artefact for future runs. When no prior `main` baseline is
 available yet, the job writes a skip report instead of failing the workflow.
+The same job also generates a Python-versus-Rust comparison report from the
+candidate smoke artefacts and appends a Markdown summary table to
+`$GITHUB_STEP_SUMMARY`, so reviewers can inspect backend speedups even when the
+Rust ratchet later fails the job.
 
 The ratchet rule is:
 
@@ -1971,9 +1975,23 @@ Artefacts uploaded by CI include:
   was available for comparison
 - `candidate-plan.json`
 - `candidate-throughput.json`
+- `comparison-report.json`
+- `comparison-summary.md`
 - `ratchet-report.json`
 - `main-plan.json` and `main-throughput.json` on pushes to `main`, published as
   the baseline artefact consumed by later ratchet runs
+
+The workflow summary table is generated from matched Python and Rust candidate
+scenarios using the backend-independent scenario label (for example
+`small-single-nocb`). Each row reports:
+
+- Python mean runtime in seconds
+- Rust mean runtime in seconds
+- speedup ratio = `python_mean / rust_mean`
+- faster backend (`python`, `rust`, or `tie`)
+
+Values above `1.0x` indicate Rust was faster for that row; values below `1.0x`
+indicate Python was faster.
 
 Benchmark execution is opt-in for normal development loops. `make test` skips
 the benchmark pytest module by default, while dedicated commands run benchmarks:

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1957,10 +1957,13 @@ compares Rust scenario means against the latest successful `main` baseline
 artefact. On pushes to `main`, the new smoke benchmark output is uploaded as
 the next baseline artefact for future runs. When no prior `main` baseline is
 available yet, the job writes a skip report instead of failing the workflow.
-The same job also generates a Python-versus-Rust comparison report from the
-candidate smoke artefacts and appends a Markdown summary table to
-`$GITHUB_STEP_SUMMARY`, so reviewers can inspect backend speedups even when the
-Rust ratchet later fails the job.
+The baseline fetch helper follows GitHub’s signed archive redirects without
+forwarding GitHub-only authentication headers to the storage host, avoiding
+cross-origin 401 responses during artefact download. The same job also
+generates a Python-versus-Rust comparison report from the candidate smoke
+artefacts and appends a Markdown summary table to `$GITHUB_STEP_SUMMARY`, so
+reviewers can inspect backend speedups even when the Rust ratchet later fails
+the job.
 
 The ratchet rule is:
 

--- a/docs/execplans/4-4-4-benchmark-comparison-report.md
+++ b/docs/execplans/4-4-4-benchmark-comparison-report.md
@@ -1,0 +1,402 @@
+# Generate benchmark comparison report and workflow summary table (4.4.4)
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+Roadmap reference: `docs/roadmap.md` item `4.4.4`.
+
+## Purpose / big picture
+
+Roadmap item `4.4.4` requires the benchmark CI flow to produce a human-readable
+comparison report for the Python and Rust stream backends and publish a summary
+table to the GitHub Actions workflow summary.
+
+After this work, a maintainer opening a pull request or inspecting a `main`
+workflow run can read the workflow summary and immediately see how the current
+candidate smoke benchmark compares Python and Rust for the same benchmark
+scenario. The existing Rust regression ratchet from `4.4.3` remains the gating
+check against the latest successful `main` baseline artefact, while `4.4.4`
+adds same-run Python-versus-Rust evidence for the candidate checkout.
+
+This task is complete only when:
+
+- CI still runs the existing `benchmark-ratchet` job on pull requests and
+  pushes to `main`.
+- The job generates a structured comparison report artefact derived from the
+  candidate smoke benchmark plan and throughput JSON.
+- The job appends a Markdown summary table to `$GITHUB_STEP_SUMMARY` showing
+  Python and Rust results for matched scenarios.
+- Unit tests (`pytest`) and behavioural tests (`pytest-bdd`) cover report
+  generation, contract validation, and workflow-facing summary output.
+- `docs/cuprum-design.md` and `docs/users-guide.md` describe the comparison
+  report and workflow summary behaviour.
+- `docs/roadmap.md` marks `4.4.4` as done.
+- Quality gates pass: `make check-fmt`, `make typecheck`, `make lint`,
+  `make test`, `make markdownlint`, and `make nixie`.
+
+## Constraints
+
+- Keep scope bounded to roadmap item `4.4.4`. Do not redesign the `4.4.3`
+  ratchet threshold or baseline-fetch logic.
+- Follow repository test-first policy:
+  - add or modify tests first;
+  - capture a failing state;
+  - implement the minimal code to pass.
+- Provide both test styles:
+  - unit tests in `cuprum/unittests/` with `pytest`;
+  - behavioural tests in `tests/behaviour/` plus Gherkin in
+    `tests/features/` using `pytest-bdd`.
+- Keep benchmark scenario naming and selection compatible with
+  `benchmarks/pipeline_throughput.py` and
+  `benchmarks/ci_benchmark_ratchet_profile.py`.
+- Keep the existing public runtime API in `cuprum/` stable.
+- Do not add runtime dependencies or new GitHub Actions marketplace actions.
+- Keep the comparison report deterministic and derived from checked-in JSON
+  contracts rather than ad hoc shell parsing.
+- Keep the workflow summary generation additive: when the baseline artefact is
+  unavailable, the Python-versus-Rust summary table must still be published for
+  the candidate smoke run.
+- Keep documentation aligned in `docs/cuprum-design.md`,
+  `docs/users-guide.md`, and `docs/roadmap.md`.
+- Keep Python changes compliant with `.rules/python-*.md`, Ruff, and typing
+  checks.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires edits to more than 10 files, including
+  this ExecPlan, stop and escalate.
+- Interface: if `benchmarks/ci_benchmark_ratchet_profile.py` or
+  `benchmarks/ratchet_rust_performance.py` need breaking CLI changes rather
+  than additive flags or a new helper module, stop and escalate.
+- Dependencies: if a new third-party Python package or GitHub Action is
+  required, stop and escalate.
+- Iterations: if the same failing test persists after 3 fix attempts, stop and
+  escalate with options.
+- Runtime: if the new report-generation step adds more than 2 minutes to the
+  `benchmark-ratchet` job on `ubuntu-latest`, stop and propose a cheaper
+  summary path.
+- Ambiguity: if the expected summary table must include baseline-versus-
+  candidate data in addition to Python-versus-Rust data, stop and ask for a
+  decision before broadening the report contract.
+
+## Risks
+
+- Risk: the filtered CI smoke profile might not retain perfectly matched Python
+  and Rust scenario pairs for every comparison row. Severity: high. Likelihood:
+  low. Mitigation: validate pairings explicitly by shared scenario dimensions
+  and fail fast if a Python or Rust counterpart is missing.
+
+- Risk: report code may duplicate JSON validation logic already used by the
+  ratchet and baseline-fetch helpers. Severity: medium. Likelihood: medium.
+  Mitigation: reuse `benchmarks/_validation.py` and extract only minimal new
+  helpers when duplication becomes concrete.
+
+- Risk: GitHub Actions workflow summary formatting may become brittle if the
+  summary is assembled inline in shell heredocs. Severity: medium. Likelihood:
+  medium. Mitigation: generate Markdown from a checked-in Python helper, write
+  it to a file, and append that file to `$GITHUB_STEP_SUMMARY`.
+
+- Risk: local validation can miss workflow-only issues because full GitHub
+  Actions execution is not available in this environment. Severity: medium.
+  Likelihood: medium. Mitigation: cover workflow-facing behaviour with
+  CLI-based behavioural tests, keep shell glue minimal, and validate workflow
+  syntax statically.
+
+- Risk: a generated local native module
+  (`cuprum/_rust_backend_native*.so`) can unexpectedly change `make test`
+  behaviour during final gates. Severity: medium. Likelihood: medium.
+  Mitigation: remove generated native artefacts before final gate runs unless
+  Rust-path testing is intentionally part of the validation step.
+
+## Progress
+
+- [x] (2026-03-08 00:00Z) Reviewed roadmap item `4.4.4`, the completed
+  `4.4.3` benchmark-ratchet implementation, the benchmark ADR, and repository
+  documentation/testing constraints.
+- [x] (2026-03-08 00:10Z) Drafted this ExecPlan for roadmap item `4.4.4`.
+- [ ] Stage A: add fail-first unit and behavioural tests for Python-versus-Rust
+  report generation and workflow-summary Markdown output.
+- [ ] Stage B: implement report-generation helper and CLI.
+- [ ] Stage C: integrate report generation and summary publication into
+  `.github/workflows/ci.yml`.
+- [ ] Stage D: update `docs/cuprum-design.md`, `docs/users-guide.md`, and mark
+  roadmap item `4.4.4` done in `docs/roadmap.md`.
+- [ ] Stage E: run full validation and capture outcomes in this ExecPlan.
+
+## Surprises & discoveries
+
+- Observation: `.github/workflows/ci.yml` already downloads the latest
+  successful `main` baseline artefact, runs the candidate smoke benchmarks, and
+  uploads JSON artefacts, but it does not write anything to
+  `$GITHUB_STEP_SUMMARY`. Impact: `4.4.4` should extend the existing
+  `benchmark-ratchet` job rather than introducing a second benchmark-reporting
+  job.
+
+- Observation: `benchmarks/ratchet_rust_performance.py` already produces a
+  JSON comparison report, but that report compares baseline versus candidate
+  Rust means only. Impact: `4.4.4` needs a separate report contract or additive
+  helper focused on Python-versus-Rust data from the candidate smoke run.
+
+- Observation: `benchmarks/ci_benchmark_ratchet_profile.py` already writes a
+  filtered candidate plan containing the exact scenario list paired with the
+  throughput JSON used by CI. Impact: the new report should consume the
+  filtered candidate plan and throughput files instead of rebuilding scenario
+  selection logic.
+
+- Observation: the accepted Rust-extension ADR already promises that CI will
+  generate comparison reports in the GitHub Actions summary. Impact: the
+  implementation should align the workflow with the ADR rather than introducing
+  a different reporting surface.
+
+## Decision log
+
+- Decision: generate the Python-versus-Rust comparison from the candidate smoke
+  benchmark artefacts (`candidate-plan.json` and `candidate-throughput.json`)
+  rather than from baseline artefacts. Rationale: roadmap item `4.4.4` is about
+  backend comparison, while `4.4.3` already covers baseline-versus-candidate
+  regression gating. Date/Author: 2026-03-08 / Codex.
+
+- Decision: keep report generation in a checked-in Python helper module with a
+  small CLI instead of assembling Markdown directly in the workflow shell.
+  Rationale: Python code is easier to unit test, validate, and reuse for both
+  JSON output and Markdown summary rendering. Date/Author: 2026-03-08 / Codex.
+
+- Decision: treat missing Python or Rust counterparts in a comparison group as
+  a contract error. Rationale: a partial comparison table would hide benchmark
+  selection drift and undermine confidence in the CI summary. Date/Author:
+  2026-03-08 / Codex.
+
+## Outcomes & retrospective
+
+Implementation has not started. Success for this ExecPlan means the repository
+gains a tested Python-versus-Rust comparison report, the workflow summary shows
+the new table on `pull_request` and `push` runs, the relevant docs are updated,
+and roadmap item `4.4.4` is marked done only after all quality gates pass.
+
+## Context and orientation
+
+Relevant repository areas and current behaviour:
+
+- `.github/workflows/ci.yml`
+  - defines the `benchmark-ratchet` job;
+  - fetches the latest successful `main` baseline artefact;
+  - runs smoke benchmarks for the candidate checkout;
+  - writes `candidate-plan.json`, `candidate-throughput.json`, and
+    `ratchet-report.json`;
+  - uploads benchmark JSON artefacts.
+- `benchmarks/ci_benchmark_ratchet_profile.py`
+  - reads the full dry-run plan from `benchmarks/pipeline_throughput.py`;
+  - filters the smoke matrix used in CI;
+  - runs `hyperfine`;
+  - writes the filtered plan whose `scenarios` list aligns with the throughput
+    `results` list by index.
+- `benchmarks/ratchet_rust_performance.py`
+  - validates plan and throughput JSON;
+  - compares baseline-versus-candidate Rust scenario means;
+  - writes `ratchet-report.json`.
+- `benchmarks/_validation.py`
+  - centralizes JSON-shape validation helpers already reused by benchmark
+    helpers.
+- `cuprum/unittests/test_ci_benchmark_ratchet_profile.py`
+  - covers CI smoke profile selection.
+- `cuprum/unittests/test_benchmark_ci_ratchet.py`
+  - covers ratchet report JSON and comparison logic.
+- `tests/behaviour/test_benchmark_ci_ratchet_behaviour.py` and
+  `tests/features/benchmark_ci_ratchet.feature`
+  - cover CLI-facing ratchet behaviour.
+- `docs/cuprum-design.md` section 13.9
+  - documents the benchmark suite, CI ratchet, and artefacts.
+- `docs/users-guide.md`
+  - documents benchmark commands and CI benchmark behaviour.
+
+Terminology used in this plan:
+
+- Candidate run: the smoke benchmark execution for the commit under test in the
+  current workflow run.
+- Comparison group: the set of scenarios that share the same payload size,
+  stage count, and callback mode, differing only by backend (`python` or
+  `rust`).
+- Speedup ratio: `python_mean / rust_mean` for the matched comparison group.
+  Values greater than `1.0` mean Rust is faster; values less than `1.0` mean
+  Python is faster.
+
+## Plan of work
+
+Stage A: tests first.
+
+Add unit tests for a new Python-versus-Rust comparison helper module. Cover:
+
+1. loading and validating the filtered plan and throughput JSON;
+2. grouping matching Python and Rust scenarios by shared dimensions;
+3. rejecting missing or duplicate backend pairs;
+4. calculating comparison rows and speedup ratios deterministically;
+5. rendering Markdown summary text with the expected header and table columns.
+
+Add behavioural scenarios that invoke the report CLI with fixture JSON files
+and assert:
+
+- the command exits successfully for valid paired inputs;
+- the JSON report contains matched Python and Rust means plus derived speedup;
+- the Markdown summary contains a table suitable for
+  `$GITHUB_STEP_SUMMARY`;
+- malformed inputs fail with a configuration-error exit code.
+
+Suggested test files:
+
+- `cuprum/unittests/test_benchmark_comparison_report.py`
+- `tests/behaviour/test_benchmark_comparison_report_behaviour.py`
+- `tests/features/benchmark_comparison_report.feature`
+
+Go/no-go: proceed only after the new tests fail because the report helper does
+not yet exist.
+
+Stage B: implement the report-generation helper and CLI.
+
+Create a dedicated helper module, preferably
+`benchmarks/python_vs_rust_comparison_report.py`, that:
+
+1. reads the filtered candidate plan and candidate throughput JSON;
+2. validates that each comparison group has exactly one Python and one Rust
+   entry;
+3. computes per-group comparison rows with explicit fields for scenario label,
+   Python mean, Rust mean, speedup ratio, and faster backend;
+4. writes a structured JSON report artefact;
+5. renders a Markdown summary block that can be appended to the GitHub Actions
+   workflow summary;
+6. optionally includes ratchet status metadata from `ratchet-report.json` so
+   the summary can mention whether baseline comparison passed, failed, or was
+   skipped.
+
+Keep the CLI deterministic and file-based. A likely command shape is:
+
+```plaintext
+uv run python benchmarks/python_vs_rust_comparison_report.py \
+  --plan /tmp/candidate-plan.json \
+  --throughput /tmp/candidate-throughput.json \
+  --ratchet-report /tmp/ratchet-report.json \
+  --output-json /tmp/comparison-report.json \
+  --output-markdown /tmp/comparison-summary.md
+```
+
+Suggested JSON report contract:
+
+```json
+{
+  "rows": [
+    {
+      "comparison_id": "small-single-nocb",
+      "python_scenario_name": "python-small-single-nocb",
+      "rust_scenario_name": "rust-small-single-nocb",
+      "python_mean": 0.42,
+      "rust_mean": 0.21,
+      "speedup_ratio": 2.0,
+      "faster_backend": "rust"
+    }
+  ],
+  "summary": {
+    "row_count": 1,
+    "rust_wins": 1,
+    "python_wins": 0
+  }
+}
+```
+
+The exact field names may evolve during implementation, but the report must
+remain explicit, stable, and easy to validate in tests.
+
+Go/no-go: proceed only after the new unit and behavioural tests pass.
+
+Stage C: integrate report generation into the workflow.
+
+Update `.github/workflows/ci.yml` so the existing `benchmark-ratchet` job:
+
+1. runs the new report helper after `ratchet-report.json` is available;
+2. writes `comparison-report.json` and `comparison-summary.md` into the same
+   artefact directory used by the other benchmark outputs;
+3. appends `comparison-summary.md` to `$GITHUB_STEP_SUMMARY`;
+4. uploads the new report artefacts with the existing benchmark artefact set.
+
+Keep the workflow summary path simple and observable. Prefer:
+
+```plaintext
+cat "${artifact_dir}/comparison-summary.md" >> "${GITHUB_STEP_SUMMARY}"
+```
+
+instead of embedding large Markdown blocks inline in shell scripts.
+
+Expected workflow-summary content:
+
+- a short heading explaining that the table reflects the candidate smoke
+  benchmark run;
+- one row per matched Python/Rust comparison group;
+- columns for scenario, Python mean, Rust mean, speedup ratio, and faster
+  backend;
+- a short ratchet status line stating whether baseline comparison passed,
+  failed, or was skipped because no previous `main` baseline artefact exists.
+
+Go/no-go: proceed only after targeted tests and local workflow file checks pass.
+
+Stage D: documentation and roadmap updates.
+
+Update the design and user documentation to describe:
+
+- what the new comparison report contains;
+- where the workflow summary table appears;
+- how it relates to the existing Rust regression ratchet;
+- how to interpret the speedup ratio and winner column.
+
+Files to update:
+
+- `docs/cuprum-design.md`
+- `docs/users-guide.md`
+- `docs/roadmap.md` (mark `4.4.4` as done only after implementation and
+  validation are complete)
+
+Keep wording aligned with the accepted ADR promise that CI generates comparison
+reports in the GitHub Actions summary.
+
+Stage E: validation and close-out.
+
+Run targeted tests first, then the full repository gates. Capture outcomes in
+`Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective`.
+
+Use `tee` and `set -o pipefail` for all long-running commands so the exit code
+is preserved and the logs remain reviewable:
+
+```bash
+set -o pipefail; make fmt 2>&1 | tee /tmp/4-4-4-make-fmt.log
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/4-4-4-check-fmt.log
+set -o pipefail; make typecheck 2>&1 | tee /tmp/4-4-4-typecheck.log
+set -o pipefail; make lint 2>&1 | tee /tmp/4-4-4-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/4-4-4-test.log
+set -o pipefail; MDLINT=/root/.bun/bin/markdownlint-cli2 make markdownlint \
+  2>&1 | tee /tmp/4-4-4-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/4-4-4-nixie.log
+```
+
+If local native artefacts exist, remove them before the final default gate run:
+
+```bash
+rm -f cuprum/_rust_backend_native*.so
+```
+
+## Acceptance evidence
+
+The implementing agent should capture concise evidence showing:
+
+- the new unit tests fail before implementation and pass after;
+- the behavioural test demonstrates a generated Markdown summary table;
+- the workflow writes `comparison-report.json` and `comparison-summary.md`;
+- `$GITHUB_STEP_SUMMARY` receives the rendered summary table;
+- the final quality gates pass;
+- `docs/roadmap.md` item `4.4.4` is checked only in the completed change.
+
+## Approval gate
+
+This document is the draft phase only. Do not start implementation until the
+user explicitly approves this ExecPlan or requests revisions.

--- a/docs/execplans/4-4-4-benchmark-comparison-report.md
+++ b/docs/execplans/4-4-4-benchmark-comparison-report.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 Roadmap reference: `docs/roadmap.md` item `4.4.4`.
 
@@ -118,14 +118,23 @@ This task is complete only when:
   `4.4.3` benchmark-ratchet implementation, the benchmark ADR, and repository
   documentation/testing constraints.
 - [x] (2026-03-08 00:10Z) Drafted this ExecPlan for roadmap item `4.4.4`.
-- [ ] Stage A: add fail-first unit and behavioural tests for Python-versus-Rust
-  report generation and workflow-summary Markdown output.
-- [ ] Stage B: implement report-generation helper and CLI.
-- [ ] Stage C: integrate report generation and summary publication into
-  `.github/workflows/ci.yml`.
-- [ ] Stage D: update `docs/cuprum-design.md`, `docs/users-guide.md`, and mark
-  roadmap item `4.4.4` done in `docs/roadmap.md`.
-- [ ] Stage E: run full validation and capture outcomes in this ExecPlan.
+- [x] (2026-03-12 23:14Z) Stage A: added fail-first unit and behavioural tests
+  for Python-versus-Rust report generation and workflow-summary Markdown
+  output. Red phase confirmed with `ModuleNotFoundError` for
+  `benchmarks.python_vs_rust_comparison_report`.
+- [x] (2026-03-12 23:20Z) Stage B: implemented
+  `benchmarks/python_vs_rust_comparison_report.py` with paired scenario
+  validation, JSON report writing, ratchet-status loading, Markdown summary
+  rendering, and CLI exit codes.
+- [x] (2026-03-12 23:25Z) Stage C: integrated comparison-report generation and
+  workflow-summary publication into `.github/workflows/ci.yml`, including
+  uploaded Markdown artefacts for inspection.
+- [x] (2026-03-12 23:28Z) Stage D: updated `docs/cuprum-design.md` and
+  `docs/users-guide.md`, and marked roadmap item `4.4.4` done in
+  `docs/roadmap.md`.
+- [x] (2026-03-12 23:42Z) Stage E: final validation complete. Passed
+  `make fmt`, `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie`.
 
 ## Surprises & discoveries
 
@@ -152,6 +161,18 @@ This task is complete only when:
   implementation should align the workflow with the ADR rather than introducing
   a different reporting surface.
 
+- Observation: placing summary publication after the ratchet command in the
+  same shell step would suppress the workflow summary whenever the Rust ratchet
+  failed with exit code `1`. Impact: summary generation and publication were
+  moved into separate `if: always()` workflow steps so reviewers still get the
+  Python-versus-Rust table on failing benchmark runs.
+
+- Observation: `make test` initially failed on an unrelated timing assertion in
+  `cuprum/unittests/test_concurrency.py::test_concurrency_none_allows_unlimited`
+   while several other gate commands were running concurrently. Impact: the
+  final `make test` validation was rerun in isolation and passed cleanly; the
+  `4.4.4` implementation did not require changes to concurrency code.
+
 ## Decision log
 
 - Decision: generate the Python-versus-Rust comparison from the candidate smoke
@@ -170,12 +191,45 @@ This task is complete only when:
   selection drift and undermine confidence in the CI summary. Date/Author:
   2026-03-08 / Codex.
 
+- Decision: publish the summary table in a dedicated `if: always()` workflow
+  step and upload `comparison-summary.md` alongside the JSON artefacts.
+  Rationale: preserves reviewer-visible output on ratchet failures and keeps
+  the generated Markdown easy to inspect outside the GitHub Actions summary.
+  Date/Author: 2026-03-12 / Codex.
+
 ## Outcomes & retrospective
 
-Implementation has not started. Success for this ExecPlan means the repository
-gains a tested Python-versus-Rust comparison report, the workflow summary shows
-the new table on `pull_request` and `push` runs, the relevant docs are updated,
-and roadmap item `4.4.4` is marked done only after all quality gates pass.
+Implementation completed successfully.
+
+Delivered:
+
+- `benchmarks/python_vs_rust_comparison_report.py` with validated candidate
+  plan/throughput pairing, ratchet-status summary loading, JSON report output,
+  Markdown workflow-summary rendering, and CLI exit codes.
+- Unit tests in `cuprum/unittests/test_benchmark_comparison_report.py`.
+- Behavioural tests in
+  `tests/behaviour/test_benchmark_comparison_report_behaviour.py` with
+  `tests/features/benchmark_comparison_report.feature`.
+- Workflow integration in `.github/workflows/ci.yml` so the existing
+  `benchmark-ratchet` job writes `comparison-report.json`,
+  `comparison-summary.md`, appends the Markdown table to
+  `$GITHUB_STEP_SUMMARY`, and uploads both artefacts.
+- Documentation updates in `docs/cuprum-design.md` and `docs/users-guide.md`.
+- Roadmap update in `docs/roadmap.md`, marking item `4.4.4` done.
+
+Quality and validation summary:
+
+- Red phase: targeted tests failed with `ModuleNotFoundError` for the new
+  comparison-report helper.
+- Green phase: benchmark-specific unit and behavioural tests passed.
+- Final gates passed:
+  - `make fmt`
+  - `make check-fmt`
+  - `make typecheck`
+  - `make lint`
+  - `make test`
+  - `make markdownlint`
+  - `make nixie`
 
 ## Context and orientation
 

--- a/docs/execplans/4-4-4-benchmark-comparison-report.md
+++ b/docs/execplans/4-4-4-benchmark-comparison-report.md
@@ -11,9 +11,9 @@ Roadmap reference: `docs/roadmap.md` item `4.4.4`.
 
 ## Purpose / big picture
 
-Roadmap item `4.4.4` requires the benchmark CI flow to produce a human-readable
-comparison report for the Python and Rust stream backends and publish a summary
-table to the GitHub Actions workflow summary.
+Roadmap item `4.4.4` requires the benchmark continuous integration (CI) flow to
+produce a human-readable comparison report for the Python and Rust stream
+backends and publish a summary table to the GitHub Actions workflow summary.
 
 After this work, a maintainer opening a pull request or inspecting a `main`
 workflow run can read the workflow summary and immediately see how the current
@@ -115,8 +115,8 @@ This task is complete only when:
 ## Progress
 
 - [x] (2026-03-08 00:00Z) Reviewed roadmap item `4.4.4`, the completed
-  `4.4.3` benchmark-ratchet implementation, the benchmark ADR, and repository
-  documentation/testing constraints.
+  `4.4.3` benchmark-ratchet implementation, the benchmark architecture decision
+  record (ADR), and repository documentation/testing constraints.
 - [x] (2026-03-08 00:10Z) Drafted this ExecPlan for roadmap item `4.4.4`.
 - [x] (2026-03-12 23:14Z) Stage A: added fail-first unit and behavioural tests
   for Python-versus-Rust report generation and workflow-summary Markdown
@@ -452,5 +452,4 @@ The implementing agent should capture concise evidence showing:
 
 ## Approval gate
 
-This document is the draft phase only. Do not start implementation until the
-user explicitly approves this ExecPlan or requests revisions.
+Implementation complete. All objectives met and quality gates passed.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -169,7 +169,7 @@ scenarios whilst maintaining pure Python as a first-class pathway.
 - [x] 4.4.3. Add a CI job that runs benchmarks on pull requests and main branch
   pushes; store results as JSON artefacts and fail if the Rust pathway
   regresses beyond a 10% threshold.
-- [ ] 4.4.4. Generate benchmark comparison report (Python vs Rust) and publish a
+- [x] 4.4.4. Generate benchmark comparison report (Python vs Rust) and publish a
   summary table to the GitHub Actions workflow summary.
 
 ### 4.5. Documentation

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1132,13 +1132,33 @@ The continuous integration (CI) workflows run the following checks:
   - It benchmarks the current checkout in smoke mode.
   - It compares Rust means against the latest successful `main` baseline
     artefact when one exists.
-  - It uploads candidate JSON artefacts plus `ratchet-report.json`.
+  - It generates a Python-versus-Rust comparison report from the candidate
+    smoke artefacts and appends the same Markdown table to the GitHub Actions
+    workflow summary.
+  - It uploads candidate JSON artefacts plus `ratchet-report.json` and
+    `comparison-report.json`.
   - On pushes to `main`, it also publishes the new smoke benchmark JSON as the
     next baseline artefact for future runs.
   - If no previous `main` baseline exists yet, it records a bootstrap skip
     report instead of failing the workflow.
   - It fails when any Rust scenario has
     `(candidate_mean - baseline_mean) / baseline_mean > 0.10`.
+
+The workflow summary table is derived from the filtered candidate smoke plan
+and throughput JSON. Rows are matched by the shared scenario label
+(`small-single-nocb`, `small-single-cb`, and so on) and include:
+
+- Python mean runtime in seconds
+- Rust mean runtime in seconds
+- speedup ratio `python_mean / rust_mean`
+- faster backend (`python`, `rust`, or `tie`)
+
+Interpretation:
+
+- `2.00x` means the Python run took twice as long as the Rust run, so Rust was
+  faster.
+- `1.00x` means the two backends were effectively tied for that scenario.
+- `0.80x` means Python was faster for that scenario.
 
 - Pure Python wheel:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1132,6 +1132,8 @@ The continuous integration (CI) workflows run the following checks:
   - It benchmarks the current checkout in smoke mode.
   - It compares Rust means against the latest successful `main` baseline
     artefact when one exists.
+  - Its baseline fetch helper follows GitHub’s signed archive redirects
+    without forwarding GitHub-only authentication headers to the storage host.
   - It generates a Python-versus-Rust comparison report from the candidate
     smoke artefacts and appends the same Markdown table to the GitHub Actions
     workflow summary.

--- a/tests/behaviour/test_benchmark_comparison_report_behaviour.py
+++ b/tests/behaviour/test_benchmark_comparison_report_behaviour.py
@@ -1,0 +1,237 @@
+"""Behavioural tests for benchmark comparison report CLI output."""
+
+from __future__ import annotations
+
+import json
+import subprocess  # noqa: S404 - behavioural test intentionally invokes CLI process
+import sys
+import typing as typ
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+if typ.TYPE_CHECKING:
+    import pathlib as pth
+
+
+class FixtureBundle(typ.TypedDict):
+    """Typed fixture bundle for one comparison-report CLI invocation."""
+
+    candidate_plan_path: pth.Path
+    candidate_throughput_path: pth.Path
+    ratchet_report_path: pth.Path
+    output_json_path: pth.Path
+    output_markdown_path: pth.Path
+
+
+class CliResult(typ.TypedDict):
+    """Typed CLI result payload."""
+
+    completed: subprocess.CompletedProcess[str]
+    output_json_path: pth.Path
+    output_markdown_path: pth.Path
+
+
+@scenario(
+    "../features/benchmark_comparison_report.feature",
+    "Generate a benchmark comparison report and markdown summary",
+)
+def test_generate_benchmark_comparison_report() -> None:
+    """CLI should produce JSON and Markdown for valid paired benchmark data."""
+
+
+@scenario(
+    "../features/benchmark_comparison_report.feature",
+    "Reject malformed benchmark comparison artefacts",
+)
+def test_reject_malformed_benchmark_comparison_report() -> None:
+    """CLI should fail for malformed or unpaired benchmark data."""
+
+
+def _scenario_payload(
+    *,
+    name: str,
+    backend: str,
+    with_line_callbacks: bool = False,
+) -> dict[str, object]:
+    """Create one benchmark scenario payload."""
+    return {
+        "name": name,
+        "backend": backend,
+        "payload_bytes": 1024,
+        "stages": 2,
+        "with_line_callbacks": with_line_callbacks,
+    }
+
+
+def _write_json(path: pth.Path, payload: dict[str, object]) -> None:
+    """Write one JSON payload."""
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _prepare_fixture_bundle(
+    *,
+    tmp_path: pth.Path,
+    malformed: bool,
+) -> FixtureBundle:
+    """Create CLI fixtures for valid or malformed benchmark comparison data."""
+    candidate_plan_path = tmp_path / "candidate-plan.json"
+    candidate_throughput_path = tmp_path / "candidate-throughput.json"
+    ratchet_report_path = tmp_path / "ratchet-report.json"
+    output_json_path = tmp_path / "comparison-report.json"
+    output_markdown_path = tmp_path / "comparison-summary.md"
+
+    scenarios: list[dict[str, object]] = [
+        _scenario_payload(name="python-small-single-nocb", backend="python"),
+        _scenario_payload(name="rust-small-single-nocb", backend="rust"),
+    ]
+    results: list[dict[str, object]] = [
+        {"command": "python-small-single-nocb", "mean": 0.42},
+        {"command": "rust-small-single-nocb", "mean": 0.21},
+    ]
+
+    if malformed:
+        scenarios.pop()
+        results.pop()
+
+    _write_json(
+        candidate_plan_path,
+        {
+            "dry_run": True,
+            "rust_available": True,
+            "command": ["hyperfine", "placeholder"],
+            "scenarios": scenarios,
+        },
+    )
+    _write_json(candidate_throughput_path, {"results": results})
+    _write_json(
+        ratchet_report_path,
+        {
+            "baseline_available": False,
+            "comparison_performed": False,
+            "passed": True,
+            "reason": "no_previous_main_benchmark_baseline",
+        },
+    )
+
+    return {
+        "candidate_plan_path": candidate_plan_path,
+        "candidate_throughput_path": candidate_throughput_path,
+        "ratchet_report_path": ratchet_report_path,
+        "output_json_path": output_json_path,
+        "output_markdown_path": output_markdown_path,
+    }
+
+
+@given(
+    "paired candidate benchmark artefacts",
+    target_fixture="comparison_fixture_bundle",
+)
+def given_paired_candidate_benchmark_artefacts(
+    tmp_path: pth.Path,
+) -> FixtureBundle:
+    """Create valid benchmark comparison inputs."""
+    return _prepare_fixture_bundle(tmp_path=tmp_path, malformed=False)
+
+
+@given(
+    "malformed candidate benchmark artefacts",
+    target_fixture="comparison_fixture_bundle",
+)
+def given_malformed_candidate_benchmark_artefacts(
+    tmp_path: pth.Path,
+) -> FixtureBundle:
+    """Create malformed benchmark comparison inputs."""
+    return _prepare_fixture_bundle(tmp_path=tmp_path, malformed=True)
+
+
+@when(
+    "I run the benchmark comparison report CLI",
+    target_fixture="comparison_cli_result",
+)
+def when_run_benchmark_comparison_report_cli(
+    comparison_fixture_bundle: FixtureBundle,
+) -> CliResult:
+    """Execute the benchmark comparison-report CLI."""
+    command = [
+        sys.executable,
+        "benchmarks/python_vs_rust_comparison_report.py",
+        "--plan",
+        str(comparison_fixture_bundle["candidate_plan_path"]),
+        "--throughput",
+        str(comparison_fixture_bundle["candidate_throughput_path"]),
+        "--ratchet-report",
+        str(comparison_fixture_bundle["ratchet_report_path"]),
+        "--output-json",
+        str(comparison_fixture_bundle["output_json_path"]),
+        "--output-markdown",
+        str(comparison_fixture_bundle["output_markdown_path"]),
+    ]
+    completed = subprocess.run(  # noqa: S603 - fixed test command
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return {
+        "completed": completed,
+        "output_json_path": comparison_fixture_bundle["output_json_path"],
+        "output_markdown_path": comparison_fixture_bundle["output_markdown_path"],
+    }
+
+
+def _assert_returncode(comparison_cli_result: CliResult, *, expected: int) -> None:
+    """Assert the CLI return code and include stdout/stderr on failure."""
+    completed = comparison_cli_result["completed"]
+    assert completed.returncode == expected, (
+        f"expected comparison report CLI to exit with code {expected}, got "
+        f"{completed.returncode}:\nstdout={completed.stdout}\nstderr={completed.stderr}"
+    )
+
+
+@then("the comparison report command exits successfully")
+def then_comparison_report_command_exits_successfully(
+    comparison_cli_result: CliResult,
+) -> None:
+    """Successful comparison-report CLI runs should exit zero."""
+    _assert_returncode(comparison_cli_result, expected=0)
+
+
+@then("the comparison report command exits with malformed-input failure")
+def then_comparison_report_command_exits_with_malformed_input_failure(
+    comparison_cli_result: CliResult,
+) -> None:
+    """Malformed comparison-report CLI runs should exit two."""
+    _assert_returncode(comparison_cli_result, expected=2)
+
+
+@then("the comparison report JSON contains paired backend rows")
+def then_comparison_report_json_contains_paired_backend_rows(
+    comparison_cli_result: CliResult,
+) -> None:
+    """JSON output should contain one paired Python/Rust comparison row."""
+    payload = json.loads(
+        comparison_cli_result["output_json_path"].read_text(encoding="utf-8")
+    )
+    assert payload["summary"]["row_count"] == 1, "expected exactly one comparison row"
+    row = payload["rows"][0]
+    assert row["comparison_id"] == "small-single-nocb"
+    assert row["python_mean"] == pytest.approx(0.42)
+    assert row["rust_mean"] == pytest.approx(0.21)
+    assert row["faster_backend"] == "rust"
+
+
+@then("the comparison summary markdown contains a workflow table")
+def then_comparison_summary_markdown_contains_a_workflow_table(
+    comparison_cli_result: CliResult,
+) -> None:
+    """Markdown output should be ready for `$GITHUB_STEP_SUMMARY`."""
+    markdown = comparison_cli_result["output_markdown_path"].read_text(encoding="utf-8")
+    assert "## Python vs Rust benchmark comparison" in markdown
+    assert "Rust regression ratchet skipped" in markdown
+    assert (
+        "| Scenario | Python mean (s) | Rust mean (s) | Speedup | Faster backend |"
+        in markdown
+    )
+    assert "| `small-single-nocb` | 0.420000 | 0.210000 | 2.00x | rust |" in markdown

--- a/tests/behaviour/test_benchmark_comparison_report_behaviour.py
+++ b/tests/behaviour/test_benchmark_comparison_report_behaviour.py
@@ -52,15 +52,19 @@ def _scenario_payload(
     *,
     name: str,
     backend: str,
-    with_line_callbacks: bool = False,
+    **overrides: object,
 ) -> dict[str, object]:
     """Create one benchmark scenario payload."""
+    defaults: dict[str, object] = {
+        "payload_bytes": 1024,
+        "stages": 2,
+        "with_line_callbacks": False,
+    }
     return {
         "name": name,
         "backend": backend,
-        "payload_bytes": 1024,
-        "stages": 2,
-        "with_line_callbacks": with_line_callbacks,
+        **defaults,
+        **overrides,
     }
 
 

--- a/tests/behaviour/test_benchmark_comparison_report_behaviour.py
+++ b/tests/behaviour/test_benchmark_comparison_report_behaviour.py
@@ -204,6 +204,8 @@ def then_comparison_report_command_exits_with_malformed_input_failure(
 ) -> None:
     """Malformed comparison-report CLI runs should exit two."""
     _assert_returncode(comparison_cli_result, expected=2)
+    completed = comparison_cli_result["completed"]
+    assert "benchmark comparison report failed to evaluate inputs" in completed.stderr
 
 
 @then("the comparison report JSON contains paired backend rows")

--- a/tests/features/benchmark_comparison_report.feature
+++ b/tests/features/benchmark_comparison_report.feature
@@ -1,0 +1,16 @@
+Feature: Benchmark comparison report
+  Maintainers can generate a Python-versus-Rust comparison report from the
+  candidate smoke benchmark artefacts and publish the same summary text to the
+  GitHub Actions workflow summary.
+
+  Scenario: Generate a benchmark comparison report and markdown summary
+    Given paired candidate benchmark artefacts
+    When I run the benchmark comparison report CLI
+    Then the comparison report command exits successfully
+    And the comparison report JSON contains paired backend rows
+    And the comparison summary markdown contains a workflow table
+
+  Scenario: Reject malformed benchmark comparison artefacts
+    Given malformed candidate benchmark artefacts
+    When I run the benchmark comparison report CLI
+    Then the comparison report command exits with malformed-input failure


### PR DESCRIPTION
## Summary
- Adds a Python-vs-Rust benchmark comparison report generator (Counter-based) integrated into CI, including unit/behavioural tests and docs, plus automation to render a Markdown workflow summary. Also fixes a CI artefact download issue by stripping GitHub-specific headers on cross-origin redirects to avoid authentication failures, with tests validating the change.

## Changes
### New
- benchmarks/python_vs_rust_comparison_report.py
- cuprum/unittests/test_benchmark_comparison_report.py
- tests/behaviour/test_benchmark_comparison_report_behaviour.py
- tests/features/benchmark_comparison_report.feature
- docs/cuprum-design.md and docs/roadmap.md updated to reflect the refactor and reporting artefacts.
- docs/execplans/4-4-4-benchmark-comparison-report.md added
- docs/users-guide.md updated to describe the workflow summary generation and how to interpret the speedup metrics.
- CI pipeline updated (.github/workflows/ci.yml) to generate and publish the Python-vs-Rust comparison report and summary (comparison-report.json and comparison-summary.md).
- benchmarks/fetch_main_benchmark_baseline.py updated with _ArtifactArchiveRedirectHandler to strip Authorization and related headers during cross-origin redirects, ensuring CI artefact downloads do not trip on authentication headers.

### CI and runtime fixes
- Refactor _strip_cross_origin_headers in _ArtifactArchiveRedirectHandler to remove a nested loop and streamline header-stripping logic. This ensures cross-origin redirects do not forward sensitive GitHub headers while keeping the same effective behaviour.
- CI workflow extended to run the new comparison-report generation and to publish artefacts and summary.
- The artefact fetch helper handles cross-origin redirects without forwarding sensitive GitHub authentication headers.

### Documentation and planning artefacts
- Updated docs/cuprum-design.md to describe the Python-vs-Rust report and cross-origin redirect handling in CI fetches.
- Updated docs/users-guide.md to document the new report generation and summary surface in CI.
- docs/roadmap.md updated to mark 4.4.4 progress as complete.
- ExecPlan doc (docs/execplans/4-4-4-benchmark-comparison-report.md) added to reflect current plan and implementation status.

### Tests
- Unit tests for the new reporter module and comparison logic added in cuprum/unittests/test_benchmark_comparison_report.py.
- Behavioural tests and a Gherkin feature added under tests/behaviour and tests/features to validate CLI usage and workflow summary output.
- CI integration tests updated to cover the new reporting artefacts.

## Rationale
- The Python-vs-Rust report generation now uses a Counter-based aggregation to tally outcomes, providing deterministic, testable results and a clean JSON+Markdown output for CI visibility.
- The CI artefact fetch fix prevents cross-origin redirects from propagating sensitive authentication headers, avoiding 401s during artefact download and stabilising the CI workflow.

## Testing plan (now implemented)
- Unit tests for the new Python-versus-Rust comparison reporter module and the comparison logic exist in cuprum/unittests/test_benchmark_comparison_report.py.
- Behavioural tests and a Gherkin feature validate CLI usage and workflow summary output under tests/behaviour and tests/features.
- CI is extended to run the reporter, generate comparison-report.json and comparison-summary.md, and append the Markdown table to the workflow summary.

## Documentation impact
- ExecPlan document (4-4-4) updated to reflect the refactor and the new reporting artefacts.
- docs/cuprum-design.md and docs/users-guide.md updated; roadmap item 4.4.4 marked done.

## Acceptance criteria
- ExecPlan complete and guides implementation for 4.4.4.
- Python-vs-Rust report implemented, with JSON and Markdown outputs produced in CI.
- Unit and behavioural tests cover report generation, contract validation, and workflow-facing summary output.
- Documentation updates describing the report and workflow summary behaviour.
- No runtime-breaking changes introduced at this stage.

## Notes
- This PR contains both the planning artefact and the implemented reporter, tests, and CI integration. Further iteration may be needed as testing reveals edge cases.

📎 **Task**: https://www.devboxer.com/task/c9363ba6-fefa-47d4-b233-0d66386d602a

📎 **Task**: https://www.devboxer.com/task/230efaa1-7e21-4308-bb59-da3621445a05

📎 **Task**: https://www.devboxer.com/task/5d014fd0-27fb-4311-a972-3119179338a8