### PR TITLE
Add context narrowing property tests (#66)

### DIFF
--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -173,6 +173,7 @@ def _validate_timeout(timeout: float | None, class_name: str) -> float | None:
         raise ValueError(msg)
     return timeout_float
 
+
 def _narrow_allowlist(
     parent: frozenset[Program],
     config: frozenset[Program] | None,
@@ -188,6 +189,7 @@ def _narrow_allowlist(
         return parent & config
     return config
 
+
 def _is_narrowed_allowlist_restricted(
     config: frozenset[Program] | None,
     *,
@@ -196,12 +198,14 @@ def _is_narrowed_allowlist_restricted(
     """Return whether a narrowed context has an active allowlist restriction."""
     return parent_is_restricted or config is not None
 
+
 def _merge_before_hooks(
     parent: tuple[BeforeHook, ...],
     config: tuple[BeforeHook, ...],
 ) -> tuple[BeforeHook, ...]:
     """Append scoped before hooks after parent hooks for FIFO execution."""
     return parent + config
+
 
 def _merge_after_hooks(
     parent: tuple[AfterHook, ...],
@@ -210,12 +214,14 @@ def _merge_after_hooks(
     """Prepend scoped after hooks before parent hooks for LIFO execution."""
     return config + parent
 
+
 def _merge_observe_hooks(
     parent: tuple[ExecHook, ...],
     config: tuple[ExecHook, ...],
 ) -> tuple[ExecHook, ...]:
     """Append scoped observe hooks after parent hooks for FIFO execution."""
     return parent + config
+
 
 def _resolve_narrowed_timeout(
     parent: float | None, config: float | None
@@ -224,6 +230,8 @@ def _resolve_narrowed_timeout(
     if config is None:
         return parent
     return config
+
+
 @dc.dataclass(frozen=True, slots=True)
 class ScopeConfig:
     """Configuration object for scoped execution context updates.

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -170,7 +170,57 @@ def _validate_timeout(timeout: float | None, class_name: str) -> float | None:
         raise ValueError(msg)
     return timeout_float
 
+def _narrow_allowlist(
+    parent: frozenset[Program],
+    config: frozenset[Program] | None,
+    *,
+    parent_is_restricted: bool = False,
+) -> frozenset[Program]:
+    """Return the allowlist produced by narrowing a parent context."""
+    if config is None:
+        return parent
+    if parent_is_restricted and not parent:
+        return parent
+    if parent:
+        return parent & config
+    return config
 
+def _is_narrowed_allowlist_restricted(
+    config: frozenset[Program] | None,
+    *,
+    parent_is_restricted: bool,
+) -> bool:
+    """Return whether a narrowed context has an active allowlist restriction."""
+    return parent_is_restricted or config is not None
+
+def _merge_before_hooks(
+    parent: tuple[BeforeHook, ...],
+    config: tuple[BeforeHook, ...],
+) -> tuple[BeforeHook, ...]:
+    """Append scoped before hooks after parent hooks for FIFO execution."""
+    return parent + config
+
+def _merge_after_hooks(
+    parent: tuple[AfterHook, ...],
+    config: tuple[AfterHook, ...],
+) -> tuple[AfterHook, ...]:
+    """Prepend scoped after hooks before parent hooks for LIFO execution."""
+    return config + parent
+
+def _merge_observe_hooks(
+    parent: tuple[ExecHook, ...],
+    config: tuple[ExecHook, ...],
+) -> tuple[ExecHook, ...]:
+    """Append scoped observe hooks after parent hooks for FIFO execution."""
+    return parent + config
+
+def _resolve_narrowed_timeout(
+    parent: float | None, config: float | None
+) -> float | None:
+    """Return the timeout inherited or overridden by a narrowed context."""
+    if config is None:
+        return parent
+    return config
 @dc.dataclass(frozen=True, slots=True)
 class ScopeConfig:
     """Configuration object for scoped execution context updates.
@@ -235,6 +285,9 @@ class CuprumContext:
         Optional immutable environment overlay layered over the live
         ``os.environ`` when command environments are resolved. When ``None``,
         no overlay is active on this context.
+    _allowlist_is_restricted:
+        Internal marker distinguishing the permissive empty default allowlist
+        from an empty allowlist produced by narrowing a restricted scope.
 
     """
 
@@ -244,6 +297,7 @@ class CuprumContext:
     observe_hooks: tuple[ExecHook, ...] = ()
     timeout: float | None = None
     env_overlay: cabc.Mapping[str, str] | None = None
+    _allowlist_is_restricted: bool = False
 
     def __post_init__(self) -> None:
         """Validate and coerce timeout after initialization."""
@@ -272,7 +326,7 @@ class CuprumContext:
         default). This allows gradual adoption: code can run without explicit
         context setup, and scoped(ScopeConfig()) can later establish restrictions.
         """
-        if not self.allowlist:
+        if not self.allowlist and not self._allowlist_is_restricted:
             return  # Empty allowlist permits all programs
         if not self.is_allowed(program):
             msg = f"Program '{program}' is not allowed in the current context"
@@ -299,29 +353,24 @@ class CuprumContext:
         add programs). This ensures safety while allowing initial setup.
 
         """
-        if config.allowlist is None:
-            new_allowlist = self.allowlist
-        elif self.allowlist:
-            # Parent has programs: intersect to narrow
-            new_allowlist = self.allowlist & config.allowlist
-        else:
-            # Parent is empty: use provided allowlist as new base
-            new_allowlist = config.allowlist
-
-        new_before = self.before_hooks + config.before_hooks
-        # After hooks run inner-to-outer, so prepend new hooks
-        new_after = config.after_hooks + self.after_hooks
-        new_observe = self.observe_hooks + config.observe_hooks
-        new_timeout = self.timeout if config.timeout is None else config.timeout
-        new_env_overlay = merge_env_overlays(self.env_overlay, config.env_overlay)
-
+        is_restricted = _is_narrowed_allowlist_restricted(
+            config.allowlist,
+            parent_is_restricted=self._allowlist_is_restricted,
+        )
         return CuprumContext(
-            allowlist=new_allowlist,
-            before_hooks=new_before,
-            after_hooks=new_after,
-            observe_hooks=new_observe,
-            timeout=new_timeout,
-            env_overlay=new_env_overlay,
+            allowlist=_narrow_allowlist(
+                self.allowlist,
+                config.allowlist,
+                parent_is_restricted=self._allowlist_is_restricted,
+            ),
+            before_hooks=_merge_before_hooks(self.before_hooks, config.before_hooks),
+            after_hooks=_merge_after_hooks(self.after_hooks, config.after_hooks),
+            observe_hooks=_merge_observe_hooks(
+                self.observe_hooks, config.observe_hooks
+            ),
+            timeout=_resolve_narrowed_timeout(self.timeout, config.timeout),
+            env_overlay=merge_env_overlays(self.env_overlay, config.env_overlay),
+            _allowlist_is_restricted=is_restricted,
         )
 
     def with_allowlist(self, allowlist: frozenset[Program]) -> CuprumContext:
@@ -330,7 +379,11 @@ class CuprumContext:
         Unlike narrow(), this sets the allowlist directly without intersection.
         Use with care; prefer narrow() for enforcing safety invariants.
         """
-        return dc.replace(self, allowlist=allowlist)
+        return dc.replace(
+            self,
+            allowlist=allowlist,
+            _allowlist_is_restricted=bool(allowlist),
+        )
 
     def with_before_hook(self, hook: BeforeHook) -> CuprumContext:
         """Return a context with an additional before hook."""

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -400,7 +400,8 @@ class CuprumContext:
             self,
             allowlist=allowlist,
             _allowlist_is_restricted=self._allowlist_is_restricted
-            or bool(self.allowlist),
+            or bool(self.allowlist)
+            or bool(allowlist),
         )
 
     def with_before_hook(self, hook: BeforeHook) -> CuprumContext:
@@ -432,11 +433,11 @@ class CuprumContext:
 
     def with_program(self, program: Program) -> CuprumContext:
         """Return a context with the program added to the allowlist."""
-        return dc.replace(self, allowlist=self.allowlist | {program})
+        return self.with_allowlist(self.allowlist | {program})
 
     def without_program(self, program: Program) -> CuprumContext:
         """Return a context with the program removed from the allowlist."""
-        return dc.replace(self, allowlist=self.allowlist - {program})
+        return self.with_allowlist(self.allowlist - {program})
 
     def with_env_overlay(
         self,

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -399,7 +399,8 @@ class CuprumContext:
         return dc.replace(
             self,
             allowlist=allowlist,
-            _allowlist_is_restricted=self._allowlist_is_restricted or bool(allowlist),
+            _allowlist_is_restricted=self._allowlist_is_restricted
+            or bool(self.allowlist),
         )
 
     def with_before_hook(self, hook: BeforeHook) -> CuprumContext:

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import dataclasses as dc
+import logging
 import os
 import typing as typ
 from contextvars import ContextVar, Token
@@ -58,6 +59,8 @@ from cuprum.events import ExecHook
 if typ.TYPE_CHECKING:
     from cuprum.program import Program
     from cuprum.sh import CommandResult, SafeCmd
+
+_logger = logging.getLogger(__name__)
 
 
 type BeforeHook = cabc.Callable[[SafeCmd], None]
@@ -330,6 +333,15 @@ class CuprumContext:
             return  # Empty allowlist permits all programs
         if not self.is_allowed(program):
             msg = f"Program '{program}' is not allowed in the current context"
+            _logger.warning(
+                "Program %s denied by context allowlist restricted_state=%s",
+                program,
+                self._allowlist_is_restricted,
+                extra={
+                    "operation": program,
+                    "restricted_state": self._allowlist_is_restricted,
+                },
+            )
             raise ForbiddenProgramError(msg)
 
     def narrow(self, config: ScopeConfig) -> CuprumContext:

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -322,9 +322,9 @@ class CuprumContext:
     def check_allowed(self, program: Program) -> None:
         """Raise ForbiddenProgramError if program is not allowed.
 
-        When the allowlist is empty, all programs are permitted (permissive
-        default). This allows gradual adoption: code can run without explicit
-        context setup, and scoped(ScopeConfig()) can later establish restrictions.
+        When the allowlist is empty and unrestricted, all programs are
+        permitted (permissive default). When the allowlist is empty and
+        restricted, all programs are denied.
         """
         if not self.allowlist and not self._allowlist_is_restricted:
             return  # Empty allowlist permits all programs
@@ -347,10 +347,11 @@ class CuprumContext:
 
         Notes
         -----
-        When the parent has an empty allowlist, the provided allowlist is used
-        directly to establish a base scope. When the parent has programs, the
-        new allowlist is intersected to enforce narrowing (can only remove, not
-        add programs). This ensures safety while allowing initial setup.
+        When the parent has an empty *unrestricted* allowlist, the provided
+        allowlist is used directly to establish a base scope. When the parent
+        is restricted and empty, narrowing keeps it empty. When the parent has
+        programs, the new allowlist is intersected to enforce narrowing (can
+        only remove, not add programs).
 
         """
         is_restricted = _is_narrowed_allowlist_restricted(

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -382,7 +382,7 @@ class CuprumContext:
         return dc.replace(
             self,
             allowlist=allowlist,
-            _allowlist_is_restricted=bool(allowlist),
+            _allowlist_is_restricted=self._allowlist_is_restricted or bool(allowlist),
         )
 
     def with_before_hook(self, hook: BeforeHook) -> CuprumContext:

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -316,9 +316,10 @@ class CuprumContext:
     def is_allowed(self, program: Program) -> bool:
         """Return True when the program is in the allowlist.
 
-        Note: An empty allowlist returns False for all programs, but
-        check_allowed() treats an empty allowlist as permissive.
-        Use check_allowed() for enforcement with permissive defaults.
+        This method only checks membership and returns False for empty
+        allowlists. Use check_allowed() for enforcement; it applies the
+        two-mode empty-allowlist policy, permitting empty unrestricted
+        contexts and denying empty restricted contexts.
         """
         return program in self.allowlist
 
@@ -328,6 +329,9 @@ class CuprumContext:
         When the allowlist is empty and unrestricted, all programs are
         permitted (permissive default). When the allowlist is empty and
         restricted, all programs are denied.
+
+        A warning log with operation and restricted_state fields is emitted
+        before raising ForbiddenProgramError.
         """
         if not self.allowlist and not self._allowlist_is_restricted:
             return  # Empty allowlist permits all programs

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -51,6 +51,7 @@
       'cuprum/unittests/__snapshots__/test_tee_profile_worker_selector_reentrancy.ambr',
       'cuprum/unittests/_tee_profile_worker_test_helpers.py',
       'cuprum/unittests/conftest.py',
+      'cuprum/unittests/strategies.py',
       'cuprum/unittests/test_adapters.py',
       'cuprum/unittests/test_backend.py',
       'cuprum/unittests/test_benchmark_ci_ratchet.py',

--- a/cuprum/unittests/conftest.py
+++ b/cuprum/unittests/conftest.py
@@ -90,6 +90,7 @@ def _join_and_assert_finished(
         f"expected threads to finish{f' ({context})' if context else ''}, got {alive}"
     )
 
+
 def pytest_configure(config: pytest.Config) -> None:
     """Register local pytest markers."""
     config.addinivalue_line(

--- a/cuprum/unittests/conftest.py
+++ b/cuprum/unittests/conftest.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 import typing as typ
 
+import hypothesis_crosshair_provider  # noqa: F401
+from hypothesis import settings
 from hypothesis import strategies as st
 
 from benchmarks import tee_profile_worker
 
 if typ.TYPE_CHECKING:
     import threading
+
+    import pytest
+
+settings.register_profile(
+    "crosshair",
+    settings(backend="crosshair", deadline=None, derandomize=True, max_examples=50),
+)
 
 _VOLATILE_KEYS: frozenset[str] = frozenset({
     "sha256",
@@ -79,4 +88,11 @@ def _join_and_assert_finished(
     alive = [thread.name for thread in threads if thread.is_alive()]
     assert not alive, (  # noqa: S101 - shared test helper asserts on caller's behalf.
         f"expected threads to finish{f' ({context})' if context else ''}, got {alive}"
+    )
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register local pytest markers."""
+    config.addinivalue_line(
+        "markers",
+        "crosshair: property tests suitable for Hypothesis' CrossHair backend",
     )

--- a/cuprum/unittests/conftest.py
+++ b/cuprum/unittests/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import typing as typ
 
-import hypothesis_crosshair_provider  # noqa: F401
+import hypothesis_crosshair_provider  # noqa: F401  # Registers CrossHair backend provider on import.
 from hypothesis import settings
 from hypothesis import strategies as st
 

--- a/cuprum/unittests/conftest.py
+++ b/cuprum/unittests/conftest.py
@@ -1,4 +1,9 @@
-"""Shared test helpers for the tee profiling benchmark harness."""
+"""Shared pytest configuration and helpers for Cuprum unit tests.
+
+The module imports hypothesis_crosshair_provider so Hypothesis can use the
+CrossHair backend, registers the local ``crosshair`` Hypothesis profile, and
+declares the matching pytest marker for symbolic helper-property checks.
+"""
 
 from __future__ import annotations
 

--- a/cuprum/unittests/strategies.py
+++ b/cuprum/unittests/strategies.py
@@ -1,4 +1,8 @@
-"""Shared Hypothesis strategies for Cuprum unit tests."""
+"""Shared Hypothesis strategies for context helper-property tests.
+
+The strategies generate bounded Program, allowlist, timeout, and hook values
+used by the CuprumContext property suite and optional CrossHair-backed runs.
+"""
 
 from __future__ import annotations
 

--- a/cuprum/unittests/strategies.py
+++ b/cuprum/unittests/strategies.py
@@ -1,0 +1,57 @@
+"""Shared Hypothesis strategies for Cuprum unit tests."""
+
+from __future__ import annotations
+
+import typing as typ
+
+from hypothesis import strategies as st
+
+from cuprum.program import Program
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+    from hypothesis.strategies import SearchStrategy
+
+
+def programs() -> SearchStrategy[Program]:
+    """Generate valid program names."""
+    return st.from_regex(r"[a-z][a-z0-9_-]{0,15}", fullmatch=True).map(Program)
+
+
+def allowlists() -> SearchStrategy[frozenset[Program]]:
+    """Generate finite allowlists."""
+    return st.frozensets(programs(), max_size=10)
+
+
+def optional_allowlists() -> SearchStrategy[frozenset[Program] | None]:
+    """Generate optional allowlists."""
+    return st.none() | allowlists()
+
+
+def timeouts() -> SearchStrategy[float | None]:
+    """Generate valid optional timeout values."""
+    return st.none() | st.floats(
+        min_value=0.0,
+        max_value=3600.0,
+        allow_nan=False,
+        allow_infinity=False,
+    )
+
+
+def hook_tuples() -> SearchStrategy[tuple[cabc.Callable[..., None], ...]]:
+    """Generate tuples of identity-distinct no-op hook callables."""
+
+    def make_hook(index: int) -> cabc.Callable[..., None]:
+        """Build a distinct no-op hook closing over ``index``."""
+
+        def hook(*args: object) -> None:
+            """Discard arguments while capturing ``index`` for identity."""
+            # Force closure capture and avoid unused-variable warnings.
+            _ = (index, args)
+
+        return hook
+
+    return st.lists(st.integers(), max_size=10, unique=True).map(
+        lambda indexes: tuple(make_hook(index) for index in indexes),
+    )

--- a/cuprum/unittests/test_context.py
+++ b/cuprum/unittests/test_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import logging
 import typing as typ
 from unittest import mock
 
@@ -526,12 +527,29 @@ def test_context_is_isolated_per_async_task() -> None:
 # =============================================================================
 
 
-def test_forbidden_program_error_raised_for_disallowed() -> None:
-    """check_allowed raises ForbiddenProgramError for disallowed programs."""
-    ctx = CuprumContext(allowlist=frozenset([ECHO]))
+def test_forbidden_program_error_raised_for_disallowed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """check_allowed raises and logs denied programs."""
+    ctx = CuprumContext().narrow(ScopeConfig(allowlist=frozenset([ECHO])))
+
+    caplog.set_level(logging.WARNING, logger="cuprum.context")
+
     with pytest.raises(ForbiddenProgramError) as exc_info:
         ctx.check_allowed(LS)
+
     assert "ls" in str(exc_info.value).lower()
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "cuprum.context" and record.levelno == logging.WARNING
+    ]
+    assert len(records) == 1
+    record = typ.cast("typ.Any", records[0])
+    assert "ls" in record.getMessage()
+    assert "restricted_state=True" in record.getMessage()
+    assert record.operation == LS
+    assert record.restricted_state is True
 
 
 def test_check_allowed_passes_for_allowed_program() -> None:

--- a/cuprum/unittests/test_context.py
+++ b/cuprum/unittests/test_context.py
@@ -165,6 +165,16 @@ def test_with_allowlist_preserves_empty_restricted_allowlist() -> None:
         replaced.check_allowed(ECHO)
 
 
+def test_with_allowlist_empty_preserves_existing_non_empty_restriction() -> None:
+    """with_allowlist() keeps prior non-empty allowlists restrictive."""
+    parent = CuprumContext(allowlist=frozenset([ECHO]))
+    replaced = parent.with_allowlist(frozenset())
+
+    assert replaced.allowlist == frozenset()
+    with pytest.raises(ForbiddenProgramError):
+        replaced.check_allowed(ECHO)
+
+
 @pytest.mark.crosshair
 @_PROPERTY_SETTINGS
 @given(parent=cuprum_st.allowlists(), config=cuprum_st.optional_allowlists())
@@ -644,7 +654,7 @@ def test_validate_timeout_preserves_non_negative_floats(timeout: float) -> None:
 
 @pytest.mark.crosshair
 @_PROPERTY_SETTINGS
-@given(timeout=st.integers(min_value=0))
+@given(timeout=st.integers(min_value=0, max_value=10**18))
 def test_validate_timeout_coerces_non_negative_integers(timeout: int) -> None:
     """Property: non-negative integer timeouts are coerced to float."""
     result = _validate_timeout(typ.cast("float", timeout), "Test")

--- a/cuprum/unittests/test_context.py
+++ b/cuprum/unittests/test_context.py
@@ -153,6 +153,17 @@ def test_narrowed_empty_allowlist_remains_restricted() -> None:
         narrowed.check_allowed(ECHO)
 
 
+def test_with_allowlist_preserves_empty_restricted_allowlist() -> None:
+    """with_allowlist() does not make a restricted empty allowlist permissive."""
+    parent = CuprumContext(allowlist=frozenset([ECHO]))
+    empty = parent.narrow(ScopeConfig(allowlist=frozenset()))
+    replaced = empty.with_allowlist(frozenset())
+
+    assert replaced.allowlist == frozenset()
+    with pytest.raises(ForbiddenProgramError):
+        replaced.check_allowed(ECHO)
+
+
 @pytest.mark.crosshair
 @_PROPERTY_SETTINGS
 @given(parent=cuprum_st.allowlists(), config=cuprum_st.optional_allowlists())

--- a/cuprum/unittests/test_context.py
+++ b/cuprum/unittests/test_context.py
@@ -175,6 +175,27 @@ def test_with_allowlist_empty_preserves_existing_non_empty_restriction() -> None
         replaced.check_allowed(ECHO)
 
 
+def test_with_allowlist_non_empty_replacement_is_restricted() -> None:
+    """with_allowlist() marks explicit non-empty replacements as restricted."""
+    replaced = CuprumContext().with_allowlist(frozenset([ECHO]))
+    emptied = replaced.without_program(ECHO)
+
+    assert emptied.allowlist == frozenset()
+    with pytest.raises(ForbiddenProgramError):
+        emptied.check_allowed(ECHO)
+
+
+def test_with_program_and_without_program_preserve_restriction() -> None:
+    """Program mutation helpers maintain explicit allowlist policy."""
+    ctx = CuprumContext().with_program(ECHO)
+    emptied = ctx.without_program(ECHO)
+
+    assert ctx.is_allowed(ECHO) is True
+    assert emptied.allowlist == frozenset()
+    with pytest.raises(ForbiddenProgramError):
+        emptied.check_allowed(ECHO)
+
+
 @pytest.mark.crosshair
 @_PROPERTY_SETTINGS
 @given(parent=cuprum_st.allowlists(), config=cuprum_st.optional_allowlists())

--- a/cuprum/unittests/test_context.py
+++ b/cuprum/unittests/test_context.py
@@ -8,6 +8,8 @@ import typing as typ
 from unittest import mock
 
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from cuprum.catalogue import ECHO, LS
 from cuprum.context import (
@@ -16,6 +18,12 @@ from cuprum.context import (
     CuprumContext,
     ForbiddenProgramError,
     ScopeConfig,
+    _merge_after_hooks,
+    _merge_before_hooks,
+    _merge_observe_hooks,
+    _narrow_allowlist,
+    _resolve_narrowed_timeout,
+    _validate_timeout,
     after,
     allow,
     before,
@@ -24,6 +32,16 @@ from cuprum.context import (
     scoped,
 )
 from cuprum.program import Program
+from cuprum.unittests import strategies as cuprum_st
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+_PROPERTY_SETTINGS = settings(derandomize=True, deadline=None, max_examples=50)
+
+# Run the symbolic backend for these tests with:
+#   uv run pytest cuprum/unittests/test_context.py -m crosshair \
+#     --hypothesis-profile=crosshair
 
 # =============================================================================
 # CuprumContext Basics
@@ -124,9 +142,127 @@ def test_narrow_prepends_after_hooks() -> None:
     assert narrowed.after_hooks == (child_hook, parent_hook)
 
 
-# =============================================================================
-# Global ContextVar Access
-# =============================================================================
+def test_narrowed_empty_allowlist_remains_restricted() -> None:
+    """narrow() preserves an empty restricted allowlist across nested scopes."""
+    parent = CuprumContext(allowlist=frozenset([ECHO]))
+    empty = parent.narrow(ScopeConfig(allowlist=frozenset()))
+    narrowed = empty.narrow(ScopeConfig(allowlist=frozenset([ECHO])))
+
+    assert narrowed.allowlist == frozenset()
+    with pytest.raises(ForbiddenProgramError):
+        narrowed.check_allowed(ECHO)
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(parent=cuprum_st.allowlists(), config=cuprum_st.optional_allowlists())
+def test_narrow_allowlist_can_only_shrink_non_empty_parent(
+    parent: frozenset[Program],
+    config: frozenset[Program] | None,
+) -> None:
+    """Property: narrowing cannot broaden a populated parent allowlist."""
+    result = _narrow_allowlist(parent, config)
+
+    if parent:
+        assert result <= parent
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(parent=cuprum_st.allowlists(), config=cuprum_st.allowlists())
+def test_narrow_allowlist_result_subset_of_config(
+    parent: frozenset[Program],
+    config: frozenset[Program],
+) -> None:
+    """Property: explicit config allowlists constrain the result."""
+    assert _narrow_allowlist(parent, config) <= config
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(parent=cuprum_st.allowlists())
+def test_narrow_allowlist_none_config_preserves_parent(
+    parent: frozenset[Program],
+) -> None:
+    """Property: absent config allowlist inherits the parent exactly."""
+    assert _narrow_allowlist(parent, None) == parent
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(
+    parent=cuprum_st.allowlists().filter(bool),
+    first=cuprum_st.allowlists(),
+    second=cuprum_st.allowlists(),
+)
+def test_narrow_allowlist_two_steps_match_single_intersection(
+    parent: frozenset[Program],
+    first: frozenset[Program],
+    second: frozenset[Program],
+) -> None:
+    """Property: repeated narrowing matches one equivalent intersection."""
+    first_step = _narrow_allowlist(parent, first, parent_is_restricted=True)
+    two_step = _narrow_allowlist(first_step, second, parent_is_restricted=True)
+    single_step = _narrow_allowlist(parent, first & second)
+
+    assert two_step == single_step
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(parent=cuprum_st.hook_tuples(), config=cuprum_st.hook_tuples())
+def test_merge_before_hooks_preserves_fifo_order(
+    parent: tuple[cabc.Callable[..., None], ...],
+    config: tuple[cabc.Callable[..., None], ...],
+) -> None:
+    """Property: before hooks append child hooks after parent hooks."""
+    result = _merge_before_hooks(
+        typ.cast("tuple[BeforeHook, ...]", parent),
+        typ.cast("tuple[BeforeHook, ...]", config),
+    )
+
+    assert len(result) == len(parent) + len(config)
+    assert result[: len(parent)] == parent
+    assert result[len(parent) :] == config
+    assert set(result) == {*parent, *config}
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(parent=cuprum_st.hook_tuples(), config=cuprum_st.hook_tuples())
+def test_merge_after_hooks_preserves_lifo_order(
+    parent: tuple[cabc.Callable[..., None], ...],
+    config: tuple[cabc.Callable[..., None], ...],
+) -> None:
+    """Property: after hooks prepend child hooks before parent hooks."""
+    result = _merge_after_hooks(
+        typ.cast("tuple[AfterHook, ...]", parent),
+        typ.cast("tuple[AfterHook, ...]", config),
+    )
+
+    assert len(result) == len(parent) + len(config)
+    assert result[: len(config)] == config
+    assert result[len(config) :] == parent
+    assert set(result) == {*parent, *config}
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(parent=cuprum_st.hook_tuples(), config=cuprum_st.hook_tuples())
+def test_merge_observe_hooks_preserves_fifo_order(
+    parent: tuple[cabc.Callable[..., None], ...],
+    config: tuple[cabc.Callable[..., None], ...],
+) -> None:
+    """Property: observe hooks append child hooks after parent hooks."""
+    result = _merge_observe_hooks(
+        typ.cast("tuple[typ.Any, ...]", parent),
+        typ.cast("tuple[typ.Any, ...]", config),
+    )
+
+    assert len(result) == len(parent) + len(config)
+    assert result[: len(parent)] == parent
+    assert result[len(parent) :] == config
+    assert set(result) == {*parent, *config}
 
 
 def test_current_context_returns_context() -> None:
@@ -455,3 +591,77 @@ def test_cuprum_context_timeout_validation(
         assert ctx.timeout == expected_result
         if expected_result is not None:
             assert isinstance(ctx.timeout, float)
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(timeout=st.none())
+def test_validate_timeout_preserves_none(timeout: None) -> None:
+    """Property: None timeout values are preserved."""
+    assert _validate_timeout(timeout, "Test") is None
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(timeout=st.floats(min_value=0.0, max_value=3600.0, allow_nan=False))
+def test_validate_timeout_preserves_non_negative_floats(timeout: float) -> None:
+    """Property: non-negative float timeouts are accepted unchanged."""
+    result = _validate_timeout(timeout, "Test")
+
+    assert result is not None
+    assert result >= timeout
+    assert result <= timeout
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(timeout=st.integers(min_value=0))
+def test_validate_timeout_coerces_non_negative_integers(timeout: int) -> None:
+    """Property: non-negative integer timeouts are coerced to float."""
+    result = _validate_timeout(typ.cast("float", timeout), "Test")
+
+    assert result is not None
+    assert isinstance(result, float)
+    assert result.hex() == float(timeout).hex()
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(timeout=st.floats(max_value=-0.000001, allow_nan=False))
+def test_validate_timeout_rejects_negative_floats(timeout: float) -> None:
+    """Property: negative float timeouts are rejected."""
+    with pytest.raises(ValueError, match="timeout must be non-negative"):
+        _validate_timeout(timeout, "Test")
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(timeout=st.integers(max_value=-1))
+def test_validate_timeout_rejects_negative_integers(timeout: int) -> None:
+    """Property: negative integer timeouts are rejected."""
+    with pytest.raises(ValueError, match="timeout must be non-negative"):
+        _validate_timeout(typ.cast("float", timeout), "Test")
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(parent=cuprum_st.timeouts())
+def test_resolve_narrowed_timeout_inherits_without_config(
+    parent: float | None,
+) -> None:
+    """Property: absent config timeout inherits the parent timeout."""
+    assert _resolve_narrowed_timeout(parent, None) == parent
+
+
+@pytest.mark.crosshair
+@_PROPERTY_SETTINGS
+@given(
+    parent=cuprum_st.timeouts(),
+    config=st.floats(min_value=0.0, max_value=3600.0, allow_nan=False),
+)
+def test_resolve_narrowed_timeout_config_overrides_parent(
+    parent: float | None,
+    config: float,
+) -> None:
+    """Property: explicit config timeout overrides any parent timeout."""
+    assert _resolve_narrowed_timeout(parent, config) == config

--- a/cuprum/unittests/test_pipeline.py
+++ b/cuprum/unittests/test_pipeline.py
@@ -8,7 +8,15 @@ import typing as typ
 
 import pytest
 
-from cuprum import ECHO, ScopeConfig, TimeoutExpired, scoped, sh
+from cuprum import (
+    ECHO,
+    LS,
+    ForbiddenProgramError,
+    ScopeConfig,
+    TimeoutExpired,
+    scoped,
+    sh,
+)
 from cuprum._testing import (
     _READ_SIZE,
     _PipelineWaitResult,
@@ -158,6 +166,19 @@ def test_pipeline_can_append_stages() -> None:
     pipeline = first | second | third
 
     assert pipeline.parts == (first, second, third)
+
+
+def test_pipeline_run_sync_enforces_scoped_allowlist() -> None:
+    """Pipeline execution rejects stages outside the active allowlist."""
+    echo = sh.make(ECHO)
+    ls = sh.make(LS)
+    pipeline = echo("hello") | ls()
+
+    with (
+        scoped(ScopeConfig(allowlist=frozenset([ECHO]))),
+        pytest.raises(ForbiddenProgramError, match="ls"),
+    ):
+        pipeline.run_sync()
 
 
 def _run_test_pipeline(

--- a/docs/adr-002-additional-rust-components.md
+++ b/docs/adr-002-additional-rust-components.md
@@ -309,14 +309,14 @@ measured tee scenario. This evidence justifies the Phase 2 dispatcher
 experiment, but it does not satisfy the wall-time acceptance gate by itself;
 that gate still requires a Rust-versus-Python dispatcher benchmark showing at
 least 20% lower median wall time for the targeted heavy scenario, plus the
-regression checks listed above. The first dispatcher must remain narrower
-than the public helper: fd-backed, UTF-8/replace, capture-only streams with no
-echo sink and no line callbacks.
+regression checks listed above. The first dispatcher must remain narrower than
+the public helper: fd-backed, UTF-8/replace, capture-only streams with no echo
+sink and no line callbacks.
 
 `rust_consume_stream()` ships in the wheel and is exercised by tests, but
 production code does not route stream consumption through it yet. The symbol is
-annotated as "implemented but not yet integrated" in `cuprum/_streams_rs.py` and
-the users' guide so it is not mistaken for a wired bridge. A guard test
+annotated as "implemented but not yet integrated" in `cuprum/_streams_rs.py`
+and the users' guide so it is not mistaken for a wired bridge. A guard test
 (`cuprum/unittests/test_rust_streams.py`) fails if production code starts
 referencing the symbol without revisiting this decision. Phase 2 integration
 should remove that marker only alongside the dispatcher, fallback path, and the

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -899,8 +899,8 @@ The following design decisions were made during implementation:
 **Allowlist narrowing semantics:**
 
 - When `narrow()` is called on the unrestricted default context with an empty
-  allowlist, the provided allowlist is used directly as the new base. This
-  allows establishing an initial scope from the default context.
+  allowlist, the empty allowlist is used directly as the new base, so the
+  scope is explicitly restricted to no programs.
 - When `narrow()` is called on a context with a non-empty allowlist, the
   provided allowlist is intersected with the parent's. This ensures narrowing
   can only remove programs, never add them.

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -899,8 +899,8 @@ The following design decisions were made during implementation:
 **Allowlist narrowing semantics:**
 
 - When `narrow()` is called on the unrestricted default context with an empty
-  allowlist, the empty allowlist is used directly as the new base, so the
-  scope is explicitly restricted to no programs.
+  allowlist, the empty allowlist is used directly as the new base, so the scope
+  is explicitly restricted to no programs.
 - When `narrow()` is called on a context with a non-empty allowlist, the
   provided allowlist is intersected with the parent's. This ensures narrowing
   can only remove programs, never add them.
@@ -1748,9 +1748,9 @@ Cuprum selects the stream backend at runtime using the following precedence:
      `_pump_stream()` for that transfer.
 
 Final stdout and stderr consumption currently bypasses this Rust dispatch
-pathway. `rust_consume_stream()` remains a Phase 2 candidate behind the
-ADR-002 measurement and parity-test gates, so backend selection does not change
-capture semantics yet.
+pathway. `rust_consume_stream()` remains a Phase 2 candidate behind the ADR-002
+measurement and parity-test gates, so backend selection does not change capture
+semantics yet.
 
 This strategy ensures:
 
@@ -1803,8 +1803,8 @@ worker invocation and do not accumulate across calls.
 
 `_EnvBackendSelector` accepts an optional `clock` parameter (a zero-argument
 callable returning `float`) so tests can inject a deterministic time source.
-The selector records `clock()` before and after each `_BACKEND_LOCK` acquisition
-and adds the difference to `metrics_state.lock_wait_seconds`.
+The selector records `clock()` before and after each `_BACKEND_LOCK`
+acquisition and adds the difference to `metrics_state.lock_wait_seconds`.
 
 For screen readers: The following flowchart illustrates the backend selection
 algorithm, showing how the environment variable and availability checks

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -898,12 +898,15 @@ The following design decisions were made during implementation:
 
 **Allowlist narrowing semantics:**
 
-- When `narrow()` is called on a context with an empty allowlist, the provided
-  allowlist is used directly as the new base. This allows establishing an
-  initial scope from the default (empty) context.
+- When `narrow()` is called on the unrestricted default context with an empty
+  allowlist, the provided allowlist is used directly as the new base. This
+  allows establishing an initial scope from the default context.
 - When `narrow()` is called on a context with a non-empty allowlist, the
   provided allowlist is intersected with the parent's. This ensures narrowing
   can only remove programs, never add them.
+- When narrowing an explicit restricted scope produces an empty allowlist, that
+  empty allowlist remains restrictive. Nested scopes cannot use it as a new
+  unrestricted base.
 - This two-mode behaviour balances safety (can't widen) with usability (can
   establish base scopes).
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -52,7 +52,8 @@ contracts stay aligned.
 `_allowlist_is_restricted` marker. The marker distinguishes the permissive
 default context from a context that has deliberately narrowed to an empty
 allowlist. It defaults to `False` on the default context and becomes `True`
-when narrowing receives an explicit `ScopeConfig.allowlist`. Direct allowlist
+for explicit narrowing, when `ScopeConfig.allowlist` is provided, or when
+`with_allowlist()` receives a non-empty replacement. Direct allowlist
 replacement also preserves restriction when the previous context already had an
 explicit policy. Replacing that allowlist with `frozenset()` therefore cannot
 widen the context back to the permissive default by accident.
@@ -76,8 +77,9 @@ everything" and "deny everything".
 
 `with_allowlist()` is the direct replacement path. It preserves restriction
 when the current context already has an explicit policy, even if the replacement
-allowlist is empty, so direct replacement cannot turn a deny-all context into
-the permissive default.
+allowlist is empty, and a non-empty replacement establishes an explicit policy by
+setting restriction. So direct replacement cannot turn a deny-all context into the
+permissive default.
 
 The allowlist, hook, and timeout rules are split into pure helpers so the
 invariants can be tested directly:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -45,6 +45,73 @@ uv run pytest -q cuprum/unittests/test_line_splitting.py
 Run `make test` before committing so the stream behaviour and the pure helper
 contracts stay aligned.
 
+
+## Context allowlist internals
+
+`CuprumContext` stores an `allowlist` plus the internal
+`_allowlist_is_restricted` marker. The marker distinguishes the permissive
+default context from a context that has deliberately narrowed to an empty
+allowlist. It defaults to `False` on the default context and becomes `True`
+when narrowing receives an explicit `ScopeConfig.allowlist`, or when direct
+allowlist replacement installs a non-empty allowlist. Once a context is already
+restricted, replacing the allowlist with `frozenset()` preserves that marker so
+the context cannot be widened back to the permissive default by accident.
+
+`check_allowed()` therefore has two empty-allowlist modes. Empty and
+unrestricted means *no policy has been established yet*, so every program is
+permitted for the adoption-friendly default. Empty and restricted means a
+policy has been established and then narrowed to no programs, so every program
+is denied. Keeping that bit separate from the set contents prevents permission
+broadening regressions where `frozenset()` could otherwise mean both "allow
+everything" and "deny everything".
+
+`narrow()` handles allowlists in three cases:
+
+- An empty unrestricted parent uses the provided allowlist directly, creating
+  the first explicit base scope.
+- An empty restricted parent stays empty, preserving the deny-all result of
+  earlier narrowing.
+- A non-empty parent intersects its allowlist with the provided allowlist, so
+  nested scopes can remove programs but cannot add new ones.
+
+`with_allowlist()` is the direct replacement path. It intentionally treats a
+non-empty replacement as restricted because an explicit allowlist policy now
+exists. If the current context is already restricted, an empty replacement keeps
+the restricted marker so direct replacement cannot turn a deny-all context into
+the permissive default.
+
+The allowlist, hook, and timeout rules are split into pure helpers so the
+invariants can be tested directly:
+
+- `_narrow_allowlist(parent, config, parent_is_restricted=...)` returns the
+  narrowed allowlist for the three parent/config cases without mutating either
+  input.
+- `_is_narrowed_allowlist_restricted(config, parent_is_restricted=...)`
+  returns whether the child context should enforce allowlist policy after
+  narrowing.
+- `_merge_before_hooks(parent, config)` appends scoped before hooks after
+  parent hooks so execution stays FIFO.
+- `_merge_after_hooks(parent, config)` prepends scoped after hooks before
+  parent hooks so teardown stays LIFO.
+- `_merge_observe_hooks(parent, config)` appends scoped observation hooks after
+  parent hooks so execution stays FIFO.
+- `_validate_timeout(timeout, class_name)` coerces non-negative timeout values
+  to `float`, preserves `None`, and rejects negative values.
+- `_resolve_narrowed_timeout(parent, config)` inherits the parent timeout when
+  the scoped config is silent and otherwise uses the scoped value.
+
+Context property tests live in `cuprum/unittests/test_context.py`. Run them
+directly with:
+
+```bash
+uv run pytest -q cuprum/unittests/test_context.py
+```
+
+The same test module marks pure-helper properties for optional CrossHair
+execution. The `crosshair` Hypothesis profile is registered in
+`cuprum/unittests/conftest.py`; using it requires the
+`hypothesis-crosshair` package from the dev dependency group.
+
 ## `rust_consume_stream` integration status
 
 `rust_consume_stream` is implemented, tested, and exported, but production

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -367,7 +367,8 @@ on the same thread, logs the rejected backend and thread identifier, and raises
 
 `TeeProfileWorkerResult` includes selector metrics gathered while activating
 the backend. The metrics are thread-local, reset for each worker run, and
-reported with the rest of the worker payload.
+reported with the rest of the worker payload. They represent per-invocation
+totals for `TeeProfileWorkerResult`, not process-lifetime aggregates.
 
 | Field                       | Type    | Description                                                                          |
 | --------------------------- | ------- | ------------------------------------------------------------------------------------ |

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -45,7 +45,6 @@ uv run pytest -q cuprum/unittests/test_line_splitting.py
 Run `make test` before committing so the stream behaviour and the pure helper
 contracts stay aligned.
 
-
 ## Context allowlist internals
 
 `CuprumContext` stores an `allowlist` plus the internal

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2,13 +2,13 @@
 
 This guide is for maintainers. It captures the operational scope for build,
 test, lint, release, debugging, and extension workflows and acts as the source
-of truth for day-to-day contributor expectations. For the system design, see
-the [design document](cuprum-design.md); for where code lives, see the
-[repository layout](repository-layout.md); and for accepted architectural
-decisions, see
-[ADR-002: Additional Rust components](adr-002-additional-rust-components.md),
-[ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md), and
-[ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md).
+of truth for day-to-day contributor expectations. For the system design, see the
+[design document](cuprum-design.md); for where code lives, see the
+[repository layout](repository-layout.md). Accepted architectural decisions are:
+
+- [ADR-002: Additional Rust components](adr-002-additional-rust-components.md)
+- [ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md)
+- [ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md)
 
 ## Stream line-splitting properties
 
@@ -50,8 +50,8 @@ contracts stay aligned.
 `CuprumContext` stores an `allowlist` plus the internal
 `_allowlist_is_restricted` marker. The marker distinguishes the permissive
 default context from a context that has deliberately narrowed to an empty
-allowlist. It defaults to `False` on the default context and becomes `True`
-for explicit narrowing, when `ScopeConfig.allowlist` is provided, or when
+allowlist. It defaults to `False` on the default context and becomes `True` for
+explicit narrowing, when `ScopeConfig.allowlist` is provided, or when
 `with_allowlist()` receives a non-empty replacement. Direct allowlist
 replacement also preserves restriction when the previous context already had an
 explicit policy. Replacing that allowlist with `frozenset()` therefore cannot
@@ -75,10 +75,10 @@ everything" and "deny everything".
   nested scopes can remove programs but cannot add new ones.
 
 `with_allowlist()` is the direct replacement path. It preserves restriction
-when the current context already has an explicit policy, even if the replacement
-allowlist is empty, and a non-empty replacement establishes an explicit policy by
-setting restriction. So direct replacement cannot turn a deny-all context into the
-permissive default.
+when the current context already has an explicit policy, even if the
+replacement allowlist is empty, and a non-empty replacement establishes an
+explicit policy by setting restriction. So direct replacement cannot turn a
+deny-all context into the permissive default.
 
 The allowlist, hook, and timeout rules are split into pure helpers so the
 invariants can be tested directly:
@@ -109,19 +109,18 @@ uv run pytest -q cuprum/unittests/test_context.py
 
 The same test module marks pure-helper properties for optional CrossHair
 execution. The `crosshair` Hypothesis profile is registered in
-`cuprum/unittests/conftest.py`; using it requires the
-`hypothesis-crosshair` package from the dev dependency group.
+`cuprum/unittests/conftest.py`; using it requires the `hypothesis-crosshair`
+package from the dev dependency group.
 
 ## `rust_consume_stream` integration status
 
 `rust_consume_stream` is implemented, tested, and exported, but production
 consumes currently go through the pure-Python `_consume_stream` function until
-Phase 2 is complete.
-Integration is deferred to
+Phase 2 is complete. Integration is deferred to
 [ADR-002: Additional Rust components](adr-002-additional-rust-components.md)
-(Phase 2). The rationale is to defer consume-side dispatch until the
-ADR-002 Phase 2 stack is complete, including dispatcher wiring, the Python
-fallback path, and parity/property coverage.
+(Phase 2). The rationale is to defer consume-side dispatch until the ADR-002
+Phase 2 stack is complete, including dispatcher wiring, the Python fallback
+path, and parity/property coverage.
 
 ## Fail-fast reducer properties
 
@@ -707,8 +706,8 @@ dependency from `uv.lock` is available before running `fmt`, `check-fmt`, or
 `lint`. Continuous Integration (CI) and local runs must keep using this
 `uv run` path for Ruff linting and formatting so preview-rule changes only
 arrive through an explicit lockfile update. `interrogate` is also invoked via
-`uv run` in the `lint` recipe, but it is not included in `VENV_TOOLS` and so
-is not gated by the probe; it relies on `uv sync` having installed it into the
+`uv run` in the `lint` recipe, but it is not included in `VENV_TOOLS` and so is
+not gated by the probe; it relies on `uv sync` having installed it into the
 locked virtualenv.
 
 Because `interrogate` requires a docstring on every documentable node,
@@ -829,11 +828,11 @@ When refreshing this container, update the value in
 comment to the original mutable reference:
 `# ghcr.io/rust-cross/manylinux_2_28-cross:aarch64`.
 
-The deterministic tests assert that the live workflow value is correctly
-formed and consumed by the aarch64 build step. The property-based tests prove
-that the shared regex accepts every valid 64-character hexadecimal digest and
-rejects the unbounded space of mutable tags and truncated digests, giving
-confidence beyond any single example.
+The deterministic tests assert that the live workflow value is correctly formed
+and consumed by the aarch64 build step. The property-based tests prove that the
+shared regex accepts every valid 64-character hexadecimal digest and rejects
+the unbounded space of mutable tags and truncated digests, giving confidence
+beyond any single example.
 
 To update the pinned digest, resolve the tag digest for
 `ghcr.io/rust-cross/manylinux_2_28-cross:aarch64`, replace only the value in

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -52,10 +52,10 @@ contracts stay aligned.
 `_allowlist_is_restricted` marker. The marker distinguishes the permissive
 default context from a context that has deliberately narrowed to an empty
 allowlist. It defaults to `False` on the default context and becomes `True`
-when narrowing receives an explicit `ScopeConfig.allowlist`, or when direct
-allowlist replacement installs a non-empty allowlist. Once a context is already
-restricted, replacing the allowlist with `frozenset()` preserves that marker so
-the context cannot be widened back to the permissive default by accident.
+when narrowing receives an explicit `ScopeConfig.allowlist`. Direct allowlist
+replacement also preserves restriction when the previous context already had an
+explicit policy. Replacing that allowlist with `frozenset()` therefore cannot
+widen the context back to the permissive default by accident.
 
 `check_allowed()` therefore has two empty-allowlist modes. Empty and
 unrestricted means *no policy has been established yet*, so every program is
@@ -74,10 +74,9 @@ everything" and "deny everything".
 - A non-empty parent intersects its allowlist with the provided allowlist, so
   nested scopes can remove programs but cannot add new ones.
 
-`with_allowlist()` is the direct replacement path. It intentionally treats a
-non-empty replacement as restricted because an explicit allowlist policy now
-exists. If the current context is already restricted, an empty replacement keeps
-the restricted marker so direct replacement cannot turn a deny-all context into
+`with_allowlist()` is the direct replacement path. It preserves restriction
+when the current context already has an explicit policy, even if the replacement
+allowlist is empty, so direct replacement cannot turn a deny-all context into
 the permissive default.
 
 The allowlist, hook, and timeout rules are split into pure helpers so the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -217,9 +217,9 @@ for wins a one-line Python change already captures.
 
 This phase turns the baseline's two pure-Python findings into shipped
 improvements: the read-size plateau (about a 20% win on every parent-side
-consume path) and the per-line observe-hook dispatch cost (the dominant tee-path
-cost when line callbacks are active). Both are independent of the Rust extension
-and deliver value on their own.
+consume path) and the per-line observe-hook dispatch cost (the dominant
+tee-path cost when line callbacks are active). Both are independent of the Rust
+extension and deliver value on their own.
 
 ### 5.1. Bank the read-size win on every parent-side consume path
 
@@ -232,7 +232,8 @@ adr-002-additional-rust-components.md Proposal 3.
 - [ ] 5.1.1. Raise `_READ_SIZE` (`cuprum/_streams.py:14`) from 4 KiB to the
   profiled plateau in the 16-64 KiB range, choosing the value from a fresh
   read-size sweep rather than assuming the baseline number.
-  - Update `test_stream_preserves_random_payloads_around_python_read_size_boundary`
+  - Update
+    `test_stream_preserves_random_payloads_around_python_read_size_boundary`
     (`cuprum/unittests/test_stream_property_based.py:120`) to exercise chunk
     boundaries around the new size.
   - Success: the `tee-devnull-nocb-s1` scenario median wall time is at least 20%
@@ -244,27 +245,28 @@ adr-002-additional-rust-components.md Proposal 3.
 
 This step answers whether the roughly 46x line-callback slowdown can be cut by
 removing per-line work from the observe-hook path without changing observable
-event semantics. Its outcome informs whether per-line events ever need to become
-opt-in. See tee-hotpath-profiling-baseline-2026-06-12.md §5 (Table 4).
+event semantics. Its outcome informs whether per-line events ever need to
+become opt-in. See tee-hotpath-profiling-baseline-2026-06-12.md §5 (Table 4).
 
 - [ ] 5.2.1. Hoist the invariant `ExecEvent` / `_EventDetails`
   (`cuprum/events.py:31`, `cuprum/_pipeline_types.py:40`) fields out of the
   per-line path in `_StageObservation.emit` (`cuprum/_pipeline_types.py:62`),
-  precomputing programme, argv (`SafeCmd.argv_with_program`, `cuprum/sh.py:363`),
-  cwd, env, and pid once per stream rather than per line.
+  precomputing programme, argv (`SafeCmd.argv_with_program`,
+  `cuprum/sh.py:363`), cwd, env, and pid once per stream rather than per line.
   - Success: per-line emission no longer reconstructs invariant fields, the
     callback scenario's dataclass-construction share falls from the 39% baseline
     to no more than 10% in a committed profiler artefact, and emitted event
     payloads are unchanged.
 - [ ] 5.2.2. Remove the per-hook `inspect.isawaitable` call from the per-line
-  path in `_emit_exec_event` (`cuprum/_observability.py:35`) by classifying each
-  hook as sync or async once at registration.
+  path in `_emit_exec_event` (`cuprum/_observability.py:35`) by classifying
+  each hook as sync or async once at registration.
   - Requires 5.2.1.
   - Success: known-sync hooks dispatch without per-line awaitable detection,
     async hooks retain identical scheduling behaviour, and a committed profiler
     artefact shows `inspect.isawaitable` contributes 0 sampled frames in the
     per-line hot path.
-- [ ] 5.2.3. Add a combinatorial event-parity suite proving the optimized path is
+- [ ] 5.2.3. Add a combinatorial event-parity suite proving the optimized path
+      is
   behaviour-preserving across the hook-type and stream-mode matrix.
   - Requires 5.2.1 and 5.2.2.
   - Cover sync and async hooks crossed with capture, echo, and line-callback
@@ -276,26 +278,27 @@ opt-in. See tee-hotpath-profiling-baseline-2026-06-12.md §5 (Table 4).
 ## 6. Trustworthy, accelerated capture-only consume (issues `#90`, `#127`)
 
 Idea: if a narrowly scoped capture-only consume dispatcher clears the 20%
-wall-time gate the baseline projects from the roughly 51% capture double-touch —
-measured against the tuned phase 5 baseline — Cuprum can route the measured
+wall-time gate the baseline projects from the roughly 51% capture double-touch
+— measured against the tuned phase 5 baseline — Cuprum can route the measured
 hotspot through Rust while keeping Python as the behavioural reference. If it
-cannot clear the gate, `rust_consume_stream` stays inert and the negative result
-is recorded.
+cannot clear the gate, `rust_consume_stream` stays inert and the negative
+result is recorded.
 
-Issue `#127` deliberately took the annotate-first fork: `rust_consume_stream` is
-shipped, tested, and documented as "implemented but not integrated", guarded by
-tests that fail if production code routes through it. This phase resolves that
-ambiguity by either wiring the dispatcher symmetric to `_pump_stream_dispatch`
-or recording why the gate was not met. Issue `#90` (proptest at the PyO3
-boundary) is folded in as the correctness de-risking step.
+Issue `#127` deliberately took the annotate-first fork: `rust_consume_stream`
+is shipped, tested, and documented as "implemented but not integrated", guarded
+by tests that fail if production code routes through it. This phase resolves
+that ambiguity by either wiring the dispatcher symmetric to
+`_pump_stream_dispatch` or recording why the gate was not met. Issue `#90`
+(proptest at the PyO3 boundary) is folded in as the correctness de-risking step.
 
 ### 6.1. Harden the PyO3 stream boundary so Rust and Python are interchangeable
 
-This step answers whether `rust_pump_stream` and `rust_consume_stream` map errors
-and decode identically to Python across the full input domain, not just scenario
-fixtures. Its outcome is the correctness foundation the dispatcher relies on. See
-issue `#90`, tee-hotpath-profiling-baseline-2026-06-12.md §§3-4, and
-adr-002-additional-rust-components.md (decoding-drift and FD-ownership risks).
+This step answers whether `rust_pump_stream` and `rust_consume_stream` map
+errors and decode identically to Python across the full input domain, not just
+scenario fixtures. Its outcome is the correctness foundation the dispatcher
+relies on. See issue `#90`, tee-hotpath-profiling-baseline-2026-06-12.md §§3-4,
+and adr-002-additional-rust-components.md (decoding-drift and FD-ownership
+risks).
 
 - [ ] 6.1.1. Introduce a `RustStreamError` enum in `rust/cuprum-rust/src/lib.rs`
   and convert it to PyO3 errors at a single boundary point.
@@ -314,14 +317,13 @@ adr-002-additional-rust-components.md (decoding-drift and FD-ownership risks).
 
 This step answers whether native read-and-decode beats the tuned Python consume
 by the 20% the ADR requires, on the one eligible scenario. Its outcome decides
-whether wiring proceeds at all. See
-adr-002-additional-rust-components.md Phase 2,
-tee-hotpath-profiling-baseline-2026-06-12.md §"Implications" item 1, and roadmap
-step 4.4.
+whether wiring proceeds at all. See adr-002-additional-rust-components.md Phase
+2, tee-hotpath-profiling-baseline-2026-06-12.md §"Implications" item 1, and
+roadmap step 4.4.
 
 - [ ] 6.2.1. Add a Rust-versus-Python consume dispatcher benchmark for the
-  fd-backed, UTF-8/replace, capture-only, no-echo, no-callback scenario, measured
-  against the phase 5 tuned baseline.
+  fd-backed, UTF-8/replace, capture-only, no-echo, no-callback scenario,
+  measured against the phase 5 tuned baseline.
   - Requires phase 5, 6.1.1, and 6.1.2.
   - Success: the benchmark reports median wall time for both paths and publishes
     it to the workflow summary; the gate passes only when the Rust median is at
@@ -332,18 +334,20 @@ step 4.4.
 
 ### 6.3. Wire `_consume_stream_dispatch` and route capture through it
 
-This step answers whether consume dispatch can reuse the pump-dispatch shape with
-a strict eligibility predicate and transparent fallback. It proceeds only if the
-gate in 6.2 passed. See `cuprum/_pipeline_streams.py:290`
-(`_pump_stream_dispatch`) and the `_StreamConfig` fields in `cuprum/_streams.py`.
+This step answers whether consume dispatch can reuse the pump-dispatch shape
+with a strict eligibility predicate and transparent fallback. It proceeds only
+if the gate in 6.2 passed. See `cuprum/_pipeline_streams.py:290`
+(`_pump_stream_dispatch`) and the `_StreamConfig` fields in
+`cuprum/_streams.py`.
 
 - [ ] 6.3.1. Implement `_consume_stream_dispatch` mirroring
   `_pump_stream_dispatch`, with an eligibility predicate over `_StreamConfig`:
-  `capture_output and not echo_output`, UTF-8 `encoding`, `errors == "replace"`,
-  no line callback (`on_line is None`), and an extractable reader FD; otherwise
-  fall back to the Python `_consume_stream`.
+  `capture_output and not echo_output`, UTF-8 `encoding`,
+  `errors == "replace"`, no line callback (`on_line is None`), and an
+  extractable reader FD; otherwise fall back to the Python `_consume_stream`.
   - Requires 6.1.1 and 6.2.1.
-  - Route the consume call sites at `cuprum/_subprocess_execution.py:229,236` and
+  - Route the consume call sites at `cuprum/_subprocess_execution.py:229,236`
+    and
     `cuprum/_pipeline_stage_streams.py:71,94` through the dispatcher.
   - Success: a backend-selection test proves Rust is engaged only when the
     predicate holds and `get_stream_backend()` is `RUST`, and that dispatch falls
@@ -359,7 +363,8 @@ gate in 6.2 passed. See `cuprum/_pipeline_streams.py:290`
     (`cuprum/unittests/test_rust_streams.py`) to assert the wired state.
   - Success: `make check-fmt lint test` is green with the guards asserting
     production routing rather than its absence.
-- [ ] 6.3.3. Add a combinatorial fallback E2E suite across the eligibility matrix.
+- [ ] 6.3.3. Add a combinatorial fallback E2E suite across the eligibility
+      matrix.
   - Requires 6.3.1.
   - Cover backend (`auto`, `rust`, `python`) crossed with capture, echo,
     line-callback, encoding (UTF-8 and non-UTF-8), error policy (`replace` and
@@ -375,10 +380,12 @@ gate fell. See adr-002-additional-rust-components.md Phase 2, cuprum-design.md
 
 - [ ] 6.4.1. Record the phase 6 outcome in the documentation set.
   - Requires 6.2.1 in all cases. The passed-gate branch also requires 6.3.2.
-  - If the gate passed: mark ADR-002 Phase 2 as integrated, update the design-doc
+  - If the gate passed: mark ADR-002 Phase 2 as integrated, update the
+    design-doc
     §13 diagrams and prose, and describe the consume eligibility conditions and
     transparent fallback in the users' guide.
-  - If the gate failed: record the measured shortfall, keep the inert annotation,
+  - If the gate failed: record the measured shortfall, keep the inert
+    annotation,
     and note the negative result so the symbol is not mistaken for a wired bridge.
   - Success: no documentation describes `rust_consume_stream` in a way that
     contradicts its actual production status.
@@ -411,14 +418,15 @@ tee-hotpath-profiling-baseline-2026-06-12.md §"Implications" item 4 and Table 2
 
 ### 7.2. Ship the raw-sink helper behind capability checks for qualifying sinks
 
-This step answers whether the native helper can accelerate qualifying sinks while
-falling back transparently for the rest. See
+This step answers whether the native helper can accelerate qualifying sinks
+while falling back transparently for the rest. See
 adr-002-additional-rust-components.md Proposal 2 and cuprum-design.md §13.
 
 - [ ] 7.2.1. Implement the Rust raw-sink echo and tee helper with FD capability
   detection and Python fallback, routing only the sink kinds qualified by 7.1.1.
   - Requires 6.1.1 and 7.1.1.
-  - Success: qualifying fd-backed sinks route through Rust with parity to Python;
+  - Success: qualifying fd-backed sinks route through Rust with parity to
+    Python;
     non-qualifying sinks (including PTY unless 7.1.1 qualified it) fall back
     transparently; and the open question of which raw sink types qualify is
     resolved in adr-002-additional-rust-components.md.
@@ -445,21 +453,22 @@ item 1, adr-002-additional-rust-components.md (FD ownership risk), and issues
 
 ### 8.2. Restore Python-frame attribution in perf captures
 
-This step removes a tooling gap that weakens the evidence base future phases rely
-on. See tee-hotpath-profiling-baseline-2026-06-12.md §"Incidental findings" item
-2.
+This step removes a tooling gap that weakens the evidence base future phases
+rely on. See tee-hotpath-profiling-baseline-2026-06-12.md §"Incidental
+findings" item 2.
 
 - [ ] 8.2.1. Investigate why distro perf 6.12 drops `py::` trampoline frames in
   `perf script` while resolving them in `perf report`.
-  - Success: `stacks.folded` and `summary.json` carry Python-level frames, or the
+  - Success: `stacks.folded` and `summary.json` carry Python-level frames, or
+    the
     limitation is documented and the py-spy corroboration workaround is promoted
     to a first-class harness default.
 
 ### 8.3. Decide on native subprocess and pipeline orchestration
 
 This step resolves the two heaviest ADR-002 bets, which the design explicitly
-defers. See adr-002-additional-rust-components.md Proposals 4 and 5 (Phases 4 and
-5).
+defers. See adr-002-additional-rust-components.md Proposals 4 and 5 (Phases 4
+and 5).
 
 - [ ] 8.3.1. Prototype the synchronous Rust subprocess fast path and record a
   go/no-go decision.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -379,10 +379,10 @@ When you call `SafeCmd.run()` or `run_sync()`, Cuprum automatically:
 **Empty allowlist behaviour:** When no parent context is established,
 `scoped(ScopeConfig())` is the permissive root context (all programs allowed),
 which supports adoption by defaulting to non-restrictive execution for
-first-time callers.
-Nested `scoped(ScopeConfig())` calls inherit the current parent policy, so they
-cannot widen permissions. If an explicit empty allowlist is introduced in an
-already restricted path, that scope remains restrictive and permits no programs.
+first-time callers. Nested `scoped(ScopeConfig())` calls inherit the current
+parent policy, so they cannot widen permissions. If an explicit empty allowlist
+is introduced in an already restricted path, that scope remains restrictive and
+permits no programs.
 
 ### Scoped contexts
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -386,8 +386,8 @@ already restricted path, that scope remains restrictive and permits no programs.
 
 ### Scoped contexts
 
-Use `scoped(ScopeConfig())` to establish a narrowed execution context within a
-code block:
+Use `scoped(ScopeConfig(allowlist=...))` to establish a narrowed execution
+context within a code block:
 
 ```python
 from cuprum import ECHO, LS, ScopeConfig, scoped

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -376,12 +376,13 @@ When you call `SafeCmd.run()` or `run_sync()`, Cuprum automatically:
 3. Invokes all registered after hooks (in LIFO order) after the process
    completes.
 
-**Empty allowlist behaviour:** When no context is established, all programs are
-permitted. This permissive default is intentional to ease adoption but weakens
-safety. `scoped(ScopeConfig())` remains permissive; establish an explicit
-allowlist via `scoped(ScopeConfig(allowlist=...))` to enforce policy once
-onboarded. An empty allowlist produced by narrowing an explicit scope remains
-restrictive and permits no programs.
+**Empty allowlist behaviour:** When no parent context is established,
+`scoped(ScopeConfig())` is the permissive root context (all programs allowed),
+which supports adoption by defaulting to non-restrictive execution for
+first-time callers.
+Nested `scoped(ScopeConfig())` calls inherit the current parent policy, so they
+cannot widen permissions. If an explicit empty allowlist is introduced in an
+already restricted path, that scope remains restrictive and permits no programs.
 
 ### Scoped contexts
 
@@ -404,11 +405,9 @@ with scoped(ScopeConfig(allowlist=frozenset([ECHO, LS]))) as ctx:
 
 Key properties of `scoped(ScopeConfig())`:
 
-- When the parent allowlist is empty, the provided allowlist becomes the new
-  base unless that empty allowlist was produced by narrowing an explicit
-  restricted scope.
-- When the parent has programs, the new allowlist is intersected (can only
-  narrow, never widen).
+- At root/no-parent, `ScopeConfig()` remains permissive by default.
+- In nested scopes, `ScopeConfig()` inherits the parent allowlist and therefore
+  remains restricted when the parent is restricted.
 - Context is automatically restored when the block exits, even on exception.
 
 ### Accessing the current context
@@ -1185,19 +1184,6 @@ on the same thread: nested selector activation raises `RuntimeError` rather
 than risking a stale environment value or backend cache leak. Avoid wrapping one
 `BackendSelector` activation inside another; start a separate worker process
 or let the outer selector own the full profiled run.
-
-Worker results include selector observability fields:
-
-- `lock_wait_seconds` (float): cumulative seconds spent waiting to enter
-  `_BACKEND_LOCK` while forcing backend selection.
-- `reentrant_rejection_count` (int): count of nested selector activations
-  rejected on the current thread.
-
-Both values are cleared at the start of every worker run, so
-`worker-result.json` reports per-invocation totals rather than process-lifetime
-aggregates. When comparing repeated benchmark runs, treat `lock_wait_seconds`
-and `reentrant_rejection_count` as metrics for that single worker invocation's
-`_BACKEND_LOCK` selector context.
 
 Both backends are tested for behavioural parity across edge cases including
 empty streams, multi-byte UTF-8 at chunk boundaries, broken pipes (where the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -378,9 +378,10 @@ When you call `SafeCmd.run()` or `run_sync()`, Cuprum automatically:
 
 **Empty allowlist behaviour:** When no context is established, all programs are
 permitted. This permissive default is intentional to ease adoption but weakens
-safety; establish an explicit allowlist via `scoped(ScopeConfig())` to enforce
-policy once onboarded. An empty allowlist produced by narrowing an explicit
-scope remains restrictive and permits no programs.
+safety. `scoped(ScopeConfig())` remains permissive; establish an explicit
+allowlist via `scoped(ScopeConfig(allowlist=...))` to enforce policy once
+onboarded. An empty allowlist produced by narrowing an explicit scope remains
+restrictive and permits no programs.
 
 ### Scoped contexts
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -446,9 +446,9 @@ with scoped(ScopeConfig(allowlist=frozenset([ECHO]))):
 For manual control, use the `AllowRegistration` handle directly:
 
 ```python
-from cuprum import LS, allow, current_context, ScopeConfig, scoped
+from cuprum import ECHO, LS, allow, current_context, ScopeConfig, scoped
 
-with scoped(ScopeConfig()):
+with scoped(ScopeConfig(allowlist=frozenset([ECHO]))):
     reg = allow(LS)
     assert current_context().is_allowed(LS)
     reg.detach()  # Remove LS from allowlist

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -376,10 +376,11 @@ When you call `SafeCmd.run()` or `run_sync()`, Cuprum automatically:
 3. Invokes all registered after hooks (in LIFO order) after the process
    completes.
 
-**Empty allowlist behaviour:** When no context is established (or the context
-has an empty allowlist), all programs are permitted. This permissive default is
-intentional to ease adoption but weakens safety; establish an explicit
-allowlist via `scoped(ScopeConfig())` to enforce policy once onboarded.
+**Empty allowlist behaviour:** When no context is established, all programs are
+permitted. This permissive default is intentional to ease adoption but weakens
+safety; establish an explicit allowlist via `scoped(ScopeConfig())` to enforce
+policy once onboarded. An empty allowlist produced by narrowing an explicit
+scope remains restrictive and permits no programs.
 
 ### Scoped contexts
 
@@ -403,7 +404,8 @@ with scoped(ScopeConfig(allowlist=frozenset([ECHO, LS]))) as ctx:
 Key properties of `scoped(ScopeConfig())`:
 
 - When the parent allowlist is empty, the provided allowlist becomes the new
-  base.
+  base unless that empty allowlist was produced by narrowing an explicit
+  restricted scope.
 - When the parent has programs, the new allowlist is intersected (can only
   narrow, never widen).
 - Context is automatically restored when the block exits, even on exception.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ Repository = "https://github.com/leynos/cuprum"
 dev = [
     "crosshair-tool",
     "hypothesis",
+    "hypothesis-crosshair",
     "interrogate",
     "pytest",
     "pytest-benchmark",

--- a/uv.lock
+++ b/uv.lock
@@ -92,6 +92,7 @@ source = { editable = "." }
 dev = [
     { name = "crosshair-tool" },
     { name = "hypothesis" },
+    { name = "hypothesis-crosshair" },
     { name = "interrogate" },
     { name = "maturin" },
     { name = "pyright" },
@@ -111,6 +112,7 @@ dev = [
 dev = [
     { name = "crosshair-tool" },
     { name = "hypothesis" },
+    { name = "hypothesis-crosshair" },
     { name = "interrogate" },
     { name = "maturin", specifier = "==1.13.3" },
     { name = "pyright" },
@@ -152,6 +154,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/e1/ef365ff480903b929d28e057f57b76cae51a30375943e33374ec9a165d9c/hypothesis-6.151.9.tar.gz", hash = "sha256:2f284428dda6c3c48c580de0e18470ff9c7f5ef628a647ee8002f38c3f9097ca", size = 463534, upload-time = "2026-02-16T22:59:23.09Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl", hash = "sha256:7b7220585c67759b1b1ef839b1e6e9e3d82ed468cfc1ece43c67184848d7edd9", size = 529307, upload-time = "2026-02-16T22:59:20.443Z" },
+]
+
+[[package]]
+name = "hypothesis-crosshair"
+version = "0.0.28"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "crosshair-tool" },
+    { name = "hypothesis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/2e/8c00562bdd92e5f27263b1e150a439f6949ba862c26eab124aed10d4f21f/hypothesis_crosshair-0.0.28.tar.gz", hash = "sha256:5b881d6178162dfa393852bc92e59186894c48f3879c64382f4681494af9757e", size = 13795, upload-time = "2026-04-29T00:13:57.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/ff/4e4b289884514859034154361855ba4ae8f163342b67f24a013f60a058ff/hypothesis_crosshair-0.0.28-py3-none-any.whl", hash = "sha256:fa7651a4f74d219db84743370ddc206fcfed612d80a49d58988baf75f497f018", size = 15968, upload-time = "2026-04-29T00:13:56.594Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This branch adds property-based coverage for `CuprumContext.narrow` and `_validate_timeout`, and it extracts the narrowing, hook merge, and timeout resolution rules into named pure helpers.

Closes [#66](https://github.com/leynos/cuprum/issues/66).

It also closes a permission-broadening gap found while encoding the properties: an empty allowlist produced by narrowing a restricted scope now remains restrictive, rather than becoming a new permissive base for later nested scopes.

## Review walkthrough

- Start with [cuprum/context.py](https://github.com/leynos/cuprum/blob/issue-66-property-based-tests-for-cuprumcontext-narrow-and-validate-timeout-cuprum-context-py/cuprum/context.py) for the pure helpers and the internal restricted-empty allowlist state.
- Then review [cuprum/unittests/strategies.py](https://github.com/leynos/cuprum/blob/issue-66-property-based-tests-for-cuprumcontext-narrow-and-validate-timeout-cuprum-context-py/cuprum/unittests/strategies.py) and [cuprum/unittests/test_context.py](https://github.com/leynos/cuprum/blob/issue-66-property-based-tests-for-cuprumcontext-narrow-and-validate-timeout-cuprum-context-py/cuprum/unittests/test_context.py) for the Hypothesis and CrossHair-backed properties.
- Finish with [cuprum/unittests/conftest.py](https://github.com/leynos/cuprum/blob/issue-66-property-based-tests-for-cuprumcontext-narrow-and-validate-timeout-cuprum-context-py/cuprum/unittests/conftest.py), [docs/users-guide.md](https://github.com/leynos/cuprum/blob/issue-66-property-based-tests-for-cuprumcontext-narrow-and-validate-timeout-cuprum-context-py/docs/users-guide.md), and [docs/cuprum-design.md](https://github.com/leynos/cuprum/blob/issue-66-property-based-tests-for-cuprumcontext-narrow-and-validate-timeout-cuprum-context-py/docs/cuprum-design.md) for verification setup and documented semantics.

## Validation

- `make check-fmt`: passed.
- `make test`: passed, 623 passed and 44 skipped; Rust nextest passed 4 tests.
- `make typecheck`: passed.
- `make lint`: passed.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `uv run pytest -q cuprum/unittests/test_context.py -m crosshair --hypothesis-profile=crosshair`: passed, 14 passed and 43 deselected.
- `coderabbit review --agent`: passed with 0 findings after addressing the initial strategy comments.

## References

- Lody session: https://lody.ai/leynos/sessions/4ce8383c-7edf-45b7-a7c7-aa4344723f5f
