### PR TITLE
Add reducer property checks for final results (#67)

### DIFF
--- a/cuprum/concurrent.py
+++ b/cuprum/concurrent.py
@@ -180,6 +180,13 @@ def _build_final_results(
         final_results (not original positions) for failed commands, in ascending
         order.
 
+    post: all(result is not None for result in __return__[0])
+    post: __return__[0] == [result for result in results if result is not None]
+    post: len(__return__[0]) == sum(1 for result in results if result is not None)
+    post: all(0 <= idx < len(__return__[0]) for idx in __return__[1])
+    post: all(not __return__[0][idx].ok for idx in __return__[1])
+    post: __return__[1] == sorted(__return__[1])
+
     """
     final_results: list[CommandResult] = []
     failures: list[int] = []

--- a/cuprum/sh.py
+++ b/cuprum/sh.py
@@ -42,9 +42,7 @@ from cuprum.catalogue import UnknownProgramError as UnknownProgramError
 from cuprum.context import current_context, merge_env_overlays
 from cuprum.context import observe as observe
 from cuprum.context import scoped as scoped
-
-if typ.TYPE_CHECKING:
-    from cuprum.program import Program
+from cuprum.program import Program  # noqa: TC001
 
 type _ArgValue = str | int | float | bool | Path
 type SafeCmdBuilder = cabc.Callable[..., SafeCmd]

--- a/cuprum/sh.py
+++ b/cuprum/sh.py
@@ -42,6 +42,9 @@ from cuprum.catalogue import UnknownProgramError as UnknownProgramError
 from cuprum.context import current_context, merge_env_overlays
 from cuprum.context import observe as observe
 from cuprum.context import scoped as scoped
+
+# Program must be imported at runtime rather than under TYPE_CHECKING
+# because test modules instantiate CommandResult with Program values directly.
 from cuprum.program import Program  # noqa: TC001
 
 type _ArgValue = str | int | float | bool | Path

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -56,6 +56,7 @@
       'cuprum/unittests/test_benchmark_ci_ratchet.py',
       'cuprum/unittests/test_benchmark_comparison_report.py',
       'cuprum/unittests/test_benchmark_suite.py',
+      'cuprum/unittests/test_build_final_results_property.py',
       'cuprum/unittests/test_builder_library.py',
       'cuprum/unittests/test_catalogue.py',
       'cuprum/unittests/test_ci_benchmark_ratchet_profile.py',

--- a/cuprum/unittests/test_build_final_results_property.py
+++ b/cuprum/unittests/test_build_final_results_property.py
@@ -1,0 +1,102 @@
+"""Property tests for compacting fail-fast concurrent command results.
+
+Run ``crosshair check
+cuprum.unittests.test_build_final_results_property._assert_build_final_results_invariants
+--analysis_kind asserts`` for symbolic verification.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from cuprum.concurrent import _build_final_results
+from cuprum.sh import CommandResult, Program
+
+_MAX_TEXT_SIZE: int = 8
+_MAX_ARGV_SIZE: int = 4
+_MAX_RESULTS_SIZE: int = 8
+
+
+def _load_crosshair_hypothesis() -> None:
+    """Load CrossHair's Hypothesis integration when the package provides it."""
+    if importlib.util.find_spec("crosshair.hypothesis") is not None:
+        importlib.import_module("crosshair.hypothesis")
+
+
+_load_crosshair_hypothesis()
+
+
+@st.composite
+def command_results(draw: st.DrawFn) -> CommandResult:
+    """Build compact ``CommandResult`` instances for reducer properties."""
+    return CommandResult(
+        program=Program(draw(st.text(min_size=1, max_size=_MAX_TEXT_SIZE))),
+        argv=draw(
+            st.lists(
+                st.text(max_size=_MAX_TEXT_SIZE),
+                max_size=_MAX_ARGV_SIZE,
+            ).map(tuple),
+        ),
+        exit_code=draw(
+            st.one_of(
+                st.sampled_from([-1, 0, 1]),
+                st.integers(min_value=-128, max_value=255),
+            ),
+        ),
+        pid=draw(st.one_of(st.just(-1), st.integers(min_value=0, max_value=4096))),
+        stdout=draw(st.one_of(st.none(), st.text(max_size=_MAX_TEXT_SIZE))),
+        stderr=draw(st.one_of(st.none(), st.text(max_size=_MAX_TEXT_SIZE))),
+    )
+
+
+@st.composite
+def partial_results_lists(draw: st.DrawFn) -> list[CommandResult | None]:
+    """Build partial result lists with completed and cancelled entries."""
+    return draw(
+        st.lists(
+            st.one_of(st.none(), command_results()),
+            max_size=_MAX_RESULTS_SIZE,
+        ),
+    )
+
+
+def _build_final_results_invariants_hold(
+    inputs: list[CommandResult | None],
+) -> bool:
+    """Return whether the reducer satisfies its compaction invariants."""
+    final_results, failures = _build_final_results(inputs)
+    expected_results = [result for result in inputs if result is not None]
+
+    return (
+        all(0 <= idx < len(final_results) for idx in failures)
+        and all(not final_results[idx].ok for idx in failures)
+        and failures == sorted(failures)
+        and None not in final_results
+        and len(final_results) == sum(1 for result in inputs if result is not None)
+        and final_results == expected_results
+    )
+
+
+def _assert_build_final_results_invariants(
+    inputs: list[CommandResult | None],
+) -> None:
+    """Assert the reducer's compacted output and failure-index invariants."""
+    assert _build_final_results_invariants_hold(inputs), (
+        f"expected compacted output and failure-index invariants to hold for {inputs!r}"
+    )
+
+
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(inputs=partial_results_lists())
+def test_build_final_results_preserves_compaction_invariants(
+    inputs: list[CommandResult | None],
+) -> None:
+    """Reducer output contains compacted results and valid failure indices."""
+    _assert_build_final_results_invariants(inputs)

--- a/cuprum/unittests/test_build_final_results_property.py
+++ b/cuprum/unittests/test_build_final_results_property.py
@@ -92,6 +92,14 @@ def _failure_indices_sorted(failures: list[int]) -> bool:
     return failures == sorted(failures)
 
 
+def _failures_are_exhaustive(
+    failures: list[int],
+    final_results: list[CommandResult],
+) -> bool:
+    """Return whether failures contains exactly the indices of every non-ok result."""
+    return failures == sorted(i for i, r in enumerate(final_results) if not r.ok)
+
+
 def _no_cancelled_entries(final_results: list[CommandResult]) -> bool:
     """Return whether compacted results contain no cancelled entries."""
     return None not in final_results
@@ -124,6 +132,7 @@ def _build_final_results_invariants_hold(
         _failure_indices_in_bounds(failures, final_results)
         and _failure_indices_point_to_failures(failures, final_results)
         and _failure_indices_sorted(failures)
+        and _failures_are_exhaustive(failures, final_results)
         and _no_cancelled_entries(final_results)
         and _result_count_matches(final_results, inputs)
         and _order_preserved(final_results, expected_results)

--- a/cuprum/unittests/test_build_final_results_property.py
+++ b/cuprum/unittests/test_build_final_results_property.py
@@ -63,6 +63,48 @@ def partial_results_lists(draw: st.DrawFn) -> list[CommandResult | None]:
     )
 
 
+def _failure_indices_in_bounds(
+    failures: list[int],
+    final_results: list[CommandResult],
+) -> bool:
+    """Return whether every failure index addresses the compacted result list."""
+    return all(0 <= idx < len(final_results) for idx in failures)
+
+
+def _failure_indices_point_to_failures(
+    failures: list[int],
+    final_results: list[CommandResult],
+) -> bool:
+    """Return whether every failure index points at a failed command result."""
+    return all(not final_results[idx].ok for idx in failures)
+
+
+def _failure_indices_sorted(failures: list[int]) -> bool:
+    """Return whether failure indices are sorted in ascending order."""
+    return failures == sorted(failures)
+
+
+def _no_cancelled_entries(final_results: list[CommandResult]) -> bool:
+    """Return whether compacted results contain no cancelled entries."""
+    return None not in final_results
+
+
+def _result_count_matches(
+    final_results: list[CommandResult],
+    inputs: list[CommandResult | None],
+) -> bool:
+    """Return whether compacted result count matches completed inputs."""
+    return len(final_results) == sum(1 for r in inputs if r is not None)
+
+
+def _order_preserved(
+    final_results: list[CommandResult],
+    expected_results: list[CommandResult],
+) -> bool:
+    """Return whether compacted results preserve input order."""
+    return final_results == expected_results
+
+
 def _build_final_results_invariants_hold(
     inputs: list[CommandResult | None],
 ) -> bool:
@@ -71,12 +113,12 @@ def _build_final_results_invariants_hold(
     expected_results = [result for result in inputs if result is not None]
 
     return (
-        all(0 <= idx < len(final_results) for idx in failures)
-        and all(not final_results[idx].ok for idx in failures)
-        and failures == sorted(failures)
-        and None not in final_results
-        and len(final_results) == sum(1 for result in inputs if result is not None)
-        and final_results == expected_results
+        _failure_indices_in_bounds(failures, final_results)
+        and _failure_indices_point_to_failures(failures, final_results)
+        and _failure_indices_sorted(failures)
+        and _no_cancelled_entries(final_results)
+        and _result_count_matches(final_results, inputs)
+        and _order_preserved(final_results, expected_results)
     )
 
 

--- a/cuprum/unittests/test_build_final_results_property.py
+++ b/cuprum/unittests/test_build_final_results_property.py
@@ -8,12 +8,20 @@ cuprum.unittests.test_build_final_results_property._assert_build_final_results_i
 from __future__ import annotations
 
 import importlib.util
+import sys
 
+import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from cuprum.concurrent import _build_final_results
 from cuprum.sh import CommandResult, Program
+
+if sys.version_info >= (3, 15):
+    pytest.skip(
+        "CrossHair does not support Python 3.15 CALL_KW tracing yet; see #109.",
+        allow_module_level=True,
+    )
 
 _MAX_TEXT_SIZE: int = 8
 _MAX_ARGV_SIZE: int = 4

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -35,6 +35,47 @@ uv run pytest -q cuprum/unittests/test_line_splitting.py
 Run `make test` before committing so the stream behaviour and the pure helper
 contracts stay aligned.
 
+## Fail-fast reducer properties
+
+`_build_final_results` in `cuprum/concurrent.py` is the pure reducer that
+compacts fail-fast concurrent command results.  It drops `None` (cancelled)
+entries and remaps failure indices to the compacted result list.  The reducer
+carries explicit postcondition-style contracts in its docstring:
+
+- `final_results` contains only non-`None` entries (cancelled slots removed).
+- `len(final_results)` equals the number of non-`None` entries in `inputs`.
+- Every index in `failures` is within `[0, len(final_results))`.
+- `failures` is sorted in ascending order.
+- Every index in `failures` points at an entry with `ok == False`.
+- `failures` contains *all* such indices — no non-ok entry is omitted.
+- The relative order of non-`None` inputs is preserved in `final_results`.
+
+These invariants are verified at two levels:
+
+- **Hypothesis** (`cuprum/unittests/test_build_final_results_property.py`)
+  generates up to 50 compact `CommandResult | None` lists and asserts
+  `_build_final_results_invariants_hold` over each.  Run:
+
+  ```bash
+  uv run pytest -q cuprum/unittests/test_build_final_results_property.py
+  ```
+
+- **CrossHair** performs bounded symbolic verification over the assertion
+  target.  Run:
+
+  ```bash
+  uv run crosshair check \
+    cuprum.unittests.test_build_final_results_property._assert_build_final_results_invariants \
+    --analysis_kind asserts
+  ```
+
+  CrossHair is a development dependency only.  The property module skips
+  symbolic checks on Python 3.15, where CrossHair cannot yet trace the
+  `CALL_KW` opcode (tracked in issue `#109`).
+
+When changing `_build_final_results`, run both verification paths before
+committing.
+
 ## Environment overlay resolution
 
 The user-facing `env(...)` context manager and the related `ScopeConfig` field

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -557,7 +557,10 @@ host tool. The `RUFF` variable expands to `$(UV_RUN_ENV) uv run ruff`, and the
 dependency from `uv.lock` is available before running `fmt`, `check-fmt`, or
 `lint`. Continuous Integration (CI) and local runs must keep using this
 `uv run` path for Ruff linting and formatting so preview-rule changes only
-arrive through an explicit lockfile update.
+arrive through an explicit lockfile update. `interrogate` is also invoked via
+`uv run` in the `lint` recipe, but it is not included in `VENV_TOOLS` and so
+is not gated by the probe; it relies on `uv sync` having installed it into the
+locked virtualenv.
 
 Because `interrogate` requires a docstring on every documentable node,
 documenting a large module can take it over the project's 400-line ceiling


### PR DESCRIPTION
## Summary

This branch adds property-based verification for the fail-fast result
compaction reducer in issue #67. It covers the pure `_build_final_results`
path so cancelled entries are dropped, completed results retain their relative
order, and remapped failure indices remain valid, sorted and tied to failed
results.

Closes #67.

## Review walkthrough

- Start with [`cuprum/concurrent.py`](https://github.com/leynos/cuprum/blob/aa13880a53d8750d8f7acca16eea21e40de5f22c/cuprum/concurrent.py#L166) for the reducer postconditions.
- Then review [`cuprum/unittests/test_build_final_results_property.py`](https://github.com/leynos/cuprum/blob/aa13880a53d8750d8f7acca16eea21e40de5f22c/cuprum/unittests/test_build_final_results_property.py) for the bounded Hypothesis strategies and CrossHair assertion target.
- Finish with [`pyproject.toml`](https://github.com/leynos/cuprum/blob/aa13880a53d8750d8f7acca16eea21e40de5f22c/pyproject.toml#L18) and [`uv.lock`](https://github.com/leynos/cuprum/blob/aa13880a53d8750d8f7acca16eea21e40de5f22c/uv.lock) for the `crosshair-tool` development dependency.

## Validation

- `uv run pytest -q cuprum/unittests/test_build_final_results_property.py`: passed
- `uv run crosshair check cuprum.unittests.test_build_final_results_property._assert_build_final_results_invariants --analysis_kind asserts`: passed
- `make check-fmt`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make test`: passed, 472 passed and 43 skipped
- `coderabbit review --agent`: passed with 0 findings after follow-up fixes

## Notes

The installed CrossHair command exposes `check`, not `test`, so the property
module documents the supported symbolic verification command for this version.
