### PR TITLE
Add UTF-8 property tests (#79)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -318,7 +318,6 @@ and tool-discovery recipes only. This supports non-interactive Continuous
 Integration/Continuous Delivery (CI/CD) hook environments without globally
 shadowing system tools for unrelated Makefile workflows.
 
-
 ## Rust property testing and verification
 
 Rust-level tests for `cuprum-rust` live with the crate under

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -318,6 +318,56 @@ and tool-discovery recipes only. This supports non-interactive Continuous
 Integration/Continuous Delivery (CI/CD) hook environments without globally
 shadowing system tools for unrelated Makefile workflows.
 
+
+## Rust property testing and verification
+
+Rust-level tests for `cuprum-rust` live with the crate under
+`rust/cuprum-rust/src/`. Use them for pure decoder, parsing, state-machine, and
+adapter logic where Python integration tests would only cover a few examples.
+
+Property tests use [proptest](https://docs.rs/proptest/latest/proptest/) as a
+development dependency. Prefer generated payloads and small helper functions
+that expose pure behaviour. The UTF-8 decoder tests generate arbitrary byte
+vectors and chunk split points, then compare the decoded output with
+`String::from_utf8_lossy` as the oracle.
+
+Kani harnesses are reserved for bounded verification of small, high-value state
+spaces. Gate Kani-only modules and helpers with `#[cfg(kani)]`, and share pure
+test helpers behind `#[cfg(any(test, kani))]` when both proptest and Kani need
+the same simulation path. Register new custom cfg names in the workspace lint
+configuration so `unexpected_cfgs` warnings remain meaningful.
+
+Run the normal Rust gate from the `rust/` directory:
+
+```bash
+make test
+```
+
+`make test` runs the crate tests through `cargo nextest`, including proptest
+cases compiled under `#[cfg(test)]`. Run the complete Rust lint and formatting
+gates before committing Rust changes:
+
+```bash
+make check-fmt
+make lint
+```
+
+Run Kani separately because it is a bounded model checker rather than a normal
+unit-test runner. The Kani installer places the verifier under `~/.kani`; on
+this system the dynamic library path is required when invoking the crate
+harnesses:
+
+```bash
+LD_LIBRARY_PATH=/home/leynos/.kani/kani-0.67.0/toolchain/lib \
+  cargo kani --package cuprum-rust
+```
+
+When adding new Kani proofs, keep the bounds explicit with attributes such as
+`#[kani::unwind(N)]`, include `kani::cover!` statements for the intended
+boundary cases, and avoid broad symbolic comparisons that force Kani through
+large allocation-heavy standard-library internals unless the proof genuinely
+requires that surface.
+
 ## Python linting
 
 Cuprum uses a two-tier Python lint gate. Ruff is the first tier and remains the

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,10 +3,50 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "cuprum-rust"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "proptest",
  "pyo3",
  "trybuild",
 ]
@@ -24,10 +64,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -42,13 +144,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -58,36 +168,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -149,13 +324,106 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.43"
+name = "quick-error"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -210,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -221,15 +489,28 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-triple"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "termcolor"
@@ -296,10 +577,83 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.22"
+name = "unarray"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "winapi-util"
@@ -330,6 +684,120 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -66,6 +66,7 @@ result_large_err = "deny"
 
 [workspace.lints.rust]
 missing_docs = "deny"
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(kani)"] }
 
 [workspace.lints.rustdoc]
 missing_crate_level_docs = "deny"

--- a/rust/cuprum-rust/Cargo.toml
+++ b/rust/cuprum-rust/Cargo.toml
@@ -17,6 +17,7 @@ pyo3 = { version = "0.28.3", features = ["extension-module"] }
 libc = "0.2"
 
 [dev-dependencies]
+proptest = "1"
 trybuild = { version = "1", features = ["diff"] }
 
 [lints]

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -92,13 +92,14 @@ fn rust_consume_stream(py: Python<'_>, reader_fd: i64, buffer_size: i64) -> PyRe
 
 #[cfg(unix)]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {
-    let handle_value = value as u64;
-    if usize::BITS >= 64 {
-        return Ok(handle_value as usize);
+    let fd =
+        i32::try_from(value).map_err(|_| PyValueError::new_err("file descriptor out of range"))?;
+    if fd < 0 {
+        return Err(PyValueError::new_err(
+            "file descriptor must be non-negative",
+        ));
     }
-    let truncated = u32::try_from(handle_value)
-        .map_err(|_| PyValueError::new_err("file handle out of range"))?;
-    Ok(truncated as usize)
+    Ok(fd)
 }
 
 #[cfg(windows)]
@@ -128,9 +129,9 @@ fn validate_buffer_size(buffer_size: i64) -> PyResult<BufferSize> {
 }
 
 #[cfg(unix)]
-fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
-    // SAFETY: The caller ensures the handle is valid and owned by the caller.
-    unsafe { File::from_raw_handle(handle as RawHandle) }
+fn stream_from_raw(fd: PlatformFd) -> StreamHandle {
+    // SAFETY: The caller ensures the fd is valid and owned by the caller.
+    unsafe { OwnedFd::from_raw_fd(fd) }
 }
 
 #[cfg(windows)]
@@ -167,7 +168,7 @@ fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String
 }
 
 #[cfg(unix)]
-type PlatformFd = usize;
+type PlatformFd = i32;
 
 #[cfg(windows)]
 type PlatformFd = usize;

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -27,11 +27,15 @@ use utf8::{FinalChunk, decode_utf8_replace};
 
 /// Report whether the Rust extension is available.
 ///
+/// This entry point is only reached once the native module has loaded, so it
+/// always reports `true`. The Python wrapper treats a failed import as
+/// "unavailable", so no runtime probing is needed here.
+///
 /// # Returns
-/// `true` when the extension is successfully loaded.
+/// `true` whenever the extension is loaded and callable.
 #[expect(
     clippy::missing_const_for_fn,
-    reason = "PyO3 runtime entrypoints should not be const functions."
+    reason = "runtime #[pyfunction] FFI boundary: the body is const-evaluable but the export must stay a runtime function, not a const item"
 )]
 #[pyfunction]
 fn is_available() -> bool {

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -29,8 +29,12 @@ use utf8::{FinalChunk, decode_utf8_replace};
 ///
 /// # Returns
 /// `true` when the extension is successfully loaded.
+#[expect(
+    clippy::missing_const_for_fn,
+    reason = "PyO3 runtime entrypoints should not be const functions."
+)]
 #[pyfunction]
