### PR TITLE
Pin cross-compilation container digest (#26)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -85,7 +85,7 @@ jobs:
           maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
+          container: ghcr.io/rust-cross/manylinux_2_28-cross@sha256:4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e # aarch64
           command: build
           args: >-
             --release --out wheelhouse --manifest-path rust/cuprum-rust/Cargo.toml

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -10,7 +10,7 @@ on:
 env:
   # Keep in sync with .github/actions/build-wheels/action.yml and pyproject.toml.
   MATURIN_VERSION: "1.13.3"
-  MANYLINUX_AARCH64_CONTAINER: ghcr.io/rust-cross/manylinux_2_28-cross@sha256:4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e # aarch64
+  MANYLINUX_AARCH64_CONTAINER: ghcr.io/rust-cross/manylinux_2_28-cross@sha256:4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e # ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
 
 jobs:
   build-pure-wheel:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -10,6 +10,7 @@ on:
 env:
   # Keep in sync with .github/actions/build-wheels/action.yml and pyproject.toml.
   MATURIN_VERSION: "1.13.3"
+  MANYLINUX_AARCH64_CONTAINER: ghcr.io/rust-cross/manylinux_2_28-cross@sha256:4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e # aarch64
 
 jobs:
   build-pure-wheel:
@@ -85,7 +86,7 @@ jobs:
           maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          container: ghcr.io/rust-cross/manylinux_2_28-cross@sha256:4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e # aarch64
+          container: ${{ env.MANYLINUX_AARCH64_CONTAINER }}
           command: build
           args: >-
             --release --out wheelhouse --manifest-path rust/cuprum-rust/Cargo.toml

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -68,6 +68,7 @@
       'cuprum/unittests/test_folded_summary.py',
       'cuprum/unittests/test_line_splitting.py',
       'cuprum/unittests/test_logging_hook.py',
+      'cuprum/unittests/test_manylinux_container_ref_properties.py',
       'cuprum/unittests/test_maturin_build.py',
       'cuprum/unittests/test_observe.py',
       'cuprum/unittests/test_performance_guidance_docs.py',

--- a/cuprum/unittests/test_manylinux_container_ref_properties.py
+++ b/cuprum/unittests/test_manylinux_container_ref_properties.py
@@ -1,0 +1,43 @@
+"""Property tests for manylinux container reference pinning."""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from cuprum.unittests.test_maturin_build import _MANYLINUX_CONTAINER_SHA256_RE
+
+_MANYLINUX_IMAGE = "ghcr.io/rust-cross/manylinux_2_28-cross"
+
+settings.register_profile("manylinux-container-ref", max_examples=200)
+settings.load_profile("manylinux-container-ref")
+
+
+@given(digest=st.binary(min_size=32, max_size=32))
+def test_valid_sha256_ref_always_matches(digest: bytes) -> None:
+    """Every 32-byte digest hex encoding produces a valid pinned ref."""
+    container_ref = f"{_MANYLINUX_IMAGE}@sha256:{digest.hex()}"
+
+    assert _MANYLINUX_CONTAINER_SHA256_RE.fullmatch(container_ref)
+
+
+@given(
+    tag=st.text(
+        alphabet=st.characters(blacklist_categories=("Cs",)),
+        min_size=1,
+        max_size=50,
+    )
+)
+def test_mutable_tag_never_matches(tag: str) -> None:
+    """Mutable tag references never satisfy the pinned ref regex."""
+    container_ref = f"{_MANYLINUX_IMAGE}:{tag}"
+
+    assert _MANYLINUX_CONTAINER_SHA256_RE.fullmatch(container_ref) is None
+
+
+@given(digest_length=st.integers(min_value=0, max_value=63))
+def test_truncated_digest_never_matches(digest_length: int) -> None:
+    """Truncated SHA-256 digest references never satisfy the pinned ref regex."""
+    container_ref = f"{_MANYLINUX_IMAGE}@sha256:{'a' * digest_length}"
+
+    assert _MANYLINUX_CONTAINER_SHA256_RE.fullmatch(container_ref) is None

--- a/cuprum/unittests/test_maturin_build.py
+++ b/cuprum/unittests/test_maturin_build.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.metadata as im
+import re
 import shutil
 import sys
 import typing as typ
@@ -13,15 +14,22 @@ from tests.helpers.docs import repo_root
 from tests.helpers.maturin import (
     build_native_wheel_artifact,
     read_expected_maturin_version,
+    read_manylinux_aarch64_container_ref,
     read_maturin_pins,
     toolchain_available,
     wheel_build_snapshot,
+    workflow_uses_manylinux_aarch64_container_ref,
 )
 
 if typ.TYPE_CHECKING:
     import pathlib as pth
 
     from syrupy.assertion import SnapshotAssertion
+
+
+_MANYLINUX_CONTAINER_SHA256_RE = re.compile(
+    r"^ghcr\.io/rust-cross/manylinux_2_28-cross@sha256:[0-9a-f]{64}$"
+)
 
 
 def test_maturin_pins_are_synchronized() -> None:
@@ -38,6 +46,21 @@ def test_installed_maturin_matches_expected_pin() -> None:
     installed = im.version("maturin")
     assert installed == expected, (
         f"Expected maturin {expected}, but {installed} is installed"
+    )
+
+
+def test_manylinux_aarch64_container_is_pinned_to_sha256() -> None:
+    """Aarch64 manylinux container pin must be immutable."""
+    container_ref = read_manylinux_aarch64_container_ref(repo_root())
+    assert _MANYLINUX_CONTAINER_SHA256_RE.fullmatch(container_ref), (
+        f"Expected SHA-256 pinned container ref, found {container_ref!r}"
+    )
+
+
+def test_manylinux_aarch64_container_is_referenced_by_build_step() -> None:
+    """The build job should consume the pinned aarch64 container variable."""
+    assert workflow_uses_manylinux_aarch64_container_ref(repo_root()), (
+        "Expected build-wheels.yml to reference env.MANYLINUX_AARCH64_CONTAINER"
     )
 
 

--- a/cuprum/unittests/test_maturin_build.py
+++ b/cuprum/unittests/test_maturin_build.py
@@ -12,6 +12,8 @@ import pytest
 
 from tests.helpers.docs import repo_root
 from tests.helpers.maturin import (
+    _AARCH64_CONTAINER_PIN_RE,
+    _AARCH64_CONTAINER_USAGE_RE,
     build_native_wheel_artifact,
     read_expected_maturin_version,
     read_manylinux_aarch64_container_ref,
@@ -62,6 +64,45 @@ def test_manylinux_aarch64_container_is_referenced_by_build_step() -> None:
     assert workflow_uses_manylinux_aarch64_container_ref(repo_root()), (
         "Expected build-wheels.yml to reference env.MANYLINUX_AARCH64_CONTAINER"
     )
+
+
+@pytest.mark.parametrize(
+    "container_ref",
+    [
+        "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64",
+        "ghcr.io/rust-cross/manylinux_2_28-cross:latest",
+        "ghcr.io/rust-cross/manylinux_2_28-cross@sha256:tooshort",
+        "ghcr.io/rust-cross/manylinux_2_28-cross@sha256:" + "g" * 64,
+        "",
+    ],
+)
+def test_manylinux_aarch64_container_ref_rejects_mutable_tag(
+    container_ref: str,
+) -> None:
+    """Aarch64 manylinux container refs reject mutable or invalid pins."""
+    assert _MANYLINUX_CONTAINER_SHA256_RE.fullmatch(container_ref) is None
+
+
+def test_manylinux_aarch64_container_pin_regex_rejects_missing_comment() -> None:
+    """Aarch64 manylinux container pins require the source-tag comment."""
+    yaml_line = (
+        "MANYLINUX_AARCH64_CONTAINER: "
+        "ghcr.io/rust-cross/manylinux_2_28-cross@sha256:"
+        "4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e"
+    )
+
+    assert _AARCH64_CONTAINER_PIN_RE.search(yaml_line) is None
+
+
+def test_manylinux_aarch64_container_usage_regex_rejects_literal_image() -> None:
+    """Aarch64 manylinux container usage requires the pinned env variable."""
+    yaml_line = (
+        "        container: "
+        "ghcr.io/rust-cross/manylinux_2_28-cross@sha256:"
+        "4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e"
+    )
+
+    assert _AARCH64_CONTAINER_USAGE_RE.search(yaml_line) is None
 
 
 # pytest-timeout arms SIGALRM in the *parent* process; pytest-forked blocks the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -627,7 +627,7 @@ in step.
 (`test_manylinux_aarch64_container_is_pinned_to_sha256` and
 `test_manylinux_aarch64_container_is_referenced_by_build_step`) Asserts that
 `MANYLINUX_AARCH64_CONTAINER` in `.github/workflows/build-wheels.yml` is pinned
-to a SHA-256 digest and that `build-wheels.yml` uses the pinned variable in
+to an SHA-256 digest and that `build-wheels.yml` uses the pinned variable in
 the Linux aarch64 maturin build step.
 
 When refreshing this container, update the value in

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -623,6 +623,28 @@ maturin version declared in `pyproject.toml`,
 maturin pin, update all three locations and run this test to confirm they are
 in step.
 
+**Aarch64 manylinux container pin**
+(`test_manylinux_aarch64_container_is_pinned_to_sha256` and
+`test_manylinux_aarch64_container_is_referenced_by_build_step`) Asserts that
+`MANYLINUX_AARCH64_CONTAINER` in `.github/workflows/build-wheels.yml` is pinned
+to a SHA-256 digest and that `build-wheels.yml` uses the pinned variable in
+the Linux aarch64 maturin build step.
+
+When refreshing this container, update the value in
+`MANYLINUX_AARCH64_CONTAINER` to
+`ghcr.io/rust-cross/manylinux_2_28-cross@sha256:<digest>` and keep the inline
+comment to the original mutable reference:
+`# ghcr.io/rust-cross/manylinux_2_28-cross:aarch64`.
+
+To update the pinned digest, resolve the tag digest for
+`ghcr.io/rust-cross/manylinux_2_28-cross:aarch64`, replace only the value in
+`MANYLINUX_AARCH64_CONTAINER`, and rerun:
+
+```bash
+uv run pytest cuprum/unittests/test_maturin_build.py \
+    -k "manylinux_aarch64_container"
+```
+
 **Installed version check** (`test_installed_maturin_matches_expected_pin`)
 Skipped automatically when `maturin` is not on `PATH`. When it is present,
 asserts that the installed version matches the pinned development dependency.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -636,6 +636,12 @@ When refreshing this container, update the value in
 comment to the original mutable reference:
 `# ghcr.io/rust-cross/manylinux_2_28-cross:aarch64`.
 
+The deterministic tests assert that the live workflow value is correctly
+formed and consumed by the aarch64 build step. The property-based tests prove
+that the shared regex accepts every valid 64-character hexadecimal digest and
+rejects the unbounded space of mutable tags and truncated digests, giving
+confidence beyond any single example.
+
 To update the pinned digest, resolve the tag digest for
 `ghcr.io/rust-cross/manylinux_2_28-cross:aarch64`, replace only the value in
 `MANYLINUX_AARCH64_CONTAINER`, and rerun:

--- a/tests/helpers/maturin.py
+++ b/tests/helpers/maturin.py
@@ -104,7 +104,29 @@ def read_maturin_pins(root: Path) -> dict[str, str]:
 
 
 def read_manylinux_aarch64_container_ref(root: Path) -> str:
-    """Read the pinned manylinux aarch64 container reference."""
+    """Read the pinned manylinux aarch64 container reference.
+
+    Parameters
+    ----------
+    root
+        Repository root containing ``.github/workflows/build-wheels.yml``.
+
+    Returns
+    -------
+    str
+        The pinned ``MANYLINUX_AARCH64_CONTAINER`` image reference.
+
+    Raises
+    ------
+    AssertionError
+        If the ``MANYLINUX_AARCH64_CONTAINER`` pin is missing.
+    FileNotFoundError
+        If ``.github/workflows/build-wheels.yml`` is absent.
+    OSError
+        If ``.github/workflows/build-wheels.yml`` cannot be read.
+    UnicodeDecodeError
+        If ``.github/workflows/build-wheels.yml`` is not valid UTF-8.
+    """
     workflow = (root / ".github/workflows/build-wheels.yml").read_text(encoding="utf-8")
     return _require_pin_match(
         _AARCH64_CONTAINER_PIN_RE.search(workflow),
@@ -114,7 +136,28 @@ def read_manylinux_aarch64_container_ref(root: Path) -> str:
 
 
 def workflow_uses_manylinux_aarch64_container_ref(root: Path) -> bool:
-    """Report whether the workflow references the pinned manylinux container."""
+    """Report whether the workflow references the pinned manylinux container.
+
+    Parameters
+    ----------
+    root
+        Repository root containing ``.github/workflows/build-wheels.yml``.
+
+    Returns
+    -------
+    bool
+        ``True`` when the Linux aarch64 build step uses
+        ``env.MANYLINUX_AARCH64_CONTAINER``; otherwise ``False``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``.github/workflows/build-wheels.yml`` is absent.
+    OSError
+        If ``.github/workflows/build-wheels.yml`` cannot be read.
+    UnicodeDecodeError
+        If ``.github/workflows/build-wheels.yml`` is not valid UTF-8.
+    """
     workflow = (root / ".github/workflows/build-wheels.yml").read_text(encoding="utf-8")
     return _AARCH64_CONTAINER_USAGE_RE.search(workflow) is not None
 

--- a/tests/helpers/maturin.py
+++ b/tests/helpers/maturin.py
@@ -16,9 +16,13 @@ if typ.TYPE_CHECKING:
 _MATURIN_PIN_RE = re.compile(r"maturin==(\d+\.\d+\.\d+)")
 _WORKFLOW_PIN_RE = re.compile(r'MATURIN_VERSION:\s*"(\d+\.\d+\.\d+)"')
 _ACTION_PIN_RE = re.compile(r'default:\s*"(\d+\.\d+\.\d+)"')
-_AARCH64_CONTAINER_PIN_RE = re.compile(r"MANYLINUX_AARCH64_CONTAINER:\s*([^\s#]+)")
+_AARCH64_CONTAINER_PIN_RE = re.compile(
+    r"^\s*MANYLINUX_AARCH64_CONTAINER:\s*([^\s#]+)(?:\s+#.*)?$",
+    re.MULTILINE,
+)
 _AARCH64_CONTAINER_USAGE_RE = re.compile(
-    r"container:\s*\$\{\{\s*env\.MANYLINUX_AARCH64_CONTAINER\s*\}\}"
+    r"^\s*container:\s*\$\{\{\s*env\.MANYLINUX_AARCH64_CONTAINER\s*\}\}\s*$",
+    re.MULTILINE,
 )
 _GENERATOR_RE = re.compile(r"^Generator:\s*maturin\s*\(([^)]+)\)\s*$", re.MULTILINE)
 _EXTENSION_MODULE_RE = re.compile(

--- a/tests/helpers/maturin.py
+++ b/tests/helpers/maturin.py
@@ -54,10 +54,15 @@ def read_expected_maturin_version(root: Path) -> str:
     return match.group(1)
 
 
-def _require_pin_match(match: re.Match[str] | None, location: str) -> str:
+def _require_pin_match(
+    match: re.Match[str] | None,
+    location: str,
+    *,
+    subject: str = "maturin version pin",
+) -> str:
     """Extract a version from a regex match or raise AssertionError with location."""
     if match is None:
-        msg = f"Could not locate maturin version pin in {location}"
+        msg = f"Could not locate {subject} in {location}"
         raise AssertionError(msg)
     return match.group(1)
 
@@ -104,6 +109,7 @@ def read_manylinux_aarch64_container_ref(root: Path) -> str:
     return _require_pin_match(
         _AARCH64_CONTAINER_PIN_RE.search(workflow),
         ".github/workflows/build-wheels.yml",
+        subject="MANYLINUX_AARCH64_CONTAINER pin",
     )
 
 

--- a/tests/helpers/maturin.py
+++ b/tests/helpers/maturin.py
@@ -16,6 +16,10 @@ if typ.TYPE_CHECKING:
 _MATURIN_PIN_RE = re.compile(r"maturin==(\d+\.\d+\.\d+)")
 _WORKFLOW_PIN_RE = re.compile(r'MATURIN_VERSION:\s*"(\d+\.\d+\.\d+)"')
 _ACTION_PIN_RE = re.compile(r'default:\s*"(\d+\.\d+\.\d+)"')
+_AARCH64_CONTAINER_PIN_RE = re.compile(r"MANYLINUX_AARCH64_CONTAINER:\s*([^\s#]+)")
+_AARCH64_CONTAINER_USAGE_RE = re.compile(
+    r"container:\s*\$\{\{\s*env\.MANYLINUX_AARCH64_CONTAINER\s*\}\}"
+)
 _GENERATOR_RE = re.compile(r"^Generator:\s*maturin\s*\(([^)]+)\)\s*$", re.MULTILINE)
 _EXTENSION_MODULE_RE = re.compile(
     r"^cuprum/_rust_backend_native\.cpython-[^/]+\.so$",
@@ -92,6 +96,21 @@ def read_maturin_pins(root: Path) -> dict[str, str]:
             ".github/actions/build-wheels/action.yml",
         ),
     }
+
+
+def read_manylinux_aarch64_container_ref(root: Path) -> str:
+    """Read the pinned manylinux aarch64 container reference."""
+    workflow = (root / ".github/workflows/build-wheels.yml").read_text(encoding="utf-8")
+    return _require_pin_match(
+        _AARCH64_CONTAINER_PIN_RE.search(workflow),
+        ".github/workflows/build-wheels.yml",
+    )
+
+
+def workflow_uses_manylinux_aarch64_container_ref(root: Path) -> bool:
+    """Report whether the workflow references the pinned manylinux container."""
+    workflow = (root / ".github/workflows/build-wheels.yml").read_text(encoding="utf-8")
+    return _AARCH64_CONTAINER_USAGE_RE.search(workflow) is not None
 
 
 def _maturin_module_available() -> bool:

--- a/tests/helpers/maturin.py
+++ b/tests/helpers/maturin.py
@@ -17,7 +17,7 @@ _MATURIN_PIN_RE = re.compile(r"maturin==(\d+\.\d+\.\d+)")
 _WORKFLOW_PIN_RE = re.compile(r'MATURIN_VERSION:\s*"(\d+\.\d+\.\d+)"')
 _ACTION_PIN_RE = re.compile(r'default:\s*"(\d+\.\d+\.\d+)"')
 _AARCH64_CONTAINER_PIN_RE = re.compile(
-    r"^\s*MANYLINUX_AARCH64_CONTAINER:\s*([^\s#]+)(?:\s+#.*)?$",
+    r"^\s*MANYLINUX_AARCH64_CONTAINER:\s*([^\s#]+)\s+#\s*\S.*$",
     re.MULTILINE,
 )
 _AARCH64_CONTAINER_USAGE_RE = re.compile(


### PR DESCRIPTION
## Summary

This branch pins the Linux aarch64 manylinux cross-compilation container to the reviewed SHA256 digest instead of using the mutable `aarch64` tag. It keeps the original tag as an inline comment so future maintainers can identify the image variant when refreshing the digest.

Closes #26.

## Review walkthrough

- Start with [.github/workflows/build-wheels.yml](https://github.com/leynos/cuprum/blob/f2eff9a8e2c22829f1be89c0d21db2a1cce4cd5b/.github/workflows/build-wheels.yml#L87) to review the pinned container reference used by the aarch64 wheel build job.

## Validation

- `make all`: passed.

## Summary by Sourcery

CI:
- Update the build-wheels GitHub Actions workflow to use a digest-pinned aarch64 manylinux cross container image instead of a mutable tag.