-const fn is_available() -> bool {
+fn is_available() -> bool {
     true
 }
 
@@ -88,14 +92,13 @@ fn rust_consume_stream(py: Python<'_>, reader_fd: i64, buffer_size: i64) -> PyRe
 
 #[cfg(unix)]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {
-    let fd =
-        i32::try_from(value).map_err(|_| PyValueError::new_err("file descriptor out of range"))?;
-    if fd < 0 {
-        return Err(PyValueError::new_err(
-            "file descriptor must be non-negative",
-        ));
+    let handle_value = value as u64;
+    if usize::BITS >= 64 {
+        return Ok(handle_value as usize);
     }
-    Ok(fd)
+    let truncated = u32::try_from(handle_value)
+        .map_err(|_| PyValueError::new_err("file handle out of range"))?;
+    Ok(truncated as usize)
 }
 
 #[cfg(windows)]
@@ -125,9 +128,9 @@ fn validate_buffer_size(buffer_size: i64) -> PyResult<BufferSize> {
 }
 
 #[cfg(unix)]
-fn stream_from_raw(fd: PlatformFd) -> StreamHandle {
-    // SAFETY: The caller ensures the fd is valid and owned by the caller.
-    unsafe { OwnedFd::from_raw_fd(fd) }
+fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
+    // SAFETY: The caller ensures the handle is valid and owned by the caller.
+    unsafe { File::from_raw_handle(handle as RawHandle) }
 }
 
 #[cfg(windows)]
@@ -164,7 +167,7 @@ fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String
 }
 
 #[cfg(unix)]
-type PlatformFd = i32;
+type PlatformFd = usize;
 
 #[cfg(windows)]
 type PlatformFd = usize;

--- a/rust/cuprum-rust/src/utf8.rs
+++ b/rust/cuprum-rust/src/utf8.rs
@@ -61,6 +61,19 @@ pub(crate) fn decode_utf8_replace(
     }
 }
 
+/// Decode multiple byte chunks through the incremental replacement decoder.
+#[cfg(any(test, kani))]
+pub(crate) fn decode_chunks(chunks: &[&[u8]], final_chunk: bool) -> (String, Vec<u8>) {
+    let mut pending = Vec::new();
+    let mut output = String::new();
+    for chunk in chunks {
+        pending.extend_from_slice(chunk);
+        decode_utf8_replace(&mut pending, &mut output, FinalChunk::new(false));
+    }
+    decode_utf8_replace(&mut pending, &mut output, FinalChunk::new(final_chunk));
+    (output, pending)
+}
+
 /// Append the valid UTF-8 prefix from pending to output.
 fn append_valid_prefix(pending: &[u8], output: &mut String, valid_up_to: ValidUpTo) {
     if valid_up_to.value() == 0 {
@@ -68,10 +81,10 @@ fn append_valid_prefix(pending: &[u8], output: &mut String, valid_up_to: ValidUp
     }
     // SAFETY: `valid_up_to` comes from a `Utf8Error`, so this prefix is known
     // to be valid UTF-8.
-    let Some(prefix) = pending.get(..valid_up_to.value()) else {
+    let Some(prefix_bytes) = pending.get(..valid_up_to.value()) else {
         return;
     };
-    let valid_prefix = unsafe { std::str::from_utf8_unchecked(prefix) };
+    let valid_prefix = unsafe { std::str::from_utf8_unchecked(prefix_bytes) };
     output.push_str(valid_prefix);
 }
 
@@ -125,4 +138,98 @@ fn handle_incomplete_sequence(
         pending.drain(..valid_up_to.value());
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    //! Property tests for the incremental UTF-8 replacement decoder.
+
+    use proptest::prelude::*;
+
+    use super::{FinalChunk, decode_chunks, decode_utf8_replace};
+
+    fn split_input_at_points<'input>(
+        input: &'input [u8],
+        split_points: &[usize],
+    ) -> Vec<&'input [u8]> {
+        let mut sorted_points = split_points
+            .iter()
+            .map(|point| (*point).min(input.len()))
+            .collect::<Vec<_>>();
+        sorted_points.sort_unstable();
+        sorted_points.dedup();
+
+        let mut chunks = Vec::new();
+        let mut offset = 0_usize;
+        let mut remainder = input;
+        for split_point in sorted_points {
+            let (chunk, next_remainder) = remainder.split_at(split_point.saturating_sub(offset));
+            chunks.push(chunk);
+            remainder = next_remainder;
+            offset = split_point;
+        }
+        chunks.push(remainder);
+        chunks
+    }
+
+    fn decode_single_chunk(input: &[u8], final_chunk: bool) -> (String, Vec<u8>) {
+        let mut pending = input.to_vec();
+        let mut output = String::new();
+        decode_utf8_replace(&mut pending, &mut output, FinalChunk::new(final_chunk));
+        (output, pending)
+    }
+
+    fn incomplete_tail_strategy() -> impl Strategy<Value = Vec<u8>> {
+        prop_oneof![
+            Just(vec![0xC2]),
+            Just(vec![0xDF]),
+            Just(vec![0xE0, 0xA0]),
+            Just(vec![0xE1, 0x80]),
+            Just(vec![0xEF, 0xBF]),
+            Just(vec![0xF0, 0x90, 0x80]),
+            Just(vec![0xF1, 0x80, 0x80]),
+            Just(vec![0xF4, 0x8F, 0xBF]),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn single_chunk_matches_from_utf8_lossy(input in any::<Vec<u8>>()) {
+            let (output, pending) = decode_single_chunk(&input, true);
+
+            prop_assert_eq!(output, String::from_utf8_lossy(&input).into_owned());
+            prop_assert!(pending.is_empty());
+        }
+
+        #[test]
+        fn chunked_decoding_matches_from_utf8_lossy(
+            input in any::<Vec<u8>>(),
+            split_points in prop::collection::vec(0_usize..256, 0..32),
+        ) {
+            let chunks = split_input_at_points(&input, &split_points);
+            let (output, pending) = decode_chunks(&chunks, true);
+
+            prop_assert_eq!(output, String::from_utf8_lossy(&input).into_owned());
+            prop_assert!(pending.is_empty());
+        }
+
+        #[test]
+        fn incomplete_sequences_are_retained_until_final_chunk(
+            prefix in any::<String>(),
+            tail in incomplete_tail_strategy(),
+        ) {
+            let mut input = prefix.into_bytes();
+            input.extend_from_slice(&tail);
+            let prefix_len = input.len() - tail.len();
+            let (valid_prefix, _) = input.split_at(prefix_len);
+
+            let (deferred_output, deferred_pending) = decode_single_chunk(&input, false);
+            prop_assert_eq!(deferred_output, String::from_utf8_lossy(valid_prefix));
+            prop_assert_eq!(deferred_pending, tail);
+
+            let (final_output, final_pending) = decode_single_chunk(&input, true);
+            prop_assert_eq!(final_output, String::from_utf8_lossy(&input).into_owned());
+            prop_assert!(final_pending.is_empty());
+        }
+    }
 }

--- a/rust/cuprum-rust/src/utf8.rs
+++ b/rust/cuprum-rust/src/utf8.rs
@@ -233,3 +233,97 @@ mod tests {
         }
     }
 }
+
+#[cfg(kani)]
+mod kani_proofs {
+    //! Bounded Kani proofs for short UTF-8 payloads and chunk boundaries.
+
+    use super::{FinalChunk, decode_chunks, decode_utf8_replace};
+
+    fn decode_single_chunk(input: &[u8], final_chunk: bool) -> (String, Vec<u8>) {
+        let mut pending = input.to_vec();
+        let mut output = String::new();
+        decode_utf8_replace(&mut pending, &mut output, FinalChunk::new(final_chunk));
+        (output, pending)
+    }
+
+    fn is_valid_incomplete_utf8_sequence(pending: &[u8]) -> bool {
+        match pending {
+            [first] => matches!(first, 0xC2..=0xDF | 0xE0..=0xEF | 0xF0..=0xF4),
+            [0xE0, second] => matches!(second, 0xA0..=0xBF),
+            [0xE1..=0xEC, second] => matches!(second, 0x80..=0xBF),
+            [0xED, second] => matches!(second, 0x80..=0x9F),
+            [0xEE..=0xEF, second] => matches!(second, 0x80..=0xBF),
+            [0xF0, second] => matches!(second, 0x90..=0xBF),
+            [0xF1..=0xF3, second] => matches!(second, 0x80..=0xBF),
+            [0xF4, second] => matches!(second, 0x80..=0x8F),
+            [0xF0, second, third] => matches!(second, 0x90..=0xBF) && matches!(third, 0x80..=0xBF),
+            [0xF1..=0xF3, second, third] => {
+                matches!(second, 0x80..=0xBF) && matches!(third, 0x80..=0xBF)
+            }
+            [0xF4, second, third] => matches!(second, 0x80..=0x8F) && matches!(third, 0x80..=0xBF),
+            _ => false,
+        }
+    }
+
+    #[kani::proof]
+    #[kani::unwind(5)]
+    fn single_chunk_matches_from_utf8_lossy() {
+        let input = [b'a', 0xFF, b'b'];
+        let (output, pending) = decode_single_chunk(&input, true);
+        let output_bytes = output.as_bytes();
+
+        kani::cover!(output_bytes.len() == 5, "exercise invalid UTF-8 payloads");
+        kani::assert(output_bytes.len() == 5, "replacement output length");
+        kani::assert(output_bytes[0] == b'a', "valid prefix is preserved");
+        kani::assert(output_bytes[1] == 0xEF, "replacement byte 1");
+        kani::assert(output_bytes[2] == 0xBF, "replacement byte 2");
+        kani::assert(output_bytes[3] == 0xBD, "replacement byte 3");
+        kani::assert(output_bytes[4] == b'b', "valid suffix is preserved");
+        kani::assert(
+            pending.is_empty(),
+            "final chunk must leave no pending bytes",
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(5)]
+    fn two_chunk_boundaries_match_from_utf8_lossy() {
+        let input = [0xC2, 0xA2];
+        let split_point = 1_usize;
+        let (left, right) = input.split_at(split_point);
+        let chunks = [left, right];
+        let (output, pending) = decode_chunks(&chunks, true);
+        let output_bytes = output.as_bytes();
+
+        kani::cover!(
+            left.len() == 1 && right.len() == 1,
+            "exercise split points that bisect valid multi-byte sequences"
+        );
+        kani::assert(output_bytes.len() == 2, "two chunks decode one scalar");
+        kani::assert(output_bytes[0] == 0xC2, "first scalar byte is preserved");
+        kani::assert(output_bytes[1] == 0xA2, "second scalar byte is preserved");
+        kani::assert(
+            pending.is_empty(),
+            "final chunk must leave no pending bytes",
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(5)]
+    fn pending_state_is_valid_incomplete_utf8() {
+        let input = [0xE0, 0xA0];
+        let (_output, pending) = decode_single_chunk(&input, false);
+
+        kani::assert(
+            pending.len() <= 3,
+            "pending UTF-8 tail is at most three bytes",
+        );
+        if !pending.is_empty() {
+            kani::assert(
+                is_valid_incomplete_utf8_sequence(&pending),
+                "pending bytes must form an incomplete UTF-8 prefix",
+            );
+        }
+    }
+}

--- a/rust/dylint.toml
+++ b/rust/dylint.toml
@@ -1,0 +1,2 @@
+[no_std_fs_operations]
+excluded_crates = ["_rust_backend_native"]


### PR DESCRIPTION
## Summary

This branch adds Rust-level property coverage for the incremental UTF-8 replacement decoder so arbitrary byte payloads and chunk boundaries are checked outside the Python integration layer.

Closes #79.

## Review walkthrough

- Start with [rust/cuprum-rust/src/utf8.rs](https://github.com/leynos/cuprum/blob/issue-79-rust-proptest-kani-property-tests-for-decode-utf8-replace/rust/cuprum-rust/src/utf8.rs) to review `decode_chunks`, the proptest properties, and the Kani harnesses.
- Then review [rust/cuprum-rust/Cargo.toml](https://github.com/leynos/cuprum/blob/issue-79-rust-proptest-kani-property-tests-for-decode-utf8-replace/rust/cuprum-rust/Cargo.toml) and [rust/Cargo.toml](https://github.com/leynos/cuprum/blob/issue-79-rust-proptest-kani-property-tests-for-decode-utf8-replace/rust/Cargo.toml) for the test dependency and `cfg(kani)` lint registration.
- Finish with [rust/dylint.toml](https://github.com/leynos/cuprum/blob/issue-79-rust-proptest-kani-property-tests-for-decode-utf8-replace/rust/dylint.toml) and the small Rust lint clean-ups needed to keep the existing gates passing.

## Validation

- `cargo fmt --all`: passed
- `make check-fmt`: passed
- `make test`: passed
- `make lint`: passed
- `LD_LIBRARY_PATH=/home/leynos/.kani/kani-0.67.0/toolchain/lib cargo kani --package cuprum-rust`: passed, 3 harnesses verified
- `coderabbit review --agent`: passed with 0 findings after the proptest milestone
- `coderabbit review --agent`: passed with 0 findings after the Kani milestone

## Notes

The proptest coverage uses `String::from_utf8_lossy` as the broad behavioural oracle for single-chunk, chunked, and incomplete-tail cases. The Kani harnesses use bounded concrete byte-level assertions for representative invalid, boundary-split, and pending-tail paths because direct symbolic comparison through `String::from_utf8_lossy` pulls allocation and string comparison internals beyond a useful proof size for this crate.
