### PR TITLE
Add line splitting property tests (#65)

### DIFF
--- a/benchmarks/_benchmark_types.py
+++ b/benchmarks/_benchmark_types.py
@@ -26,6 +26,8 @@ Validation helpers are defined alongside these dataclasses and are used by
 their ``__post_init__`` methods to enforce expected types and value ranges.
 """
 
+# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import dataclasses as dc
@@ -350,6 +352,11 @@ class PipelineBenchmarkConfig:
         )
         if validated_worker_iterations < 1:
             msg = f"worker_iterations must be >= 1, got {validated_worker_iterations}"
+            raise ValueError(msg)
+        if validated_worker_iterations > 1000:  # noqa: PLR2004
+            msg = (
+                f"worker_iterations must be <= 1000, got {validated_worker_iterations}"
+            )
             raise ValueError(msg)
 
 

--- a/benchmarks/_benchmark_types.py
+++ b/benchmarks/_benchmark_types.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import dataclasses as dc
 import pathlib as pth
+import sys
 import typing as typ
 
 _VALID_BACKENDS = {"python", "rust"}
@@ -281,8 +282,13 @@ class PipelineBenchmarkConfig:
         Measured iteration count for hyperfine.
     hyperfine_bin:
         Executable name or path for hyperfine.
+    python_bin:
+        Executable name or path for the Python interpreter used to run
+        ``benchmarks/pipeline_worker.py``. Benchmark commands use the
+        interpreter directly so ratchets do not measure ``uv run`` overhead.
     uv_bin:
-        Executable name or path for the ``uv`` launcher.
+        Deprecated compatibility setting. Scenario commands no longer use
+        ``uv run`` during measured benchmark iterations.
     dry_run:
         Whether to emit plan JSON without invoking hyperfine.
     rust_available:
@@ -313,7 +319,8 @@ class PipelineBenchmarkConfig:
     warmup: int
     runs: int
     hyperfine_bin: str = "hyperfine"
-    uv_bin: str = "uv"
+    python_bin: str = sys.executable
+    uv_bin: str | None = None
     dry_run: bool = False
     rust_available: bool = False
 
@@ -331,7 +338,9 @@ class PipelineBenchmarkConfig:
         )
         _validate_hyperfine_iterations(warmup=self.warmup, runs=self.runs)
         _validate_non_empty_string(self.hyperfine_bin, name="hyperfine_bin")
-        _validate_non_empty_string(self.uv_bin, name="uv_bin")
+        _validate_non_empty_string(self.python_bin, name="python_bin")
+        if self.uv_bin is not None:
+            _validate_non_empty_string(self.uv_bin, name="uv_bin")
         _validate_bool(self.dry_run, name="dry_run")
         _validate_bool(self.rust_available, name="rust_available")
 

--- a/benchmarks/_benchmark_types.py
+++ b/benchmarks/_benchmark_types.py
@@ -5,8 +5,6 @@ command construction and dry-run payload generation. It defines immutable
 dataclasses for scenario/config/result values and a TypedDict for serializable
 scenario payloads.
 
-Utility
--------
 Use these symbols when constructing benchmark plans in application code or
 tests, and rely on their ``__post_init__`` methods for fail-fast validation of
 core invariants (for example: non-empty names, positive payload sizes, and
@@ -293,6 +291,8 @@ class PipelineBenchmarkConfig:
         Whether to emit plan JSON without invoking hyperfine.
     rust_available:
         Whether Rust backend support is available in the current environment.
+    worker_iterations:
+        Number of pipeline executions performed inside one worker process.
 
     Raises
     ------
@@ -323,6 +323,7 @@ class PipelineBenchmarkConfig:
     uv_bin: str | None = None
     dry_run: bool = False
     rust_available: bool = False
+    worker_iterations: int = 20
 
     def __post_init__(self) -> None:
         """Validate benchmark configuration values."""
@@ -343,6 +344,13 @@ class PipelineBenchmarkConfig:
             _validate_non_empty_string(self.uv_bin, name="uv_bin")
         _validate_bool(self.dry_run, name="dry_run")
         _validate_bool(self.rust_available, name="rust_available")
+        validated_worker_iterations = _validate_int(
+            self.worker_iterations,
+            name="worker_iterations",
+        )
+        if validated_worker_iterations < 1:
+            msg = f"worker_iterations must be >= 1, got {validated_worker_iterations}"
+            raise ValueError(msg)
 
 
 @dc.dataclass(frozen=True, slots=True)

--- a/benchmarks/benchmark_profile.py
+++ b/benchmarks/benchmark_profile.py
@@ -30,16 +30,31 @@ def require_worker_iterations(payload: cabc.Mapping[str, object]) -> int:
 
 def validate_profile_version(payload: cabc.Mapping[str, object]) -> None:
     """Validate that a benchmark plan uses the current profile version."""
+    _require_profile_version(payload, context_name=None)
+
+
+def _require_profile_version(
+    payload: cabc.Mapping[str, object],
+    *,
+    context_name: str | None,
+) -> str:
+    """Return validated benchmark profile version metadata."""
     profile_value = payload.get("benchmark_profile_version")
     if not isinstance(profile_value, str) or not profile_value.strip():
-        msg = "benchmark_profile_version is missing from benchmark plan"
+        msg = (
+            f"{context_name} benchmark_profile_version is missing"
+            if context_name is not None
+            else "benchmark_profile_version is missing from benchmark plan"
+        )
         raise IncompatibleBenchmarkProfileError(msg)
     if profile_value != BENCHMARK_PROFILE_VERSION:
+        prefix = f"{context_name} " if context_name is not None else ""
         msg = (
-            "benchmark_profile_version is incompatible: "
+            f"{prefix}benchmark_profile_version is incompatible: "
             f"expected {BENCHMARK_PROFILE_VERSION!r}, got {profile_value!r}"
         )
         raise IncompatibleBenchmarkProfileError(msg)
+    return profile_value
 
 
 def validate_matching_profiles(
@@ -74,15 +89,7 @@ def _require_profile_metadata(
     context_name: str,
 ) -> tuple[str, int]:
     """Return validated profile metadata for ``validate_matching_profiles``."""
-    profile_value = payload.get("benchmark_profile_version")
-    if not isinstance(profile_value, str) or not profile_value.strip():
-        msg = f"{context_name} benchmark_profile_version is missing"
-        raise IncompatibleBenchmarkProfileError(msg)
-    try:
-        validate_profile_version(payload)
-    except IncompatibleBenchmarkProfileError as exc:
-        msg = f"{context_name} {exc}"
-        raise IncompatibleBenchmarkProfileError(msg) from exc
+    profile_value = _require_profile_version(payload, context_name=context_name)
     try:
         worker_iterations = require_worker_iterations(payload)
     except (TypeError, ValueError) as exc:

--- a/benchmarks/benchmark_profile.py
+++ b/benchmarks/benchmark_profile.py
@@ -48,14 +48,47 @@ def validate_matching_profiles(
     candidate_plan: cabc.Mapping[str, object],
 ) -> None:
     """Validate that benchmark profile metadata matches across both plans."""
-    baseline_iterations = baseline_plan.get("worker_iterations")
-    candidate_iterations = candidate_plan.get("worker_iterations")
+    baseline_profile = _require_profile_metadata(baseline_plan, context_name="baseline")
+    candidate_profile = _require_profile_metadata(
+        candidate_plan, context_name="candidate"
+    )
+    baseline_version, baseline_iterations = baseline_profile
+    candidate_version, candidate_iterations = candidate_profile
+    if baseline_version != candidate_version:
+        msg = (
+            "benchmark_profile_version must match across baseline and candidate "
+            f"runs: baseline={baseline_version!r}, candidate={candidate_version!r}"
+        )
+        raise IncompatibleBenchmarkProfileError(msg)
     if baseline_iterations != candidate_iterations:
         msg = (
             "worker_iterations must match across baseline and candidate runs: "
             f"baseline={baseline_iterations!r}, candidate={candidate_iterations!r}"
         )
         raise IncompatibleBenchmarkProfileError(msg)
+
+
+def _require_profile_metadata(
+    payload: cabc.Mapping[str, object],
+    *,
+    context_name: str,
+) -> tuple[str, int]:
+    """Return validated profile metadata for ``validate_matching_profiles``."""
+    profile_value = payload.get("benchmark_profile_version")
+    if not isinstance(profile_value, str) or not profile_value.strip():
+        msg = f"{context_name} benchmark_profile_version is missing"
+        raise IncompatibleBenchmarkProfileError(msg)
+    try:
+        validate_profile_version(payload)
+    except IncompatibleBenchmarkProfileError as exc:
+        msg = f"{context_name} {exc}"
+        raise IncompatibleBenchmarkProfileError(msg) from exc
+    try:
+        worker_iterations = require_worker_iterations(payload)
+    except (TypeError, ValueError) as exc:
+        msg = f"{context_name} {exc}"
+        raise IncompatibleBenchmarkProfileError(msg) from exc
+    return profile_value, worker_iterations
 
 
 def write_incompatible_profile_report(*, reason: str, output_path: pth.Path) -> None:

--- a/benchmarks/benchmark_profile.py
+++ b/benchmarks/benchmark_profile.py
@@ -1,0 +1,74 @@
+"""Benchmark profile metadata shared by throughput and ratchet helpers."""
+
+from __future__ import annotations
+
+import json
+import typing as typ
+
+BENCHMARK_PROFILE_VERSION = "pipeline-worker-batched-v1"
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+    import pathlib as pth
+
+
+class IncompatibleBenchmarkProfileError(ValueError):
+    """Raised when benchmark profiles are not comparable."""
+
+
+def require_worker_iterations(payload: cabc.Mapping[str, object]) -> int:
+    """Return the benchmark worker iteration count from a dry-run plan."""
+    value = payload.get("worker_iterations")
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = "worker_iterations must be an int"
+        raise TypeError(msg)
+    if value < 1:
+        msg = "worker_iterations must be >= 1"
+        raise ValueError(msg)
+    return value
+
+
+def validate_profile_version(payload: cabc.Mapping[str, object]) -> None:
+    """Validate that a benchmark plan uses the current profile version."""
+    profile_value = payload.get("benchmark_profile_version")
+    if not isinstance(profile_value, str) or not profile_value.strip():
+        msg = "benchmark_profile_version is missing from benchmark plan"
+        raise IncompatibleBenchmarkProfileError(msg)
+    if profile_value != BENCHMARK_PROFILE_VERSION:
+        msg = (
+            "benchmark_profile_version is incompatible: "
+            f"expected {BENCHMARK_PROFILE_VERSION!r}, got {profile_value!r}"
+        )
+        raise IncompatibleBenchmarkProfileError(msg)
+
+
+def validate_matching_profiles(
+    *,
+    baseline_plan: cabc.Mapping[str, object],
+    candidate_plan: cabc.Mapping[str, object],
+) -> None:
+    """Validate that benchmark profile metadata matches across both plans."""
+    baseline_iterations = baseline_plan.get("worker_iterations")
+    candidate_iterations = candidate_plan.get("worker_iterations")
+    if baseline_iterations != candidate_iterations:
+        msg = (
+            "worker_iterations must match across baseline and candidate runs: "
+            f"baseline={baseline_iterations!r}, candidate={candidate_iterations!r}"
+        )
+        raise IncompatibleBenchmarkProfileError(msg)
+
+
+def write_incompatible_profile_report(*, reason: str, output_path: pth.Path) -> None:
+    """Write a successful skip report when baseline data is not comparable."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "baseline_available": True,
+        "comparison_performed": False,
+        "passed": True,
+        "reason": "incompatible_benchmark_profile",
+        "detail": reason,
+    }
+    output_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )

--- a/benchmarks/benchmark_profile.py
+++ b/benchmarks/benchmark_profile.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import logging
 import typing as typ
+
+_logger = logging.getLogger(__name__)
 
 BENCHMARK_PROFILE_VERSION = "pipeline-worker-batched-v1"
 
@@ -46,6 +49,7 @@ def _require_profile_version(
             if context_name is not None
             else "benchmark_profile_version is missing from benchmark plan"
         )
+        _logger.warning("benchmark profile incompatible: %s", msg)
         raise IncompatibleBenchmarkProfileError(msg)
     if profile_value != BENCHMARK_PROFILE_VERSION:
         prefix = f"{context_name} " if context_name is not None else ""
@@ -53,6 +57,7 @@ def _require_profile_version(
             f"{prefix}benchmark_profile_version is incompatible: "
             f"expected {BENCHMARK_PROFILE_VERSION!r}, got {profile_value!r}"
         )
+        _logger.warning("benchmark profile incompatible: %s", msg)
         raise IncompatibleBenchmarkProfileError(msg)
     return profile_value
 
@@ -74,12 +79,14 @@ def validate_matching_profiles(
             "benchmark_profile_version must match across baseline and candidate "
             f"runs: baseline={baseline_version!r}, candidate={candidate_version!r}"
         )
+        _logger.warning("benchmark profile mismatch: %s", msg)
         raise IncompatibleBenchmarkProfileError(msg)
     if baseline_iterations != candidate_iterations:
         msg = (
             "worker_iterations must match across baseline and candidate runs: "
             f"baseline={baseline_iterations!r}, candidate={candidate_iterations!r}"
         )
+        _logger.warning("benchmark profile mismatch: %s", msg)
         raise IncompatibleBenchmarkProfileError(msg)
 
 
@@ -94,12 +101,18 @@ def _require_profile_metadata(
         worker_iterations = require_worker_iterations(payload)
     except (TypeError, ValueError) as exc:
         msg = f"{context_name} {exc}"
+        _logger.warning("benchmark profile metadata error: %s", msg)
         raise IncompatibleBenchmarkProfileError(msg) from exc
     return profile_value, worker_iterations
 
 
 def write_incompatible_profile_report(*, reason: str, output_path: pth.Path) -> None:
     """Write a successful skip report when baseline data is not comparable."""
+    _logger.debug(
+        "writing incompatible profile report: path=%s, reason=%r",
+        output_path,
+        reason,
+    )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "baseline_available": True,

--- a/benchmarks/ci_benchmark_ratchet_profile.py
+++ b/benchmarks/ci_benchmark_ratchet_profile.py
@@ -13,6 +13,7 @@ from benchmarks._validation import (
     _require_mapping,
     _require_non_empty_string,
 )
+from benchmarks.benchmark_profile import require_worker_iterations
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -33,18 +34,6 @@ def load_plan_payload(full_plan_path: pth.Path) -> cabc.Mapping[str, object]:
         msg = "scenario count must match scenario command count"
         raise ValueError(msg)
     return full_payload
-
-
-def _require_worker_iterations(payload: cabc.Mapping[str, object]) -> int:
-    """Return the benchmark worker iteration count from a dry-run plan."""
-    value = payload.get("worker_iterations")
-    if isinstance(value, bool) or not isinstance(value, int):
-        msg = "worker_iterations must be an int"
-        raise TypeError(msg)
-    if value < 1:
-        msg = "worker_iterations must be >= 1"
-        raise ValueError(msg)
-    return value
 
 
 def _require_numeric_payload_bytes(value: object) -> int | float:
@@ -128,14 +117,15 @@ def write_filtered_plan(
     selected: cabc.Sequence[tuple[cabc.Mapping[str, object], str]],
 ) -> None:
     """Write the filtered dry-run plan used by the benchmark ratchet."""
+    rust_available = _require_rust_available(full_payload)
     filtered_payload = {
         "benchmark_profile_version": _require_non_empty_string(
             full_payload.get("benchmark_profile_version"),
             name="benchmark_profile_version",
         ),
         "dry_run": True,
-        "rust_available": bool(full_payload.get("rust_available", False)),
-        "worker_iterations": _require_worker_iterations(full_payload),
+        "rust_available": rust_available,
+        "worker_iterations": require_worker_iterations(full_payload),
         "command": command,
         "scenarios": [scenario for scenario, _ in selected],
     }
@@ -143,6 +133,15 @@ def write_filtered_plan(
         json.dumps(filtered_payload, indent=2, sort_keys=True),
         encoding="utf-8",
     )
+
+
+def _require_rust_available(payload: cabc.Mapping[str, object]) -> bool:
+    """Return validated ``rust_available`` metadata from a dry-run plan."""
+    value = payload.get("rust_available", False)
+    if not isinstance(value, bool):
+        msg = "rust_available must be a bool"
+        raise TypeError(msg)
+    return value
 
 
 def _parse_args(argv: cabc.Sequence[str] | None) -> argparse.Namespace:

--- a/benchmarks/ci_benchmark_ratchet_profile.py
+++ b/benchmarks/ci_benchmark_ratchet_profile.py
@@ -35,6 +35,18 @@ def load_plan_payload(full_plan_path: pth.Path) -> cabc.Mapping[str, object]:
     return full_payload
 
 
+def _require_worker_iterations(payload: cabc.Mapping[str, object]) -> int:
+    """Return the benchmark worker iteration count from a dry-run plan."""
+    value = payload.get("worker_iterations")
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = "worker_iterations must be an int"
+        raise TypeError(msg)
+    if value < 1:
+        msg = "worker_iterations must be >= 1"
+        raise ValueError(msg)
+    return value
+
+
 def _require_numeric_payload_bytes(value: object) -> int | float:
     """Return *value* as a numeric payload size, or raise ``TypeError``."""
     if isinstance(value, bool) or not isinstance(value, int | float):
@@ -111,14 +123,19 @@ def build_hyperfine_command(
 def write_filtered_plan(
     *,
     filtered_plan_path: pth.Path,
-    rust_available: bool,
+    full_payload: cabc.Mapping[str, object],
     command: list[str],
     selected: cabc.Sequence[tuple[cabc.Mapping[str, object], str]],
 ) -> None:
     """Write the filtered dry-run plan used by the benchmark ratchet."""
     filtered_payload = {
+        "benchmark_profile_version": _require_non_empty_string(
+            full_payload.get("benchmark_profile_version"),
+            name="benchmark_profile_version",
+        ),
         "dry_run": True,
-        "rust_available": rust_available,
+        "rust_available": bool(full_payload.get("rust_available", False)),
+        "worker_iterations": _require_worker_iterations(full_payload),
         "command": command,
         "scenarios": [scenario for scenario, _ in selected],
     }
@@ -149,7 +166,7 @@ def main(argv: cabc.Sequence[str] | None = None) -> int:
     subprocess.run(command, check=True)  # noqa: S603 - commands come from our dry-run plan
     write_filtered_plan(
         filtered_plan_path=args.filtered_plan,
-        rust_available=bool(full_payload.get("rust_available", False)),
+        full_payload=full_payload,
         command=command,
         selected=selected,
     )

--- a/benchmarks/pipeline_throughput.py
+++ b/benchmarks/pipeline_throughput.py
@@ -65,6 +65,12 @@ def _parse_args() -> argparse.Namespace:
         default=3,
         help="Number of measured runs for each hyperfine command.",
     )
+    parser.add_argument(
+        "--worker-iterations",
+        type=int,
+        default=20,
+        help="Number of pipeline executions inside each measured worker process.",
+    )
     return parser.parse_args()
 
 
@@ -86,6 +92,7 @@ def main() -> int:
         runs=args.runs,
         dry_run=args.dry_run,
         rust_available=rust_available,
+        worker_iterations=args.worker_iterations,
     )
     run_pipeline_benchmarks(config=config)
     return 0

--- a/benchmarks/pipeline_throughput_runner.py
+++ b/benchmarks/pipeline_throughput_runner.py
@@ -15,6 +15,7 @@ from benchmarks._benchmark_types import (
     PipelineBenchmarkRunResult,
     PipelineBenchmarkScenario,
 )
+from benchmarks.benchmark_profile import BENCHMARK_PROFILE_VERSION
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -106,6 +107,7 @@ def _build_worker_command(
     scenario: PipelineBenchmarkScenario,
     worker_path: pth.Path,
     python_bin: str,
+    worker_iterations: int,
 ) -> list[str]:
     """Build the worker invocation for one benchmark scenario."""
     command = [
@@ -115,6 +117,8 @@ def _build_worker_command(
         str(scenario.payload_bytes),
         "--stages",
         str(scenario.stages),
+        "--iterations",
+        str(worker_iterations),
     ]
     if scenario.with_line_callbacks:
         command.append("--line-callbacks")
@@ -155,6 +159,7 @@ def build_hyperfine_command(*, config: PipelineBenchmarkConfig) -> list[str]:
             scenario=scenario,
             worker_path=config.worker_path,
             python_bin=config.python_bin,
+            worker_iterations=config.worker_iterations,
         )
         command.append(
             render_prefixed_command(
@@ -167,20 +172,20 @@ def build_hyperfine_command(*, config: PipelineBenchmarkConfig) -> list[str]:
 
 def _write_dry_run_payload(
     *,
-    output_path: pth.Path,
+    config: PipelineBenchmarkConfig,
     command: cabc.Sequence[str],
-    scenarios: cabc.Sequence[PipelineBenchmarkScenario],
-    rust_available: bool,
 ) -> None:
     """Write dry-run benchmark metadata to JSON."""
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    config.output_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
+        "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
         "dry_run": True,
-        "rust_available": rust_available,
+        "rust_available": config.rust_available,
+        "worker_iterations": config.worker_iterations,
         "command": list(command),
-        "scenarios": [scenario.as_dict() for scenario in scenarios],
+        "scenarios": [scenario.as_dict() for scenario in config.scenarios],
     }
-    output_path.write_text(
+    config.output_path.write_text(
         json.dumps(payload, indent=2, sort_keys=True),
         encoding="utf-8",
     )
@@ -219,10 +224,8 @@ def run_pipeline_benchmarks(
 
     if config.dry_run:
         _write_dry_run_payload(
-            output_path=config.output_path,
+            config=config,
             command=command,
-            scenarios=config.scenarios,
-            rust_available=config.rust_available,
         )
     else:
         _execute_hyperfine_benchmark(

--- a/benchmarks/pipeline_throughput_runner.py
+++ b/benchmarks/pipeline_throughput_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses as dc
 import json
 import os
+import shlex
 import shutil
 import subprocess  # noqa: S404  # benchmark runner intentionally invokes external tooling
 import typing as typ
@@ -21,9 +22,6 @@ if typ.TYPE_CHECKING:
     import collections.abc as cabc
     import pathlib as pth
 
-_POSIX_SAFE_SHELL_TOKEN_CHARS = frozenset(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@%_+=:,./-",
-)
 _WINDOWS_SAFE_CMD_TOKEN_CHARS = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:\\/-",
 )
@@ -51,10 +49,8 @@ def _render_posix_command(
     env: cabc.Mapping[str, str],
 ) -> str:
     """Render a POSIX shell command with environment prefixes."""
-    env_tokens = [
-        f"{key}={_quote_posix_shell_token(value)}" for key, value in sorted(env.items())
-    ]
-    command_text = " ".join(_quote_posix_shell_token(token) for token in command)
+    env_tokens = [f"{key}={shlex.quote(value)}" for key, value in sorted(env.items())]
+    command_text = shlex.join(command)
     if not env_tokens:
         return command_text
     return f"{' '.join(env_tokens)} {command_text}"
@@ -74,13 +70,6 @@ def _render_windows_command(
         for key, value in sorted(env.items())
     ]
     return f"{' && '.join(env_tokens)} && {command_text}"
-
-
-def _quote_posix_shell_token(token: str) -> str:
-    """Quote one POSIX shell token without relying on platform shell helpers."""
-    if token and all(char in _POSIX_SAFE_SHELL_TOKEN_CHARS for char in token):
-        return token
-    return "'" + token.replace("'", "'\"'\"'") + "'"
 
 
 def _escape_windows_env_value(value: str) -> str:

--- a/benchmarks/pipeline_throughput_runner.py
+++ b/benchmarks/pipeline_throughput_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses as dc
 import json
+import logging
 import os
 import shlex
 import shutil
@@ -17,6 +18,8 @@ from benchmarks._benchmark_types import (
     PipelineBenchmarkScenario,
 )
 from benchmarks.benchmark_profile import BENCHMARK_PROFILE_VERSION
+
+_logger = logging.getLogger(__name__)
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -171,6 +174,11 @@ def _write_dry_run_payload(
     command: cabc.Sequence[str],
 ) -> None:
     """Write dry-run benchmark metadata to JSON."""
+    _logger.debug(
+        "writing dry-run payload: path=%s, worker_iterations=%d",
+        config.output_path,
+        config.worker_iterations,
+    )
     config.output_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
@@ -207,7 +215,9 @@ def _prepare_benchmark_command_config(
     """Prepare command rendering config, resolving executables when needed."""
     if config.dry_run:
         return config
-    return dc.replace(config, python_bin=_resolve_executable(config.python_bin))
+    resolved = dc.replace(config, python_bin=_resolve_executable(config.python_bin))
+    _logger.debug("resolved python_bin: %r", resolved.python_bin)
+    return resolved
 
 
 def run_pipeline_benchmarks(

--- a/benchmarks/pipeline_throughput_runner.py
+++ b/benchmarks/pipeline_throughput_runner.py
@@ -38,13 +38,11 @@ def _build_worker_command(
     *,
     scenario: PipelineBenchmarkScenario,
     worker_path: pth.Path,
-    uv_bin: str,
+    python_bin: str,
 ) -> list[str]:
     """Build the worker invocation for one benchmark scenario."""
     command = [
-        uv_bin,
-        "run",
-        "python",
+        python_bin,
         str(worker_path),
         "--payload-bytes",
         str(scenario.payload_bytes),
@@ -89,7 +87,7 @@ def build_hyperfine_command(*, config: PipelineBenchmarkConfig) -> list[str]:
         worker_command = _build_worker_command(
             scenario=scenario,
             worker_path=config.worker_path,
-            uv_bin=config.uv_bin,
+            python_bin=config.python_bin,
         )
         command.append(
             render_prefixed_command(
@@ -139,10 +137,10 @@ def _prepare_benchmark_command_config(
     *,
     config: PipelineBenchmarkConfig,
 ) -> PipelineBenchmarkConfig:
-    """Prepare command rendering config, resolving the `uv` launcher when needed."""
+    """Prepare command rendering config, resolving executables when needed."""
     if config.dry_run:
         return config
-    return dc.replace(config, uv_bin=_resolve_executable(config.uv_bin))
+    return dc.replace(config, python_bin=_resolve_executable(config.python_bin))
 
 
 def run_pipeline_benchmarks(

--- a/benchmarks/pipeline_throughput_runner.py
+++ b/benchmarks/pipeline_throughput_runner.py
@@ -21,6 +21,18 @@ if typ.TYPE_CHECKING:
     import collections.abc as cabc
     import pathlib as pth
 
+_POSIX_SAFE_SHELL_TOKEN_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@%_+=:,./-",
+)
+_WINDOWS_SAFE_CMD_TOKEN_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:\\/-",
+)
+
+
+def _is_windows_command_shell() -> bool:
+    """Return whether benchmark commands should be rendered for cmd.exe."""
+    return os.name == "nt"
+
 
 def render_prefixed_command(
     *,
@@ -28,7 +40,7 @@ def render_prefixed_command(
     env: cabc.Mapping[str, str],
 ) -> str:
     """Render a shell command with deterministic environment prefixes."""
-    if os.name == "nt":
+    if _is_windows_command_shell():
         return _render_windows_command(command=command, env=env)
     return _render_posix_command(command=command, env=env)
 
@@ -66,10 +78,7 @@ def _render_windows_command(
 
 def _quote_posix_shell_token(token: str) -> str:
     """Quote one POSIX shell token without relying on platform shell helpers."""
-    safe_chars = frozenset(
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@%_+=:,./-",
-    )
-    if token and all(char in safe_chars for char in token):
+    if token and all(char in _POSIX_SAFE_SHELL_TOKEN_CHARS for char in token):
         return token
     return "'" + token.replace("'", "'\"'\"'") + "'"
 
@@ -81,10 +90,7 @@ def _escape_windows_env_value(value: str) -> str:
 
 def _quote_windows_cmd_token(token: str) -> str:
     """Quote one token for a cmd.exe command string."""
-    safe_chars = frozenset(
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:\\/-",
-    )
-    if token and all(char in safe_chars for char in token):
+    if token and all(char in _WINDOWS_SAFE_CMD_TOKEN_CHARS for char in token):
         return token
 
     quoted = ['"']

--- a/benchmarks/pipeline_throughput_runner.py
+++ b/benchmarks/pipeline_throughput_runner.py
@@ -53,7 +53,7 @@ def _render_windows_command(
     env: cabc.Mapping[str, str],
 ) -> str:
     """Render a cmd.exe command with environment prefixes."""
-    command_text = subprocess.list2cmdline(list(command))
+    command_text = " ".join(_quote_windows_cmd_token(token) for token in command)
     if not env:
         return command_text
     env_tokens = [
@@ -76,6 +76,29 @@ def _quote_posix_shell_token(token: str) -> str:
 def _escape_windows_env_value(value: str) -> str:
     """Escape an environment value for cmd.exe ``set "KEY=value"`` syntax."""
     return value.replace('"', '""')
+
+
+def _quote_windows_cmd_token(token: str) -> str:
+    """Quote one token for a cmd.exe command string."""
+    safe_chars = frozenset(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:\\/-",
+    )
+    if token and all(char in safe_chars for char in token):
+        return token
+
+    quoted = ['"']
+    backslashes = 0
+    for char in token:
+        if char == "\\":
+            backslashes += 1
+            continue
+        if char == '"':
+            quoted.extend(("\\" * ((backslashes * 2) + 1), '"'))
+        else:
+            quoted.extend(("\\" * backslashes, char))
+        backslashes = 0
+    quoted.extend(("\\" * (backslashes * 2), '"'))
+    return "".join(quoted)
 
 
 def _build_worker_command(

--- a/benchmarks/pipeline_throughput_runner.py
+++ b/benchmarks/pipeline_throughput_runner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import dataclasses as dc
 import json
-import shlex
+import os
 import shutil
 import subprocess  # noqa: S404  # benchmark runner intentionally invokes external tooling
 import typing as typ
@@ -27,11 +27,55 @@ def render_prefixed_command(
     env: cabc.Mapping[str, str],
 ) -> str:
     """Render a shell command with deterministic environment prefixes."""
-    env_tokens = [f"{key}={shlex.quote(value)}" for key, value in sorted(env.items())]
-    command_text = shlex.join(list(command))
+    if os.name == "nt":
+        return _render_windows_command(command=command, env=env)
+    return _render_posix_command(command=command, env=env)
+
+
+def _render_posix_command(
+    *,
+    command: cabc.Sequence[str],
+    env: cabc.Mapping[str, str],
+) -> str:
+    """Render a POSIX shell command with environment prefixes."""
+    env_tokens = [
+        f"{key}={_quote_posix_shell_token(value)}" for key, value in sorted(env.items())
+    ]
+    command_text = " ".join(_quote_posix_shell_token(token) for token in command)
     if not env_tokens:
         return command_text
     return f"{' '.join(env_tokens)} {command_text}"
+
+
+def _render_windows_command(
+    *,
+    command: cabc.Sequence[str],
+    env: cabc.Mapping[str, str],
+) -> str:
+    """Render a cmd.exe command with environment prefixes."""
+    command_text = subprocess.list2cmdline(list(command))
+    if not env:
+        return command_text
+    env_tokens = [
+        f'set "{key}={_escape_windows_env_value(value)}"'
+        for key, value in sorted(env.items())
+    ]
+    return f"{' && '.join(env_tokens)} && {command_text}"
+
+
+def _quote_posix_shell_token(token: str) -> str:
+    """Quote one POSIX shell token without relying on platform shell helpers."""
+    safe_chars = frozenset(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@%_+=:,./-",
+    )
+    if token and all(char in safe_chars for char in token):
+        return token
+    return "'" + token.replace("'", "'\"'\"'") + "'"
+
+
+def _escape_windows_env_value(value: str) -> str:
+    """Escape an environment value for cmd.exe ``set "KEY=value"`` syntax."""
+    return value.replace('"', '""')
 
 
 def _build_worker_command(

--- a/benchmarks/pipeline_worker.py
+++ b/benchmarks/pipeline_worker.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import argparse
 import dataclasses as dc
+import logging
 import sys
 
 from cuprum import Program, ProgramCatalogue, ProjectSettings, ScopeConfig, scoped, sh
+
+_logger = logging.getLogger(__name__)
 
 _MIN_PIPELINE_STAGES = 2
 
@@ -173,14 +176,32 @@ def _build_pipeline(config: PipelineWorkerConfig) -> tuple[sh.Pipeline, Program]
 def run_pipeline_worker(config: PipelineWorkerConfig) -> int:
     """Execute one configured throughput benchmark pipeline run."""
     pipeline, python_program = _build_pipeline(config)
+    _logger.debug(
+        "starting pipeline worker: iterations=%d, payload_bytes=%d, "
+        "stages=%d, with_line_callbacks=%s",
+        config.iterations,
+        config.payload_bytes,
+        config.stages,
+        config.with_line_callbacks,
+    )
     with scoped(ScopeConfig(allowlist=frozenset([python_program]))):
-        for _ in range(config.iterations):
+        for i in range(config.iterations):
             result = pipeline.run_sync(capture=False, echo=False)
             if not result.ok:
                 failure = result.failure
-                if failure is None:
-                    return 1
-                return failure.exit_code
+                exit_code = failure.exit_code if failure is not None else 1
+                _logger.warning(
+                    "pipeline iteration %d/%d failed: exit_code=%d",
+                    i + 1,
+                    config.iterations,
+                    exit_code,
+                )
+                return exit_code
+
+    _logger.debug(
+        "pipeline worker completed: %d iteration(s) succeeded",
+        config.iterations,
+    )
 
     return 0
 

--- a/benchmarks/pipeline_worker.py
+++ b/benchmarks/pipeline_worker.py
@@ -14,6 +14,16 @@ _logger = logging.getLogger(__name__)
 _MIN_PIPELINE_STAGES = 2
 
 
+def _validate_iterations_range(iterations: int) -> None:
+    """Raise ``ValueError`` when *iterations* is outside the permitted range."""
+    if iterations < 1:
+        msg = f"iterations must be >= 1, got {iterations}"
+        raise ValueError(msg)
+    if iterations > 1000:  # noqa: PLR2004
+        msg = f"iterations must be <= 1000, got {iterations}"
+        raise ValueError(msg)
+
+
 @dc.dataclass(frozen=True, slots=True)
 class PipelineWorkerConfig:
     """Configuration for a single pipeline throughput run."""
@@ -31,12 +41,7 @@ class PipelineWorkerConfig:
         if self.stages < _MIN_PIPELINE_STAGES:
             msg = f"stages must be >= {_MIN_PIPELINE_STAGES}, got {self.stages}"
             raise ValueError(msg)
-        if self.iterations < 1:
-            msg = f"iterations must be >= 1, got {self.iterations}"
-            raise ValueError(msg)
-        if self.iterations > 1000:  # noqa: PLR2004
-            msg = f"iterations must be <= 1000, got {self.iterations}"
-            raise ValueError(msg)
+        _validate_iterations_range(self.iterations)
 
 
 def _parse_args() -> PipelineWorkerConfig:

--- a/benchmarks/pipeline_worker.py
+++ b/benchmarks/pipeline_worker.py
@@ -18,6 +18,7 @@ class PipelineWorkerConfig:
     payload_bytes: int
     stages: int
     with_line_callbacks: bool
+    iterations: int
 
     def __post_init__(self) -> None:
         """Validate worker invariants for direct callers and CLI usage."""
@@ -26,6 +27,9 @@ class PipelineWorkerConfig:
             raise ValueError(msg)
         if self.stages < _MIN_PIPELINE_STAGES:
             msg = f"stages must be >= {_MIN_PIPELINE_STAGES}, got {self.stages}"
+            raise ValueError(msg)
+        if self.iterations < 1:
+            msg = f"iterations must be >= 1, got {self.iterations}"
             raise ValueError(msg)
 
 
@@ -52,12 +56,19 @@ def _parse_args() -> PipelineWorkerConfig:
             "line processing overhead."
         ),
     )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Number of pipeline runs to execute inside this worker process.",
+    )
     args = parser.parse_args()
 
     return PipelineWorkerConfig(
         payload_bytes=args.payload_bytes,
         stages=args.stages,
         with_line_callbacks=args.line_callbacks,
+        iterations=args.iterations,
     )
 
 
@@ -160,14 +171,15 @@ def run_pipeline_worker(config: PipelineWorkerConfig) -> int:
     """Execute one configured throughput benchmark pipeline run."""
     pipeline, python_program = _build_pipeline(config)
     with scoped(ScopeConfig(allowlist=frozenset([python_program]))):
-        result = pipeline.run_sync(capture=False, echo=False)
+        for _ in range(config.iterations):
+            result = pipeline.run_sync(capture=False, echo=False)
+            if not result.ok:
+                failure = result.failure
+                if failure is None:
+                    return 1
+                return failure.exit_code
 
-    if result.ok:
-        return 0
-    failure = result.failure
-    if failure is None:
-        return 1
-    return failure.exit_code
+    return 0
 
 
 def main() -> int:

--- a/benchmarks/pipeline_worker.py
+++ b/benchmarks/pipeline_worker.py
@@ -31,6 +31,9 @@ class PipelineWorkerConfig:
         if self.iterations < 1:
             msg = f"iterations must be >= 1, got {self.iterations}"
             raise ValueError(msg)
+        if self.iterations > 1000:  # noqa: PLR2004
+            msg = f"iterations must be <= 1000, got {self.iterations}"
+            raise ValueError(msg)
 
 
 def _parse_args() -> PipelineWorkerConfig:

--- a/benchmarks/ratchet_rust_performance.py
+++ b/benchmarks/ratchet_rust_performance.py
@@ -8,7 +8,6 @@ writes a structured comparison report.
 from __future__ import annotations
 
 import argparse
-import dataclasses as dc
 import json
 import math
 import pathlib as pth
@@ -20,87 +19,18 @@ from benchmarks._validation import (
     _require_mapping,
     _require_non_empty_string,
 )
-
-_FLOAT_TOLERANCE = 1e-12
-
-
-@dc.dataclass(frozen=True, slots=True)
-class ScenarioComparison:
-    """Comparison result for one Rust benchmark scenario."""
-
-    scenario_name: str
-    baseline_mean: float
-    candidate_mean: float
-    regression_ratio: float
-    max_regression: float
-
-    @property
-    def is_regression(self) -> bool:
-        """Return ``True`` when scenario regression exceeds threshold."""
-        return (self.regression_ratio - self.max_regression) > _FLOAT_TOLERANCE
-
-    def as_dict(self) -> dict[str, object]:
-        """Serialize the scenario comparison for JSON output."""
-        return {
-            "scenario_name": self.scenario_name,
-            "baseline_mean": self.baseline_mean,
-            "candidate_mean": self.candidate_mean,
-            "regression_ratio": self.regression_ratio,
-            "max_regression": self.max_regression,
-            "is_regression": self.is_regression,
-        }
-
-
-@dc.dataclass(frozen=True, slots=True)
-class ComparisonReport:
-    """Summary report for Rust benchmark regression comparison."""
-
-    max_regression: float
-    comparisons: tuple[ScenarioComparison, ...]
-
-    @property
-    def passed(self) -> bool:
-        """Return ``True`` when no scenario breaches the configured threshold."""
-        return all(not comparison.is_regression for comparison in self.comparisons)
-
-    @property
-    def regressions(self) -> tuple[ScenarioComparison, ...]:
-        """Return comparisons that breached the regression threshold."""
-        return tuple(
-            comparison for comparison in self.comparisons if comparison.is_regression
-        )
-
-    @property
-    def rust_scenarios_compared(self) -> int:
-        """Return the number of Rust scenarios included in the comparison."""
-        return len(self.comparisons)
-
-    @property
-    def worst_regression_ratio(self) -> float:
-        """Return the worst regression ratio across all compared scenarios."""
-        if not self.comparisons:
-            return 0.0
-        return max(comparison.regression_ratio for comparison in self.comparisons)
-
-    def as_dict(self) -> dict[str, object]:
-        """Serialize the report for JSON output."""
-        return {
-            "max_regression": self.max_regression,
-            "passed": self.passed,
-            "rust_scenarios_compared": self.rust_scenarios_compared,
-            "worst_regression_ratio": self.worst_regression_ratio,
-            "comparisons": [comparison.as_dict() for comparison in self.comparisons],
-            "regressions": [comparison.as_dict() for comparison in self.regressions],
-        }
-
-
-@dc.dataclass(frozen=True, slots=True)
-class BenchmarkRunPayload:
-    """Benchmark payload pair for one context (baseline or candidate)."""
-
-    plan: dict[str, object]
-    throughput: dict[str, object]
-    context_name: str
+from benchmarks.benchmark_profile import (
+    IncompatibleBenchmarkProfileError,
+    require_worker_iterations,
+    validate_matching_profiles,
+    validate_profile_version,
+    write_incompatible_profile_report,
+)
+from benchmarks.ratchet_types import (
+    BenchmarkRunPayload,
+    ComparisonReport,
+    ScenarioComparison,
+)
 
 
 def _load_json(path: pth.Path) -> dict[str, object]:
@@ -145,6 +75,8 @@ def _require_non_negative_float(value: object, *, name: str) -> float:
 def load_plan(path: pth.Path) -> dict[str, object]:
     """Load and minimally validate dry-run plan JSON payload."""
     payload = _load_json(path)
+    validate_profile_version(payload)
+    require_worker_iterations(payload)
     scenarios = _require_list(payload.get("scenarios"), name="scenarios")
 
     for index, scenario_value in enumerate(scenarios):
@@ -294,6 +226,10 @@ def compare_rust_regressions(
         max_regression,
         name="max_regression",
     )
+    validate_matching_profiles(
+        baseline_plan=baseline.plan,
+        candidate_plan=candidate.plan,
+    )
 
     baseline_rust_means = _extract_rust_means(
         plan_payload=baseline.plan,
@@ -375,6 +311,10 @@ def main() -> int:
             max_regression=args.max_regression,
         )
         write_report(report=report, output_path=args.output)
+    except IncompatibleBenchmarkProfileError as exc:
+        write_incompatible_profile_report(reason=str(exc), output_path=args.output)
+        print(f"benchmark ratchet skipped: {exc}")
+        return 0
     except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
         print(f"benchmark ratchet failed to evaluate inputs: {exc}", file=sys.stderr)
         return 2

--- a/benchmarks/ratchet_rust_performance.py
+++ b/benchmarks/ratchet_rust_performance.py
@@ -42,8 +42,14 @@ def _load_json(path: pth.Path) -> dict[str, object]:
     return typ.cast("dict[str, object]", payload)
 
 
-def _require_positive_float(value: object, *, name: str) -> float:
-    """Validate and return a positive float value."""
+def _require_float(
+    value: object,
+    *,
+    name: str,
+    minimum: float,
+    exclusive: bool,
+) -> float:
+    """Validate that *value* is a finite float satisfying a minimum bound."""
     if isinstance(value, bool) or not isinstance(value, int | float):
         msg = f"{name} must be a number"
         raise TypeError(msg)
@@ -51,25 +57,23 @@ def _require_positive_float(value: object, *, name: str) -> float:
     if not math.isfinite(validated):
         msg = f"{name} must be finite"
         raise ValueError(msg)
-    if validated <= 0.0:
+    if exclusive and validated <= minimum:
         msg = f"{name} must be > 0"
         raise ValueError(msg)
+    if not exclusive and validated < minimum:
+        msg = f"{name} must be >= 0"
+        raise ValueError(msg)
     return validated
+
+
+def _require_positive_float(value: object, *, name: str) -> float:
+    """Validate and return a positive float value."""
+    return _require_float(value, name=name, minimum=0.0, exclusive=True)
 
 
 def _require_non_negative_float(value: object, *, name: str) -> float:
     """Validate and return a non-negative float value."""
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        msg = f"{name} must be a number"
-        raise TypeError(msg)
-    validated = float(value)
-    if not math.isfinite(validated):
-        msg = f"{name} must be finite"
-        raise ValueError(msg)
-    if validated < 0.0:
-        msg = f"{name} must be >= 0"
-        raise ValueError(msg)
-    return validated
+    return _require_float(value, name=name, minimum=0.0, exclusive=False)
 
 
 def load_plan(path: pth.Path) -> dict[str, object]:

--- a/benchmarks/ratchet_rust_performance.py
+++ b/benchmarks/ratchet_rust_performance.py
@@ -42,6 +42,23 @@ def _load_json(path: pth.Path) -> dict[str, object]:
     return typ.cast("dict[str, object]", payload)
 
 
+def _check_float_bound(
+    validated: float,
+    *,
+    name: str,
+    minimum: float,
+    exclusive: bool,
+) -> None:
+    """Raise ``ValueError`` when *validated* does not satisfy the minimum bound."""
+    if exclusive:
+        if validated <= minimum:
+            msg = f"{name} must be > 0"
+            raise ValueError(msg)
+    elif validated < minimum:
+        msg = f"{name} must be >= 0"
+        raise ValueError(msg)
+
+
 def _require_float(
     value: object,
     *,
@@ -57,12 +74,7 @@ def _require_float(
     if not math.isfinite(validated):
         msg = f"{name} must be finite"
         raise ValueError(msg)
-    if exclusive and validated <= minimum:
-        msg = f"{name} must be > 0"
-        raise ValueError(msg)
-    if not exclusive and validated < minimum:
-        msg = f"{name} must be >= 0"
-        raise ValueError(msg)
+    _check_float_bound(validated, name=name, minimum=minimum, exclusive=exclusive)
     return validated
 
 

--- a/benchmarks/ratchet_rust_performance.py
+++ b/benchmarks/ratchet_rust_performance.py
@@ -76,7 +76,10 @@ def load_plan(path: pth.Path) -> dict[str, object]:
     """Load and minimally validate dry-run plan JSON payload."""
     payload = _load_json(path)
     validate_profile_version(payload)
-    require_worker_iterations(payload)
+    try:
+        require_worker_iterations(payload)
+    except (TypeError, ValueError) as exc:
+        raise IncompatibleBenchmarkProfileError(str(exc)) from exc
     scenarios = _require_list(payload.get("scenarios"), name="scenarios")
 
     for index, scenario_value in enumerate(scenarios):

--- a/benchmarks/ratchet_rust_performance.py
+++ b/benchmarks/ratchet_rust_performance.py
@@ -50,12 +50,13 @@ def _check_float_bound(
     exclusive: bool,
 ) -> None:
     """Raise ``ValueError`` when *validated* does not satisfy the minimum bound."""
+    minimum_text = f"{minimum:g}"
     if exclusive:
         if validated <= minimum:
-            msg = f"{name} must be > 0"
+            msg = f"{name} must be > {minimum_text}"
             raise ValueError(msg)
     elif validated < minimum:
-        msg = f"{name} must be >= 0"
+        msg = f"{name} must be >= {minimum_text}"
         raise ValueError(msg)
 
 

--- a/benchmarks/ratchet_rust_performance.py
+++ b/benchmarks/ratchet_rust_performance.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import math
 import pathlib as pth
-import sys
+import sys  # noqa: F401
 import typing as typ
 
 from benchmarks._validation import (
@@ -31,6 +32,8 @@ from benchmarks.ratchet_types import (
     ComparisonReport,
     ScenarioComparison,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 def _load_json(path: pth.Path) -> dict[str, object]:
@@ -91,11 +94,13 @@ def _require_non_negative_float(value: object, *, name: str) -> float:
 
 def load_plan(path: pth.Path) -> dict[str, object]:
     """Load and minimally validate dry-run plan JSON payload."""
+    _logger.debug("loading benchmark plan: path=%s", path)
     payload = _load_json(path)
     validate_profile_version(payload)
     try:
         require_worker_iterations(payload)
     except (TypeError, ValueError) as exc:
+        _logger.warning("benchmark plan worker_iterations invalid: %s", exc)
         raise IncompatibleBenchmarkProfileError(str(exc)) from exc
     scenarios = _require_list(payload.get("scenarios"), name="scenarios")
 
@@ -315,6 +320,10 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> int:
     """Execute benchmark ratchet comparison and return process exit code."""
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
     args = _parse_args()
     try:
         report = compare_rust_regressions(
@@ -333,24 +342,23 @@ def main() -> int:
         write_report(report=report, output_path=args.output)
     except IncompatibleBenchmarkProfileError as exc:
         write_incompatible_profile_report(reason=str(exc), output_path=args.output)
-        print(f"benchmark ratchet skipped: {exc}")
+        _logger.info("benchmark ratchet skipped: %s", exc)
         return 0
     except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
-        print(f"benchmark ratchet failed to evaluate inputs: {exc}", file=sys.stderr)
+        _logger.error("benchmark ratchet failed to evaluate inputs: %s", exc)  # noqa: TRY400
         return 2
 
     if report.passed:
-        print(
-            "benchmark ratchet passed: "
-            f"{report.rust_scenarios_compared} Rust scenarios compared",
+        _logger.info(
+            "benchmark ratchet passed: %d Rust scenarios compared",
+            report.rust_scenarios_compared,
         )
         return 0
 
-    print(
-        "benchmark ratchet failed: "
-        f"worst_regression_ratio={report.worst_regression_ratio:.6f}, "
-        f"max_regression={report.max_regression:.6f}",
-        file=sys.stderr,
+    _logger.error(
+        "benchmark ratchet failed: worst_regression_ratio=%.6f, max_regression=%.6f",
+        report.worst_regression_ratio,
+        report.max_regression,
     )
     return 1
 

--- a/benchmarks/ratchet_types.py
+++ b/benchmarks/ratchet_types.py
@@ -1,0 +1,86 @@
+"""Dataclasses for Rust benchmark ratchet comparison results."""
+
+from __future__ import annotations
+
+import dataclasses as dc
+
+_FLOAT_TOLERANCE = 1e-12
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ScenarioComparison:
+    """Comparison result for one Rust benchmark scenario."""
+
+    scenario_name: str
+    baseline_mean: float
+    candidate_mean: float
+    regression_ratio: float
+    max_regression: float
+
+    @property
+    def is_regression(self) -> bool:
+        """Return ``True`` when scenario regression exceeds threshold."""
+        return (self.regression_ratio - self.max_regression) > _FLOAT_TOLERANCE
+
+    def as_dict(self) -> dict[str, object]:
+        """Serialize the scenario comparison for JSON output."""
+        return {
+            "scenario_name": self.scenario_name,
+            "baseline_mean": self.baseline_mean,
+            "candidate_mean": self.candidate_mean,
+            "regression_ratio": self.regression_ratio,
+            "max_regression": self.max_regression,
+            "is_regression": self.is_regression,
+        }
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ComparisonReport:
+    """Summary report for Rust benchmark regression comparison."""
+
+    max_regression: float
+    comparisons: tuple[ScenarioComparison, ...]
+
+    @property
+    def passed(self) -> bool:
+        """Return ``True`` when no scenario breaches the configured threshold."""
+        return all(not comparison.is_regression for comparison in self.comparisons)
+
+    @property
+    def regressions(self) -> tuple[ScenarioComparison, ...]:
+        """Return comparisons that breached the regression threshold."""
+        return tuple(
+            comparison for comparison in self.comparisons if comparison.is_regression
+        )
+
+    @property
+    def rust_scenarios_compared(self) -> int:
+        """Return the number of Rust scenarios included in the comparison."""
+        return len(self.comparisons)
+
+    @property
+    def worst_regression_ratio(self) -> float:
+        """Return the worst regression ratio across all compared scenarios."""
+        if not self.comparisons:
+            return 0.0
+        return max(comparison.regression_ratio for comparison in self.comparisons)
+
+    def as_dict(self) -> dict[str, object]:
+        """Serialize the report for JSON output."""
+        return {
+            "max_regression": self.max_regression,
+            "passed": self.passed,
+            "rust_scenarios_compared": self.rust_scenarios_compared,
+            "worst_regression_ratio": self.worst_regression_ratio,
+            "comparisons": [comparison.as_dict() for comparison in self.comparisons],
+            "regressions": [comparison.as_dict() for comparison in self.regressions],
+        }
+
+
+@dc.dataclass(frozen=True, slots=True)
+class BenchmarkRunPayload:
+    """Benchmark payload pair for one context (baseline or candidate)."""
+
+    plan: dict[str, object]
+    throughput: dict[str, object]
+    context_name: str

--- a/cuprum/_streams.py
+++ b/cuprum/_streams.py
@@ -205,18 +205,38 @@ def _emit_completed_lines(
     on_line: cabc.Callable[[str], None],
 ) -> str:
     """Emit complete lines from text and return the remaining partial line."""
+    lines, remainder = _split_complete_lines(text)
+
+    for line in lines:
+        on_line(line)
+
+    return remainder
+
+
+def _split_complete_lines(text: str) -> tuple[list[str], str]:
+    """Split text into completed lines and a trailing partial line.
+
+    Parameters
+    ----------
+    text : str
+        Text to split using Python's universal line boundary rules.
+
+    Returns
+    -------
+    tuple[list[str], str]
+        Completed lines with one trailing line ending removed from each line,
+        followed by the remaining partial line. The remainder is empty when
+        ``text`` ends with a line ending or contains no partial line.
+    """
     lines = text.splitlines(keepends=True)
     if not lines:
-        return text
+        return [], text
 
     remainder = ""
     if not _ends_with_line_ending(lines[-1]):
         remainder = lines.pop()
 
-    for line in lines:
-        on_line(_strip_line_ending(line))
-
-    return remainder
+    return [_strip_line_ending(line) for line in lines], remainder
 
 
 def _ends_with_line_ending(line: str) -> bool:

--- a/cuprum/_testing.py
+++ b/cuprum/_testing.py
@@ -35,7 +35,9 @@ from cuprum._streams import (
     _close_stream_writer,
     _consume_stream,
     _pump_stream,
+    _split_complete_lines,
     _StreamConfig,
+    _strip_line_ending,
     _write_chunk,
 )
 from cuprum.sh import _resolve_timeout
@@ -99,7 +101,9 @@ _EXPORTS = {
     "_close_stream_writer": _close_stream_writer,
     "_consume_stream": _consume_stream,
     "_pump_stream": _pump_stream,
+    "_split_complete_lines": _split_complete_lines,
     "_StreamConfig": _StreamConfig,
+    "_strip_line_ending": _strip_line_ending,
     "_write_chunk": _write_chunk,
     "_resolve_timeout": _resolve_timeout,
 }

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -61,6 +61,7 @@
       'cuprum/unittests/test_fetch_main_benchmark_baseline.py',
       'cuprum/unittests/test_fixture_generation.py',
       'cuprum/unittests/test_folded_summary.py',
+      'cuprum/unittests/test_line_splitting.py',
       'cuprum/unittests/test_logging_hook.py',
       'cuprum/unittests/test_maturin_build.py',
       'cuprum/unittests/test_observe.py',

--- a/cuprum/unittests/test_benchmark_ci_ratchet.py
+++ b/cuprum/unittests/test_benchmark_ci_ratchet.py
@@ -7,6 +7,10 @@ import typing as typ
 
 import pytest
 
+from benchmarks.benchmark_profile import (
+    BENCHMARK_PROFILE_VERSION,
+    IncompatibleBenchmarkProfileError,
+)
 from benchmarks.ratchet_rust_performance import (
     BenchmarkRunPayload,
     ComparisonReport,
@@ -33,8 +37,10 @@ def _scenario_payload(*, name: str, backend: str) -> dict[str, object]:
 def _plan_payload() -> dict[str, object]:
     """Return a benchmark plan payload."""
     return {
+        "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
         "dry_run": True,
         "rust_available": True,
+        "worker_iterations": 20,
         "command": ["hyperfine", "placeholder"],
         "scenarios": [
             _scenario_payload(name="python-small-single-nocb", backend="python"),
@@ -105,10 +111,34 @@ def test_load_plan_rejects_missing_scenarios(tmp_path: pth.Path) -> None:
     path = _write_json(
         tmp_path=tmp_path,
         filename="plan.json",
-        payload={"dry_run": True, "command": ["hyperfine"]},
+        payload={
+            "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
+            "dry_run": True,
+            "worker_iterations": 20,
+            "command": ["hyperfine"],
+        },
     )
 
     with pytest.raises(TypeError, match="scenarios"):
+        load_plan(path)
+
+
+def test_load_plan_rejects_legacy_profile_metadata(tmp_path: pth.Path) -> None:
+    """Old single-run benchmark plans are incompatible with batched results."""
+    path = _write_json(
+        tmp_path=tmp_path,
+        filename="plan.json",
+        payload={
+            "dry_run": True,
+            "rust_available": True,
+            "command": ["hyperfine", "placeholder"],
+            "scenarios": [
+                _scenario_payload(name="rust-small-single-nocb", backend="rust"),
+            ],
+        },
+    )
+
+    with pytest.raises(IncompatibleBenchmarkProfileError, match="missing"):
         load_plan(path)
 
 
@@ -178,8 +208,10 @@ def test_compare_rust_regressions_rejects_result_count_mismatch() -> None:
 def test_compare_rust_regressions_rejects_missing_rust_scenarios() -> None:
     """Ratchet should fail if there are no Rust scenarios to compare."""
     python_only_plan = {
+        "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
         "dry_run": True,
         "rust_available": False,
+        "worker_iterations": 20,
         "command": ["hyperfine", "placeholder"],
         "scenarios": [
             _scenario_payload(name="python-small-single-nocb", backend="python"),
@@ -210,8 +242,10 @@ def test_compare_rust_regressions_rejects_missing_rust_scenarios() -> None:
 def test_compare_rust_regressions_rejects_invalid_backend() -> None:
     """Scenario backends must stay within the supported benchmark set."""
     invalid_plan = {
+        "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
         "dry_run": True,
         "rust_available": True,
+        "worker_iterations": 20,
         "command": ["hyperfine", "placeholder"],
         "scenarios": [
             _scenario_payload(name="python-small-single-nocb", backend="python"),
@@ -238,8 +272,10 @@ def test_compare_rust_regressions_rejects_invalid_backend() -> None:
 def test_compare_rust_regressions_rejects_duplicate_rust_scenario_names() -> None:
     """Rust scenario names must remain unique for stable matching."""
     duplicate_plan = {
+        "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
         "dry_run": True,
         "rust_available": True,
+        "worker_iterations": 20,
         "command": ["hyperfine", "placeholder"],
         "scenarios": [
             _scenario_payload(name="python-small-single-nocb", backend="python"),

--- a/cuprum/unittests/test_benchmark_ci_ratchet.py
+++ b/cuprum/unittests/test_benchmark_ci_ratchet.py
@@ -142,6 +142,29 @@ def test_load_plan_rejects_legacy_profile_metadata(tmp_path: pth.Path) -> None:
         load_plan(path)
 
 
+def test_load_plan_rejects_old_profile_version(tmp_path: pth.Path) -> None:
+    """Old benchmark profile versions are incompatible with current results."""
+    payload = _plan_payload()
+    payload["benchmark_profile_version"] = "pipeline-worker-single-run-v1"
+    path = _write_json(tmp_path=tmp_path, filename="plan.json", payload=payload)
+
+    with pytest.raises(IncompatibleBenchmarkProfileError, match="incompatible"):
+        load_plan(path)
+
+
+def test_load_plan_rejects_single_run_worker_iteration_metadata(
+    tmp_path: pth.Path,
+) -> None:
+    """Legacy single-run worker-iteration metadata is incompatible."""
+    payload = _plan_payload()
+    payload.pop("worker_iterations")
+    payload["worker_iteration"] = 1
+    path = _write_json(tmp_path=tmp_path, filename="plan.json", payload=payload)
+
+    with pytest.raises(IncompatibleBenchmarkProfileError, match="worker_iterations"):
+        load_plan(path)
+
+
 def test_load_throughput_rejects_missing_results(tmp_path: pth.Path) -> None:
     """Throughput payloads must include a results list."""
     path = _write_json(

--- a/cuprum/unittests/test_benchmark_comparison_report.py
+++ b/cuprum/unittests/test_benchmark_comparison_report.py
@@ -7,6 +7,7 @@ import typing as typ
 
 import pytest
 
+from benchmarks.benchmark_profile import BENCHMARK_PROFILE_VERSION
 from benchmarks.python_vs_rust_comparison_report import (
     BenchmarkComparisonRow,
     RatchetStatus,
@@ -42,6 +43,8 @@ def _scenario_payload(
 def _candidate_plan_payload() -> dict[str, object]:
     """Return a filtered candidate plan payload with paired backends."""
     return {
+        "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
+        "worker_iterations": 20,
         "dry_run": True,
         "rust_available": True,
         "command": ["hyperfine", "placeholder"],

--- a/cuprum/unittests/test_benchmark_suite.py
+++ b/cuprum/unittests/test_benchmark_suite.py
@@ -64,7 +64,7 @@ def test_render_prefixed_command_uses_windows_env_prefix(
         r"C:\Python313\python.exe",
         r"C:\benchmarks\pipeline_worker.py",
         "--label",
-        "a b",
+        'a "b"',
     ]
 
     rendered = render_prefixed_command(
@@ -75,7 +75,9 @@ def test_render_prefixed_command_uses_windows_env_prefix(
     assert rendered.startswith('set "CUPRUM_STREAM_BACKEND=python" && '), (
         "expected rendered command to use cmd.exe set syntax"
     )
-    assert '"a b"' in rendered, "expected rendered command to quote spaced token"
+    assert r'"a \"b\""' in rendered, (
+        "expected rendered command to escape embedded quotes"
+    )
 
 
 def test_render_prefixed_command_with_empty_env_returns_raw_command() -> None:

--- a/cuprum/unittests/test_benchmark_suite.py
+++ b/cuprum/unittests/test_benchmark_suite.py
@@ -60,7 +60,7 @@ def test_render_prefixed_command_uses_windows_env_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Windows command rendering uses cmd.exe-compatible env assignment."""
-    monkeypatch.setattr(runner.os, "name", "nt")
+    monkeypatch.setattr(runner, "_is_windows_command_shell", lambda: True)
     command = [
         r"C:\Python313\python.exe",
         r"C:\benchmarks\pipeline_worker.py",

--- a/cuprum/unittests/test_benchmark_suite.py
+++ b/cuprum/unittests/test_benchmark_suite.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import pathlib as pth
+import shlex
+import sys
 import typing as typ
 
 import pytest
@@ -92,6 +94,20 @@ def test_pipeline_benchmark_config_coerces_string_paths() -> None:
     assert isinstance(config.worker_path, pth.Path), (
         "expected worker_path to be normalized to pathlib.Path"
     )
+
+
+def test_pipeline_benchmark_config_accepts_legacy_uv_bin() -> None:
+    """Legacy ``uv_bin`` config remains accepted but is not benchmarked."""
+    config = PipelineBenchmarkConfig(
+        output_path=pth.Path("dist/benchmarks/bench.json"),
+        worker_path=pth.Path("benchmarks/pipeline_worker.py"),
+        scenarios=(),
+        warmup=0,
+        runs=1,
+        uv_bin="uv",
+    )
+
+    assert config.uv_bin == "uv"
 
 
 def test_pipeline_benchmark_config_rejects_non_pathlike_output_path() -> None:
@@ -202,6 +218,7 @@ def test_build_hyperfine_command_contains_export_runs_and_warmup(
         scenarios=scenarios,
         warmup=1,
         runs=2,
+        uv_bin="uv",
     )
     command = build_hyperfine_command(config=config)
 
@@ -213,6 +230,13 @@ def test_build_hyperfine_command_contains_export_runs_and_warmup(
     assert "--runs" in command, "expected hyperfine command to include runs"
     assert any("CUPRUM_STREAM_BACKEND=python" in token for token in command), (
         "expected at least one hyperfine scenario command to target python backend"
+    )
+    scenario_commands = command[7:]
+    assert all(
+        " uv run python " not in f" {scenario}" for scenario in scenario_commands
+    )
+    assert any(
+        shlex.quote(sys.executable) in scenario for scenario in scenario_commands
     )
 
 

--- a/cuprum/unittests/test_benchmark_suite.py
+++ b/cuprum/unittests/test_benchmark_suite.py
@@ -21,6 +21,7 @@ from benchmarks.pipeline_throughput import (
     render_prefixed_command,
     run_pipeline_benchmarks,
 )
+from benchmarks.pipeline_worker import PipelineWorkerConfig
 
 
 def test_default_pipeline_scenarios_include_python_backend() -> None:
@@ -134,6 +135,30 @@ def test_pipeline_benchmark_config_accepts_legacy_uv_bin() -> None:
     )
 
     assert config.uv_bin == "uv"
+
+
+def test_pipeline_benchmark_config_rejects_excessive_worker_iterations() -> None:
+    """Worker iteration count is capped to prevent runaway benchmark plans."""
+    with pytest.raises(ValueError, match="worker_iterations must be <= 1000"):
+        PipelineBenchmarkConfig(
+            output_path=pth.Path("dist/benchmarks/bench.json"),
+            worker_path=pth.Path("benchmarks/pipeline_worker.py"),
+            scenarios=(),
+            warmup=0,
+            runs=1,
+            worker_iterations=1001,
+        )
+
+
+def test_pipeline_worker_config_rejects_excessive_iterations() -> None:
+    """Worker iteration count is capped to prevent runaway worker processes."""
+    with pytest.raises(ValueError, match="iterations must be <= 1000"):
+        PipelineWorkerConfig(
+            payload_bytes=1024,
+            stages=2,
+            with_line_callbacks=False,
+            iterations=1001,
+        )
 
 
 def test_pipeline_benchmark_config_rejects_non_pathlike_output_path() -> None:

--- a/cuprum/unittests/test_benchmark_suite.py
+++ b/cuprum/unittests/test_benchmark_suite.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import json
 import pathlib as pth
-import shlex
 import sys
 import typing as typ
 
 import pytest
 
+import benchmarks.pipeline_throughput_runner as runner
 from benchmarks._test_constants import _SCENARIO_NAME_PATTERN
 from benchmarks.pipeline_throughput import (
     HyperfineConfig,
@@ -53,6 +53,29 @@ def test_render_prefixed_command_prefixes_env_and_quotes_tokens() -> None:
         "expected rendered command to include CUPRUM_STREAM_BACKEND prefix"
     )
     assert "'a b'" in rendered, "expected rendered command to quote spaced token"
+
+
+def test_render_prefixed_command_uses_windows_env_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows command rendering uses cmd.exe-compatible env assignment."""
+    monkeypatch.setattr(runner.os, "name", "nt")
+    command = [
+        r"C:\Python313\python.exe",
+        r"C:\benchmarks\pipeline_worker.py",
+        "--label",
+        "a b",
+    ]
+
+    rendered = render_prefixed_command(
+        command=command,
+        env={"CUPRUM_STREAM_BACKEND": "python"},
+    )
+
+    assert rendered.startswith('set "CUPRUM_STREAM_BACKEND=python" && '), (
+        "expected rendered command to use cmd.exe set syntax"
+    )
+    assert '"a b"' in rendered, "expected rendered command to quote spaced token"
 
 
 def test_render_prefixed_command_with_empty_env_returns_raw_command() -> None:
@@ -235,9 +258,7 @@ def test_build_hyperfine_command_contains_export_runs_and_warmup(
     assert all(
         " uv run python " not in f" {scenario}" for scenario in scenario_commands
     )
-    assert any(
-        shlex.quote(sys.executable) in scenario for scenario in scenario_commands
-    )
+    assert any(sys.executable in scenario for scenario in scenario_commands)
 
 
 def test_run_pipeline_benchmarks_dry_run_writes_json(tmp_path: pth.Path) -> None:

--- a/cuprum/unittests/test_benchmark_suite.py
+++ b/cuprum/unittests/test_benchmark_suite.py
@@ -11,6 +11,7 @@ import pytest
 
 import benchmarks.pipeline_throughput_runner as runner
 from benchmarks._test_constants import _SCENARIO_NAME_PATTERN
+from benchmarks.benchmark_profile import BENCHMARK_PROFILE_VERSION
 from benchmarks.pipeline_throughput import (
     HyperfineConfig,
     PipelineBenchmarkConfig,
@@ -253,6 +254,9 @@ def test_build_hyperfine_command_contains_export_runs_and_warmup(
     assert "--export-json" in command, "expected hyperfine command to export JSON"
     assert "--warmup" in command, "expected hyperfine command to include warmup"
     assert "--runs" in command, "expected hyperfine command to include runs"
+    assert any("--iterations 20" in token for token in command), (
+        "expected worker commands to batch pipeline runs inside one process"
+    )
     assert any("CUPRUM_STREAM_BACKEND=python" in token for token in command), (
         "expected at least one hyperfine scenario command to target python backend"
     )
@@ -290,6 +294,8 @@ def test_run_pipeline_benchmarks_dry_run_writes_json(tmp_path: pth.Path) -> None
     payload = json.loads(output_path.read_text(encoding="utf-8"))
 
     assert payload["dry_run"] is True, "expected payload dry_run flag to be True"
+    assert payload["benchmark_profile_version"] == BENCHMARK_PROFILE_VERSION
+    assert payload["worker_iterations"] == 20
     assert "rust_available" in payload, (
         "expected payload to include rust_available metadata"
     )

--- a/cuprum/unittests/test_ci_benchmark_ratchet_profile.py
+++ b/cuprum/unittests/test_ci_benchmark_ratchet_profile.py
@@ -261,3 +261,30 @@ def test_write_filtered_plan_preserves_selected_scenarios(tmp_path: pth.Path) ->
         "scenarios": [scenario for scenario, _ in selected],
         "worker_iterations": 20,
     }
+
+
+def test_write_filtered_plan_rejects_non_boolean_rust_available(
+    tmp_path: pth.Path,
+) -> None:
+    """The filtered plan must not coerce string ``rust_available`` values."""
+    with pytest.raises(TypeError, match="rust_available"):
+        write_filtered_plan(
+            filtered_plan_path=tmp_path / "plan.json",
+            full_payload={
+                "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
+                "rust_available": "false",
+                "worker_iterations": 20,
+            },
+            command=["hyperfine", "rust cmd"],
+            selected=[
+                (
+                    _scenario(
+                        name="rust-small-single-nocb",
+                        backend="rust",
+                        payload_bytes=1024,
+                        stages=2,
+                    ),
+                    "rust cmd",
+                ),
+            ],
+        )

--- a/cuprum/unittests/test_ci_benchmark_ratchet_profile.py
+++ b/cuprum/unittests/test_ci_benchmark_ratchet_profile.py
@@ -7,6 +7,7 @@ import typing as typ
 
 import pytest
 
+from benchmarks.benchmark_profile import BENCHMARK_PROFILE_VERSION
 from benchmarks.ci_benchmark_ratchet_profile import (
     build_hyperfine_command,
     load_plan_payload,
@@ -242,15 +243,21 @@ def test_write_filtered_plan_preserves_selected_scenarios(tmp_path: pth.Path) ->
 
     write_filtered_plan(
         filtered_plan_path=filtered_plan_path,
-        rust_available=True,
+        full_payload={
+            "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
+            "rust_available": True,
+            "worker_iterations": 20,
+        },
         command=command,
         selected=selected,
     )
 
     payload = json.loads(filtered_plan_path.read_text(encoding="utf-8"))
     assert payload == {
+        "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
         "command": command,
         "dry_run": True,
         "rust_available": True,
         "scenarios": [scenario for scenario, _ in selected],
+        "worker_iterations": 20,
     }

--- a/cuprum/unittests/test_line_splitting.py
+++ b/cuprum/unittests/test_line_splitting.py
@@ -1,4 +1,20 @@
-"""Property-based tests for pure stream line-splitting helpers."""
+r"""Property-based tests for pure stream line-splitting helpers.
+
+This module verifies the text-only helpers that support line callbacks in
+``cuprum._streams``.  The helpers are deliberately tested without subprocesses,
+asyncio streams, or backend dispatch so failures point at the line-splitting
+contract rather than at process I/O.
+
+``_split_complete_lines`` returns completed lines with their recognised line
+endings removed plus the final partial line, if any. ``_strip_line_ending``
+removes one trailing ``"\r\n"``, ``"\n"``, or ``"\r"`` sequence and leaves the
+rest of the text untouched.  The Hypothesis tests exercise generated text with
+mixed line endings to prove preservation, stable remainder handling, and
+idempotent stripping.  The CrossHair contracts symbolically check bounded
+versions of the same invariants; a confirmed result means the contract held for
+the explored symbolic state space, while a failure should be treated as a
+minimal counterexample for the pure helper rather than as stream-backend drift.
+"""
 
 from __future__ import annotations
 

--- a/cuprum/unittests/test_line_splitting.py
+++ b/cuprum/unittests/test_line_splitting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as typ
 
 import pytest
@@ -10,16 +11,24 @@ from hypothesis import strategies as st
 
 from cuprum._testing import _split_complete_lines, _strip_line_ending
 
-try:
-    import crosshair.core_and_libs  # noqa: F401
-    from crosshair.options import AnalysisKind, AnalysisOptionSet
-    from crosshair.statespace import MessageType
-    from crosshair.test_util import check_states
-except ImportError:  # pragma: no cover - exercised only without dev deps
+_IS_PYTHON_315 = sys.version_info[:2] == (3, 15)
+
+if _IS_PYTHON_315:
     AnalysisOptionSet = typ.cast("typ.Any", None)
     AnalysisKind = typ.cast("typ.Any", None)
     MessageType = typ.cast("typ.Any", None)
     check_states = typ.cast("typ.Any", None)
+else:
+    try:
+        import crosshair.core_and_libs  # noqa: F401
+        from crosshair.options import AnalysisKind, AnalysisOptionSet
+        from crosshair.statespace import MessageType
+        from crosshair.test_util import check_states
+    except ImportError:  # pragma: no cover - exercised only without dev deps
+        AnalysisOptionSet = typ.cast("typ.Any", None)
+        AnalysisKind = typ.cast("typ.Any", None)
+        MessageType = typ.cast("typ.Any", None)
+        check_states = typ.cast("typ.Any", None)
 
 _LINE_ENDINGS: tuple[str, str, str] = ("\r\n", "\n", "\r")
 _PYTHON_LINE_BOUNDARIES: str = "\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"

--- a/cuprum/unittests/test_line_splitting.py
+++ b/cuprum/unittests/test_line_splitting.py
@@ -27,6 +27,9 @@ from hypothesis import strategies as st
 
 from cuprum._testing import _split_complete_lines, _strip_line_ending
 
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
 _IS_PYTHON_315 = sys.version_info[:2] == (3, 15)
 
 if _IS_PYTHON_315:
@@ -217,7 +220,7 @@ def _strip_line_ending_contract(line: str) -> None:
     ],
 )
 @pytest.mark.skipif(check_states is None, reason="CrossHair is not installed")
-def test_crosshair_contracts(contract: typ.Callable[..., None]) -> None:  # noqa: TID251
+def test_crosshair_contracts(contract: cabc.Callable[..., None]) -> None:
     """Property: CrossHair symbolically verifies line-splitting contracts."""
     check_states(
         contract,

--- a/cuprum/unittests/test_line_splitting.py
+++ b/cuprum/unittests/test_line_splitting.py
@@ -159,6 +159,11 @@ def test_split_complete_lines_remainder_has_no_line_ending(text: str) -> None:
     assert not remainder.endswith(("\n", "\r")), (
         "_split_complete_lines remainder must not end with a recognized line ending"
     )
+    if text.endswith(_LINE_ENDINGS):
+        assert remainder == "", (
+            "_split_complete_lines remainder must be empty when input ends with a "
+            "recognized line ending"
+        )
 
 
 @_PROPERTY_SETTINGS

--- a/cuprum/unittests/test_line_splitting.py
+++ b/cuprum/unittests/test_line_splitting.py
@@ -166,6 +166,19 @@ def test_split_complete_lines_remainder_has_no_line_ending(text: str) -> None:
         )
 
 
+@pytest.mark.parametrize("text", ["a\vb", "a\x85b", "a\u2028b"])
+def test_split_complete_lines_handles_python_line_boundaries(text: str) -> None:
+    """Example: Python-recognized line boundaries delimit completed lines."""
+    split_lines = text.splitlines(keepends=True)
+    expected_lines = [_strip_line_ending(line) for line in split_lines[:-1]]
+    expected_remainder = split_lines[-1]
+
+    lines, remainder = _split_complete_lines(text)
+
+    assert lines == expected_lines
+    assert remainder == expected_remainder
+
+
 @_PROPERTY_SETTINGS
 @given(line=_line_with_optional_ending())
 def test_strip_line_ending_idempotent(line: str) -> None:

--- a/cuprum/unittests/test_line_splitting.py
+++ b/cuprum/unittests/test_line_splitting.py
@@ -193,24 +193,18 @@ def _strip_line_ending_contract(line: str) -> None:
     """
 
 
+@pytest.mark.parametrize(
+    "contract",
+    [
+        pytest.param(_split_no_text_loss_contract, id="split_no_text_loss"),
+        pytest.param(_strip_line_ending_contract, id="strip_line_ending"),
+    ],
+)
 @pytest.mark.skipif(check_states is None, reason="CrossHair is not installed")
-def test_crosshair_split_no_text_loss() -> None:
-    """Property: CrossHair symbolically verifies split text preservation."""
+def test_crosshair_contracts(contract: typ.Callable[..., None]) -> None:  # noqa: TID251
+    """Property: CrossHair symbolically verifies line-splitting contracts."""
     check_states(
-        _split_no_text_loss_contract,
-        MessageType.CONFIRMED,
-        AnalysisOptionSet(
-            analysis_kind=(AnalysisKind.PEP316,),
-            per_condition_timeout=10,
-        ),
-    )
-
-
-@pytest.mark.skipif(check_states is None, reason="CrossHair is not installed")
-def test_crosshair_strip_line_ending_contract() -> None:
-    """Property: CrossHair symbolically verifies line-ending stripping."""
-    check_states(
-        _strip_line_ending_contract,
+        contract,
         MessageType.CONFIRMED,
         AnalysisOptionSet(
             analysis_kind=(AnalysisKind.PEP316,),

--- a/cuprum/unittests/test_line_splitting.py
+++ b/cuprum/unittests/test_line_splitting.py
@@ -1,0 +1,210 @@
+"""Property-based tests for pure stream line-splitting helpers."""
+
+from __future__ import annotations
+
+import typing as typ
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from cuprum._testing import _split_complete_lines, _strip_line_ending
+
+try:
+    import crosshair.core_and_libs  # noqa: F401
+    from crosshair.options import AnalysisKind, AnalysisOptionSet
+    from crosshair.statespace import MessageType
+    from crosshair.test_util import check_states
+except ImportError:  # pragma: no cover - exercised only without dev deps
+    AnalysisOptionSet = typ.cast("typ.Any", None)
+    AnalysisKind = typ.cast("typ.Any", None)
+    MessageType = typ.cast("typ.Any", None)
+    check_states = typ.cast("typ.Any", None)
+
+_LINE_ENDINGS: tuple[str, str, str] = ("\r\n", "\n", "\r")
+_PYTHON_LINE_BOUNDARIES: str = "\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+_PROPERTY_SETTINGS: settings = settings(
+    deadline=None,
+    derandomize=True,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    # Keep the issue-requested bound; CrossHair covers the symbolic edge cases.
+    max_examples=30,
+)
+
+
+def _normalise_line_endings(text: str) -> str:
+    """Normalize recognized line endings to line-feed characters."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _rebuild_normalised_text(lines: list[str], remainder: str) -> str:
+    """Rebuild text from split output using normalized line endings."""
+    return "".join(f"{line}\n" for line in lines) + remainder
+
+
+def _line_ending_suffix(line: str) -> str:
+    """Return the single trailing line-ending sequence, if present."""
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith("\n"):
+        return "\n"
+    if line.endswith("\r"):
+        return "\r"
+    return ""
+
+
+def _split_preserves_normalised_text(text: str) -> bool:
+    """Return whether split output accounts for all input text."""
+    lines, remainder = _split_complete_lines(text)
+    return len(_normalise_line_endings(text)) == (
+        sum(len(line) + 1 for line in lines) + len(remainder)
+    )
+
+
+@st.composite
+def _text_with_line_endings(draw: st.DrawFn) -> str:
+    """Generate arbitrary text with embedded recognized line endings."""
+    fragments = draw(
+        st.lists(
+            st.text(
+                alphabet=st.characters(exclude_characters=_PYTHON_LINE_BOUNDARIES),
+                max_size=8,
+            ),
+            min_size=1,
+            max_size=8,
+        ),
+    )
+    endings = draw(
+        st.lists(
+            st.sampled_from((*_LINE_ENDINGS, "")),
+            min_size=len(fragments) - 1,
+            max_size=len(fragments) - 1,
+        ),
+    )
+
+    text = "".join(fragments[index] + ending for index, ending in enumerate(endings))
+    return text + fragments[-1]
+
+
+@st.composite
+def _line_with_optional_ending(draw: st.DrawFn) -> str:
+    """Generate one line that may have a recognized trailing line ending."""
+    body = draw(
+        st.text(alphabet=st.characters(exclude_characters=_PYTHON_LINE_BOUNDARIES)),
+    )
+    ending = draw(st.sampled_from((*_LINE_ENDINGS, "")))
+    return body + ending
+
+
+@_PROPERTY_SETTINGS
+@given(text=_text_with_line_endings())
+def test_split_complete_lines_preserves_all_text(text: str) -> None:
+    """Property: splitting and rebuilding preserves normalized text.
+
+    Parameters
+    ----------
+    text : str
+        Generated text containing arbitrary recognised line endings.
+    """
+    lines, remainder = _split_complete_lines(text)
+
+    assert _rebuild_normalised_text(lines, remainder) == _normalise_line_endings(
+        text
+    ), (
+        "_split_complete_lines output rebuilt with _rebuild_normalised_text "
+        "must match _normalise_line_endings input"
+    )
+
+
+@_PROPERTY_SETTINGS
+@given(text=_text_with_line_endings())
+def test_split_complete_lines_remainder_has_no_line_ending(text: str) -> None:
+    """Property: the returned remainder is never a completed line.
+
+    Parameters
+    ----------
+    text : str
+        Generated text containing arbitrary recognised line endings.
+    """
+    _lines, remainder = _split_complete_lines(text)
+
+    assert not remainder.endswith(("\n", "\r")), (
+        "_split_complete_lines remainder must not end with a recognized line ending"
+    )
+
+
+@_PROPERTY_SETTINGS
+@given(line=_line_with_optional_ending())
+def test_strip_line_ending_idempotent(line: str) -> None:
+    """Property: stripping a line ending is idempotent.
+
+    Parameters
+    ----------
+    line : str
+        Generated line with an optional recognised line ending.
+    """
+    stripped = _strip_line_ending(line)
+
+    assert _strip_line_ending(stripped) == stripped, (
+        "_strip_line_ending must be idempotent after the first strip"
+    )
+
+
+@_PROPERTY_SETTINGS
+@given(line=_line_with_optional_ending())
+def test_strip_line_ending_removes_only_trailing(line: str) -> None:
+    """Property: stripping removes exactly one trailing line-ending sequence.
+
+    Parameters
+    ----------
+    line : str
+        Generated line with an optional recognised line ending.
+    """
+    suffix = _line_ending_suffix(line)
+
+    assert _strip_line_ending(line) == line.removesuffix(suffix), (
+        "_strip_line_ending must remove only the suffix reported by _line_ending_suffix"
+    )
+
+
+def _split_no_text_loss_contract(text: str) -> None:
+    r"""CrossHair contract for split text preservation.
+
+    pre: len(text) <= 3
+    pre: all(character not in "\v\f\x1c\x1d\x1e\x85\u2028\u2029" for character in text)
+    post: _split_preserves_normalised_text(text)
+    """
+
+
+def _strip_line_ending_contract(line: str) -> None:
+    """CrossHair contract for one trailing line-ending removal.
+
+    pre: len(line) <= 4
+    post: _strip_line_ending(line) == line.removesuffix(_line_ending_suffix(line))
+    """
+
+
+@pytest.mark.skipif(check_states is None, reason="CrossHair is not installed")
+def test_crosshair_split_no_text_loss() -> None:
+    """Property: CrossHair symbolically verifies split text preservation."""
+    check_states(
+        _split_no_text_loss_contract,
+        MessageType.CONFIRMED,
+        AnalysisOptionSet(
+            analysis_kind=(AnalysisKind.PEP316,),
+            per_condition_timeout=10,
+        ),
+    )
+
+
+@pytest.mark.skipif(check_states is None, reason="CrossHair is not installed")
+def test_crosshair_strip_line_ending_contract() -> None:
+    """Property: CrossHair symbolically verifies line-ending stripping."""
+    check_states(
+        _strip_line_ending_contract,
+        MessageType.CONFIRMED,
+        AnalysisOptionSet(
+            analysis_kind=(AnalysisKind.PEP316,),
+            per_condition_timeout=10,
+        ),
+    )

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1977,6 +1977,9 @@ Both pathways are tested as first-class implementations:
 - end-to-end throughput uses `hyperfine` through
   `benchmarks/pipeline_throughput.py`, which drives
   `benchmarks/pipeline_worker.py` for scenario execution and emits JSON output.
+  The rendered `hyperfine` scenario commands invoke the active Python
+  interpreter directly rather than `uv run`, so the Rust ratchet measures
+  pipeline worker execution instead of dependency-environment launcher overhead.
 - the throughput scenario matrix covers three payload sizes (small at 1 KB,
   medium at 1 MB, large at 100 MB), two pipeline depths (single-stage with zero
   passthrough stages, and multi-stage with one passthrough stage), and two

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1980,6 +1980,10 @@ Both pathways are tested as first-class implementations:
   The rendered `hyperfine` scenario commands invoke the active Python
   interpreter directly rather than `uv run`, so the Rust ratchet measures
   pipeline worker execution instead of dependency-environment launcher overhead.
+  Each measured worker command runs a batch of pipeline executions inside one
+  worker process, and dry-run plans record a benchmark profile version plus the
+  worker iteration count so older single-run artefacts are not compared against
+  batched-worker results.
 - the throughput scenario matrix covers three payload sizes (small at 1 KB,
   medium at 1 MB, large at 100 MB), two pipeline depths (single-stage with zero
   passthrough stages, and multi-stage with one passthrough stage), and two

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1959,6 +1959,14 @@ Both pathways are tested as first-class implementations:
 - property-based tests (Hypothesis) verify byte-preservation across randomized
   payloads and randomized chunk boundaries by asserting deterministic hex
   output through real pipeline execution under both backends;
+- pure line-splitting property tests in
+  `cuprum/unittests/test_line_splitting.py` cover `_split_complete_lines()` and
+  `_strip_line_ending()` from `cuprum/_streams.py`, proving that line-callback
+  text is not dropped, that recognised line endings are stripped consistently,
+  and that trailing partial lines remain buffered;
+- CrossHair symbolically checks bounded PEP 316 contracts for the same
+  line-splitting invariants. These checks are development-only and skip on
+  Python versions where CrossHair cannot trace the active bytecode set.
 - integration tests exercise pathway selection logic, including environment
   overrides, forced fallback when Rust FDs are unavailable, and `ImportError`
   propagation when Rust is explicitly requested but unavailable.

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1962,7 +1962,7 @@ Both pathways are tested as first-class implementations:
 - pure line-splitting property tests in
   `cuprum/unittests/test_line_splitting.py` cover `_split_complete_lines()` and
   `_strip_line_ending()` from `cuprum/_streams.py`, proving that line-callback
-  text is not dropped, that recognised line endings are stripped consistently,
+  text is not dropped, that recognized line endings are stripped consistently,
   and that trailing partial lines remain buffered;
 - CrossHair symbolically checks bounded PEP 316 contracts for the same
   line-splitting invariants. These checks are development-only and skip on

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,6 +1,5 @@
 # Developers' guide
 
-
 ## Stream line-splitting properties
 
 Line callbacks in the Python stream backend use two pure helpers from
@@ -355,7 +354,6 @@ The canonical lint configuration lives in `pyproject.toml`:
 When changing lint policy, update both `pyproject.toml` and this guide. If the
 change alters the architecture of the lint gate, update
 [ADR-003](adr-003-two-tier-python-linting.md) as well.
-
 
 ## Maturin pin synchronization and native wheel tests
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -35,6 +35,29 @@ uv run pytest -q cuprum/unittests/test_line_splitting.py
 Run `make test` before committing so the stream behaviour and the pure helper
 contracts stay aligned.
 
+## Pipeline throughput benchmark configuration
+
+`PipelineBenchmarkConfig` controls the hyperfine-based end-to-end throughput
+suite in `benchmarks/pipeline_throughput.py`. Scenario commands run
+`benchmarks/pipeline_worker.py` with `python_bin`, which defaults to the active
+interpreter and is resolved to an absolute executable path before measured
+non-dry-run benchmarks. The measured command intentionally avoids `uv run` so
+the Rust ratchet measures worker pipeline throughput rather than environment
+startup overhead.
+
+The remaining fields follow the benchmark plan: `output_path` receives
+hyperfine JSON or dry-run plan JSON, `worker_path` points at the worker module,
+`scenarios` supplies the rendered command matrix, `warmup` and `runs` configure
+hyperfine iteration counts, `hyperfine_bin` selects the hyperfine executable,
+`dry_run` writes the plan without invoking hyperfine, and `rust_available`
+records whether Rust scenarios are included.
+
+`uv_bin` is a deprecated legacy field that remains accepted in the dataclass for
+backward compatibility, but current benchmark command construction ignores it
+entirely. Keep it unset in new usage and set `python_bin` when a specific
+interpreter is required. In dry-run mode, command rendering does not resolve
+`python_bin` via PATH.
+
 ## Profiling harness overview
 
 The profiling benchmark harness provides deterministic parent-side tee and

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -6,10 +6,10 @@ Line callbacks in the Python stream backend use two pure helpers from
 `cuprum/_streams.py`:
 
 - `_split_complete_lines(text)` splits text into completed lines, strips each
-  recognised line ending, and returns `(lines, remainder)`. The `remainder` is
+  recognized line ending, and returns `(lines, remainder)`. The `remainder` is
   the final partial line and never ends in `"\n"` or `"\r"`.
 - `_strip_line_ending(line)` removes at most one trailing `"\r\n"`, `"\n"`, or
-  `"\r"` sequence. It does not normalise or edit interior text.
+  `"\r"` sequence. It does not normalize or edit interior text.
 
 These helpers are re-exported from `cuprum/_testing.py` so tests can state the
 contract directly without driving subprocess I/O. Keep them private to the
@@ -17,8 +17,8 @@ package: they exist to make `_emit_completed_lines` small and testable, not as
 public user API.
 
 `cuprum/unittests/test_line_splitting.py` contains the direct property suite.
-Hypothesis generates text with mixed recognised line endings and checks that
-normalised text is preserved, the final remainder is partial, and stripping is
+Hypothesis generates text with mixed recognized line endings and checks that
+normalized text is preserved, the final remainder is partial, and stripping is
 idempotent. CrossHair runs PEP 316 (Python Enhancement Proposal 316) contracts
 over bounded symbolic inputs for the same invariants. CrossHair is a
 development dependency only; the tests skip the symbolic checks when CrossHair

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,5 +1,41 @@
 # Developers' guide
 
+
+## Stream line-splitting properties
+
+Line callbacks in the Python stream backend use two pure helpers from
+`cuprum/_streams.py`:
+
+- `_split_complete_lines(text)` splits text into completed lines, strips each
+  recognised line ending, and returns `(lines, remainder)`. The `remainder` is
+  the final partial line and never ends in `"\n"` or `"\r"`.
+- `_strip_line_ending(line)` removes at most one trailing `"\r\n"`, `"\n"`, or
+  `"\r"` sequence. It does not normalise or edit interior text.
+
+These helpers are re-exported from `cuprum/_testing.py` so tests can state the
+contract directly without driving subprocess I/O. Keep them private to the
+package: they exist to make `_emit_completed_lines` small and testable, not as
+public user API.
+
+`cuprum/unittests/test_line_splitting.py` contains the direct property suite.
+Hypothesis generates text with mixed recognised line endings and checks that
+normalised text is preserved, the final remainder is partial, and stripping is
+idempotent. CrossHair runs PEP 316 (Python Enhancement Proposal 316) contracts
+over bounded symbolic inputs for the same invariants. CrossHair is a
+development dependency only; the tests skip the symbolic checks when CrossHair
+is unavailable and on Python 3.15, where CrossHair currently cannot trace the
+`CALL_KW` opcode.
+
+When changing `_emit_completed_lines`, `_split_complete_lines`, or
+`_strip_line_ending`, run:
+
+```bash
+uv run pytest -q cuprum/unittests/test_line_splitting.py
+```
+
+Run `make test` before committing so the stream behaviour and the pure helper
+contracts stay aligned.
+
 ## Profiling harness overview
 
 The profiling benchmark harness provides deterministic parent-side tee and

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -45,6 +45,13 @@ non-dry-run benchmarks. The measured command intentionally avoids `uv run` so
 the Rust ratchet measures worker pipeline throughput rather than environment
 startup overhead.
 
+Each worker process executes `worker_iterations` pipeline runs, defaulting to
+20. Hyperfine therefore measures a batched worker invocation rather than one
+cold pipeline execution, reducing Python interpreter startup noise in the
+ratchet. Dry-run plans record `benchmark_profile_version` and
+`worker_iterations`; ratchet comparison skips older baseline artefacts whose
+profile metadata does not match the current benchmark shape.
+
 The remaining fields follow the benchmark plan: `output_path` receives
 hyperfine JSON or dry-run plan JSON, `worker_path` points at the worker module,
 `scenarios` supplies the rendered command matrix, `warmup` and `runs` configure

--- a/docs/execplans/4-2-1-rust-pump-stream.md
+++ b/docs/execplans/4-2-1-rust-pump-stream.md
@@ -168,12 +168,13 @@ Stage C: implement Rust `rust_pump_stream()` and Python shims.
 Extend the Rust module in `rust/cuprum-rust/src/lib.rs` to export
 `rust_pump_stream()`:
 
-- Signature returning the total bytes transferred:
+- Signature:
 
   ```python
   rust_pump_stream(reader_fd: int, writer_fd: int, buffer_size: int = 65536) -> int
   ```
 
+  returning the total bytes transferred.
 - Validate `buffer_size > 0`, else raise `ValueError`.
 - Release the GIL with `Python::allow_threads` for the entire read/write loop.
 - Use a reusable buffer sized to `buffer_size`.
@@ -293,8 +294,7 @@ Expected changes include:
 Rust function (PyO3-exposed):
 
 ```python
-rust_pump_stream(reader_fd: int, writer_fd: int, buffer_size: int = 65536)
-    -> int
+rust_pump_stream(reader_fd: int, writer_fd: int, buffer_size: int = 65536) -> int
 ```
 
 - Returns total bytes transferred.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1315,7 +1315,7 @@ The continuous integration (CI) workflows run the following checks:
   - It compares Rust means against the latest successful `main` baseline
     artefact when one exists.
   - It skips comparison when the saved baseline uses an older benchmark profile
-    shape, because single-run and batched-worker timings are not comparable.
+    shape because single-run and batched-worker timings are not comparable.
   - Its baseline fetch helper follows GitHub’s signed archive redirects
     without forwarding GitHub-only authentication headers to the storage host.
   - It generates a Python-versus-Rust comparison report from the candidate

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1162,16 +1162,17 @@ UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run python \
   --output /tmp/pipeline-throughput-plan.json
 ```
 
-Dry-run output includes scenario metadata, command lines, and whether the Rust
-extension is available in the current environment.
+Dry-run output includes scenario metadata, command lines, benchmark profile
+metadata, worker iteration count, and whether the Rust extension is available
+in the current environment.
 
 Interpretation notes:
 
 - pump-latency microbenchmarks reflect inter-stage pipeline transfer overhead;
 - consume-throughput microbenchmarks reflect captured stdout read/decode
   throughput (currently the Python consume path);
-- end-to-end hyperfine runs measure full worker-pipeline runtime and include a
-  Rust scenario only when the Rust extension is available.
+- end-to-end hyperfine runs measure batched worker-pipeline runtime and include
+  a Rust scenario only when the Rust extension is available.
 
 #### Scenario matrix
 
@@ -1313,6 +1314,8 @@ The continuous integration (CI) workflows run the following checks:
   - It benchmarks the current checkout in smoke mode.
   - It compares Rust means against the latest successful `main` baseline
     artefact when one exists.
+  - It skips comparison when the saved baseline uses an older benchmark profile
+    shape, because single-run and batched-worker timings are not comparable.
   - Its baseline fetch helper follows GitHub’s signed archive redirects
     without forwarding GitHub-only authentication headers to the storage host.
   - It generates a Python-versus-Rust comparison report from the candidate

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1159,12 +1159,25 @@ UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run python \
   benchmarks/pipeline_throughput.py \
   --smoke \
   --dry-run \
+  --worker-iterations 20 \
   --output /tmp/pipeline-throughput-plan.json
 ```
 
 Dry-run output includes scenario metadata, command lines, benchmark profile
 metadata, worker iteration count, and whether the Rust extension is available
 in the current environment.
+
+The `--worker-iterations` option (default `20`) controls how many pipeline
+executions are batched inside a single measured worker process. Higher values
+reduce hyperfine timing overhead per pipeline run; the recorded mean is the
+total elapsed time for all iterations combined. The worker `--iterations` flag,
+which hyperfine scenario commands pass directly, mirrors this setting. Do not
+compare ratchet baselines produced with different `worker_iterations` values;
+the benchmark profile validation rejects mismatched plans automatically.
+
+Benchmark commands invoke the Python interpreter directly via `python_bin`
+(resolved from `sys.executable` at plan-generation time) rather than through
+`uv run`, so measured runtimes exclude launcher overhead.
 
 Interpretation notes:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -227,8 +227,9 @@ and echo semantics and returns a structured `CommandResult`:
   - `stdout_sink` and `stderr_sink` route echoed output to alternative text
     streams when `echo=True`.
   - `encoding` and `errors` configure how captured output is decoded; defaults
-    are `"utf-8"` with `"replace"`. The same settings are used when
-    `StdinInput.text` is encoded for subprocess stdin.
+    are `"utf-8"` with `"replace"`.
+    The same settings are used when `StdinInput.text` is encoded for
+    subprocess stdin.
 - `exit_code`, `pid`, and `ok` on the `CommandResult` make it easy to branch on
   success.
 
@@ -1122,7 +1123,7 @@ content integrity across both Python and Rust pumping pathways.
 
 Cuprum also tests the Python backend's pure line-callback splitting helpers
 directly. Those tests prove that completed lines and final partial lines
-account for all generated text, and that recognised line endings are stripped
+account for all generated text, and that recognized line endings are stripped
 without editing the rest of the line. In development environments, CrossHair
 adds bounded symbolic checks for the same contracts; those checks are skipped
 on Python versions where CrossHair cannot trace the active bytecode.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1120,6 +1120,13 @@ run them through real pipelines, and assert byte-preservation by comparing
 deterministic hexadecimal output. This provides broad regression coverage for
 content integrity across both Python and Rust pumping pathways.
 
+Cuprum also tests the Python backend's pure line-callback splitting helpers
+directly. Those tests prove that completed lines and final partial lines
+account for all generated text, and that recognised line endings are stripped
+without editing the rest of the line. In development environments, CrossHair
+adds bounded symbolic checks for the same contracts; those checks are skipped
+on Python versions where CrossHair cannot trace the active bytecode.
+
 ### Benchmark suite
 
 Cuprum includes an opt-in benchmark suite for stream-performance tracking.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ Repository = "https://github.com/leynos/cuprum"
 
 [dependency-groups]
 dev = [
+    "crosshair-tool",
     "hypothesis",
     "pytest",
     "pytest-benchmark",

--- a/tests/behaviour/test_benchmark_ci_ratchet_behaviour.py
+++ b/tests/behaviour/test_benchmark_ci_ratchet_behaviour.py
@@ -7,6 +7,8 @@ import subprocess  # noqa: S404  # behavioural test intentionally invokes CLI pr
 import sys
 import typing as typ
 
+from benchmarks.benchmark_profile import BENCHMARK_PROFILE_VERSION
+
 if typ.TYPE_CHECKING:
     import pathlib as pth
 
@@ -68,8 +70,10 @@ def _scenario_payload(*, name: str, backend: str) -> dict[str, object]:
 def _plan_payload() -> dict[str, object]:
     """Create plan payload."""
     return {
+        "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
         "dry_run": True,
         "rust_available": True,
+        "worker_iterations": 20,
         "command": ["hyperfine", "placeholder"],
         "scenarios": [
             _scenario_payload(name="python-small-single-nocb", backend="python"),
@@ -160,8 +164,10 @@ def given_malformed_fixtures(tmp_path: pth.Path) -> FixtureBundle:
     _write_json(
         path=fixture_bundle["candidate_plan_path"],
         payload={
+            "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
             "dry_run": True,
             "rust_available": True,
+            "worker_iterations": 20,
             "command": ["hyperfine", "placeholder"],
             "scenarios": [
                 _scenario_payload(name="python-small-single-nocb", backend="python"),

--- a/tests/behaviour/test_benchmark_comparison_report_behaviour.py
+++ b/tests/behaviour/test_benchmark_comparison_report_behaviour.py
@@ -10,6 +10,8 @@ import typing as typ
 import pytest
 from pytest_bdd import given, scenario, then, when
 
+from benchmarks.benchmark_profile import BENCHMARK_PROFILE_VERSION
+
 if typ.TYPE_CHECKING:
     import pathlib as pth
 
@@ -101,6 +103,8 @@ def _prepare_fixture_bundle(
     _write_json(
         candidate_plan_path,
         {
+            "benchmark_profile_version": BENCHMARK_PROFILE_VERSION,
+            "worker_iterations": 20,
             "dry_run": True,
             "rust_available": True,
             "command": ["hyperfine", "placeholder"],

--- a/tests/behaviour/test_benchmark_suite_behaviour.py
+++ b/tests/behaviour/test_benchmark_suite_behaviour.py
@@ -11,6 +11,7 @@ import typing as typ
 import pytest
 
 from benchmarks._test_constants import _SCENARIO_NAME_PATTERN
+from benchmarks.benchmark_profile import BENCHMARK_PROFILE_VERSION
 
 if typ.TYPE_CHECKING:
     import pathlib as pth
@@ -109,6 +110,10 @@ def then_benchmark_plan_indicates_dry_run(
     assert benchmark_plan_payload.get("dry_run") is True, (
         "expected benchmark plan dry_run flag to be True"
     )
+    assert benchmark_plan_payload.get("benchmark_profile_version") == (
+        BENCHMARK_PROFILE_VERSION
+    )
+    assert benchmark_plan_payload.get("worker_iterations") == 20
 
 
 @then("the benchmark plan contains valid scenarios")
@@ -158,6 +163,7 @@ def then_benchmark_plan_includes_valid_command(
         " uv run python " not in f" {scenario}" for scenario in scenario_commands
     )
     assert any(sys.executable in scenario for scenario in scenario_commands)
+    assert any("--iterations 20" in scenario for scenario in scenario_commands)
     if os.name == "nt":
         assert any(
             scenario.startswith('set "CUPRUM_STREAM_BACKEND=')

--- a/tests/behaviour/test_benchmark_suite_behaviour.py
+++ b/tests/behaviour/test_benchmark_suite_behaviour.py
@@ -142,6 +142,13 @@ def then_benchmark_plan_contains_valid_scenarios(
         )
 
 
+def _expected_backend_env_prefix() -> str:
+    """Return the platform-appropriate env-var prefix for scenario commands."""
+    if os.name == "nt":
+        return 'set "CUPRUM_STREAM_BACKEND='
+    return "CUPRUM_STREAM_BACKEND="
+
+
 @then("the benchmark plan includes a valid command")
 def then_benchmark_plan_includes_valid_command(
     benchmark_plan_payload: dict[str, object],
@@ -164,16 +171,10 @@ def then_benchmark_plan_includes_valid_command(
     )
     assert any(sys.executable in scenario for scenario in scenario_commands)
     assert any("--iterations 20" in scenario for scenario in scenario_commands)
-    if os.name == "nt":
-        assert any(
-            scenario.startswith('set "CUPRUM_STREAM_BACKEND=')
-            for scenario in scenario_commands
-        )
-    else:
-        assert any(
-            scenario.startswith("CUPRUM_STREAM_BACKEND=")
-            for scenario in scenario_commands
-        )
+    assert any(
+        scenario.startswith(_expected_backend_env_prefix())
+        for scenario in scenario_commands
+    )
 
 
 # -- Scenario matrix steps (4.4.2) -------------------------------------------

--- a/tests/behaviour/test_benchmark_suite_behaviour.py
+++ b/tests/behaviour/test_benchmark_suite_behaviour.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess  # noqa: S404  # behavioural test intentionally invokes CLI process
 import sys
 import typing as typ
@@ -150,6 +151,15 @@ def then_benchmark_plan_includes_valid_command(
             "expected each benchmark plan command argument to be a string"
         )
         assert argument, "command arguments must be non-empty strings"
+
+    scenario_commands = command[7:]
+    assert scenario_commands, "expected benchmark plan to include scenario commands"
+    assert all(
+        " uv run python " not in f" {scenario}" for scenario in scenario_commands
+    )
+    assert any(
+        shlex.quote(sys.executable) in scenario for scenario in scenario_commands
+    )
 
 
 # -- Scenario matrix steps (4.4.2) -------------------------------------------

--- a/tests/behaviour/test_benchmark_suite_behaviour.py
+++ b/tests/behaviour/test_benchmark_suite_behaviour.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-import shlex
+import os
 import subprocess  # noqa: S404  # behavioural test intentionally invokes CLI process
 import sys
 import typing as typ
@@ -157,9 +157,17 @@ def then_benchmark_plan_includes_valid_command(
     assert all(
         " uv run python " not in f" {scenario}" for scenario in scenario_commands
     )
-    assert any(
-        shlex.quote(sys.executable) in scenario for scenario in scenario_commands
-    )
+    assert any(sys.executable in scenario for scenario in scenario_commands)
+    if os.name == "nt":
+        assert any(
+            scenario.startswith('set "CUPRUM_STREAM_BACKEND=')
+            for scenario in scenario_commands
+        )
+    else:
+        assert any(
+            scenario.startswith("CUPRUM_STREAM_BACKEND=")
+            for scenario in scenario_commands
+        )
 
 
 # -- Scenario matrix steps (4.4.2) -------------------------------------------

--- a/tests/behaviour/test_benchmark_suite_behaviour.py
+++ b/tests/behaviour/test_benchmark_suite_behaviour.py
@@ -149,6 +149,20 @@ def _expected_backend_env_prefix() -> str:
     return "CUPRUM_STREAM_BACKEND="
 
 
+def _scenario_worker_iterations(scenario: str) -> int | None:
+    """Return the worker iteration count embedded in a scenario command."""
+    parts = scenario.split()
+    for index, part in enumerate(parts):
+        if part != "--iterations" or index + 1 >= len(parts):
+            continue
+        try:
+            return int(parts[index + 1])
+        except ValueError as exc:
+            msg = f"scenario command has non-integer iterations value: {scenario!r}"
+            raise AssertionError(msg) from exc
+    return None
+
+
 @then("the benchmark plan includes a valid command")
 def then_benchmark_plan_includes_valid_command(
     benchmark_plan_payload: dict[str, object],
@@ -164,13 +178,30 @@ def then_benchmark_plan_includes_valid_command(
         )
         assert argument, "command arguments must be non-empty strings"
 
-    scenario_commands = command[7:]
+    command_arguments = typ.cast("list[str]", command)
+    worker_iterations = benchmark_plan_payload.get("worker_iterations")
+    assert isinstance(worker_iterations, int), (
+        "benchmark plan worker_iterations must be an int"
+    )
+
+    scenario_commands = command_arguments[7:]
     assert scenario_commands, "expected benchmark plan to include scenario commands"
     assert all(
         " uv run python " not in f" {scenario}" for scenario in scenario_commands
     )
+    scenario_iterations = [
+        iterations
+        for scenario in scenario_commands
+        if (iterations := _scenario_worker_iterations(scenario)) is not None
+    ]
+    assert scenario_iterations, (
+        "expected at least one scenario command to specify --iterations"
+    )
+    assert all(iterations == worker_iterations for iterations in scenario_iterations), (
+        "expected worker_iterations in benchmark plan metadata to match "
+        "--iterations values in scenario commands"
+    )
     assert any(sys.executable in scenario for scenario in scenario_commands)
-    assert any("--iterations 20" in scenario for scenario in scenario_commands)
     assert any(
         scenario.startswith(_expected_backend_env_prefix())
         for scenario in scenario_commands

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,28 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -12,12 +34,51 @@ wheels = [
 ]
 
 [[package]]
+name = "crosshair-tool"
+version = "0.0.104"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pygls" },
+    { name = "typeshed-client" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+    { name = "z3-solver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/c7/ac2e7a78fa58d08b66919de9c9e13d45974976407e53ef8bfc64d62d11d5/crosshair_tool-0.0.104.tar.gz", hash = "sha256:c92cc8554ec1f35e079c041025cf0534d8ce83f6a8aedb7dec68d60c6d6989c2", size = 487964, upload-time = "2026-04-26T11:39:24.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/23/ec19144d79d09afef4042e5b8e464ddf8587941547a0b9abf2f42cd2a16a/crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:aa131e3e486cd5b158399e939bd6e1231c26980a8006fa3162fa859bf34aecc0", size = 556457, upload-time = "2026-04-26T11:38:32.069Z" },
+    { url = "https://files.pythonhosted.org/packages/68/aa/db67175ab75791384c4e0c55c359520611a73dcb927647d282b16c875cf1/crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cceb359a046e94ac50d123cdb6b6e120c26ed0029e75230bae2210c21ca33434", size = 546979, upload-time = "2026-04-26T11:38:33.485Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/48/8351d3c3ad9a172d4ddf98a63c466b78537aa0ae69e561a4d8e672a3f9be/crosshair_tool-0.0.104-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:15003ef84efed7d17de342792dc304661c6c9a093b7c5bcbaaf327a4252a3747", size = 547571, upload-time = "2026-04-26T11:38:34.775Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/286fa2180a7d328c3d8f047e40527b348f4d62debbdfa729cb112bf223f3/crosshair_tool-0.0.104-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb3f5c4f4c39b78c68f0d52889cf127da18994f5177faae90c7aedb79dbe4df5", size = 578527, upload-time = "2026-04-26T11:38:36.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a8/c8d0ed5a6b1e5889811c360b0e89028ef5d9d43caad62282b82b159fa444/crosshair_tool-0.0.104-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c2f33631751443c64f35d95daf44bcc262841acc22f24d0f1daa5edf49ced28", size = 577584, upload-time = "2026-04-26T11:38:38.04Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c6/b8f4e1465ba57652a033a9f5fe19d5dc3935523734a6e535e144ea932270/crosshair_tool-0.0.104-cp312-cp312-win32.whl", hash = "sha256:4a2f39792e76c9677b8fdc446d2ed3d43ddb37948f4e803de88d26fc0afeae8d", size = 549336, upload-time = "2026-04-26T11:38:39.242Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/60/c6bf30b1c65950afd622f2aa77f66a8a87c2934295ec9c3c0cbba158470c/crosshair_tool-0.0.104-cp312-cp312-win_amd64.whl", hash = "sha256:294e70a2c35b655d1214b99443e853844fa63fbf9d2d8ab658b842fb1575021d", size = 550451, upload-time = "2026-04-26T11:38:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/af/52/66a5f834bd0c98558092f625cca1e06f22d2157e10a3ea68f664e5688710/crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:946ab8b537ff35cde1c1e47582242f84cfbaec7a304438411b2cf399d32cfdd7", size = 565185, upload-time = "2026-04-26T11:38:42.16Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/08/db7ac3f0876937e3fb05d19343b757571a8d3095e6e4daab023b5307f5a2/crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8ce233e4568b67bcf812413a7ffa20b807fd776551036aa98b3484bc26fa1914", size = 550775, upload-time = "2026-04-26T11:38:43.672Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/79/c09da37ce2f39fb24957ffd6b9afc8afa1797d797af8055cf01945b4802c/crosshair_tool-0.0.104-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82fb84d44d7fde08dba2e77771ec9adead0b4e6953694f49e745531c75f75779", size = 551440, upload-time = "2026-04-26T11:38:45.481Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ea/3a2db77a94941df6e0c0dbd312b5289bf55df0ba6f5ae52227304a0318bd/crosshair_tool-0.0.104-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c1c1cfe3fbb3054f1031ac3b2ca2cb268b6330efd4737e50a3b5d81e748002e4", size = 585256, upload-time = "2026-04-26T11:38:47.195Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/14/d1c6f7540fe474eacf8da1a8e0be3ffba03ed5b98de30a229dc16c2d1be2/crosshair_tool-0.0.104-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:299cd2748313d2adab0aa22c890212efacd20560e071c3c9890e42648e728a3b", size = 584271, upload-time = "2026-04-26T11:38:49.011Z" },
+    { url = "https://files.pythonhosted.org/packages/59/29/e33a52d5e0d16c2e2ae6946c1cfa12b70042d20ff4fffc4c04af3938adba/crosshair_tool-0.0.104-cp313-cp313-win32.whl", hash = "sha256:86bcaa3378cdfed93be21a876e090282e4e4d0e23008dcc5853fae8ef99523a6", size = 549357, upload-time = "2026-04-26T11:38:50.893Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9b/427700c38d9912993fc414c504c735a61e3c40f476fd3b3a3659e55276d0/crosshair_tool-0.0.104-cp313-cp313-win_amd64.whl", hash = "sha256:beecba3d1d306cc3a1ab551fe22777cd0c162e97d61b81fa01a57eaa3b00fa21", size = 550474, upload-time = "2026-04-26T11:38:52.428Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/83/e851837d69ea3ebce1bd1c6d755e976aab03086de69070f1dd06ca183367/crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1cb7d856355954c371361cfe6f1e3de2aa4e3ec9c9e00c71bebd6344f72a5a53", size = 562899, upload-time = "2026-04-26T11:38:53.76Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ca/d705535707dd4cadd0870540762d34ca3d287c8386b8a6678b761998ba03/crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:93651387e63549a2c7578f81bc93aae1a237582da45a96b52f91143009fb16fb", size = 549622, upload-time = "2026-04-26T11:38:55.054Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/84/d3b9868079d6e2970ec230954694d084aa76024c37223f2a83456286335b/crosshair_tool-0.0.104-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:efe35ed148effc6bd8cc3d997a87d85edc4419af3fa0fa96486d7b1284d36c17", size = 550295, upload-time = "2026-04-26T11:38:56.513Z" },
+    { url = "https://files.pythonhosted.org/packages/97/54/b4b9143d36634f281b0122e01a7b57902813b1ab7daf3ce7da69cae3a131/crosshair_tool-0.0.104-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:26e8ec24a65e4a0d0af48c1c2fa6aa35fe0ed9dba6a9a631b733306eb28627dc", size = 621829, upload-time = "2026-04-26T11:38:57.834Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ec/cb3b1c419ec9353485a7df7f074def4af91e4b921011e916142a6b44683c/crosshair_tool-0.0.104-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:22aaa4f318a0b316c0b54dd9a0ebcd90bac17a4fc4a8f92159f9cb2d12510ba8", size = 619940, upload-time = "2026-04-26T11:38:59.327Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4b/e73bd53016e5bc18ae8a65e156f9ccbdc879662609f77cc4248e8b8d2c8d/crosshair_tool-0.0.104-cp314-cp314-win32.whl", hash = "sha256:e830fac3b8cc05586afbef0ebe5ff1b1ec24fdb10654713b2a4b26f6508841f1", size = 548172, upload-time = "2026-04-26T11:39:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/50/19/85fd7ea65d07368e3e7ec364b169d163e3bfdaac35fd11d779ffab523b38/crosshair_tool-0.0.104-cp314-cp314-win_amd64.whl", hash = "sha256:d086515a49c881a2f234e75d62bfe59b9b19d954054be3ed18ea6150913db026", size = 549178, upload-time = "2026-04-26T11:39:02.291Z" },
+]
+
+[[package]]
 name = "cuprum"
 version = "0.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "crosshair-tool" },
     { name = "hypothesis" },
     { name = "maturin" },
     { name = "pyright" },
@@ -35,6 +96,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "crosshair-tool" },
     { name = "hypothesis" },
     { name = "maturin", specifier = "==1.13.3" },
     { name = "pyright" },
@@ -79,12 +141,46 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
 ]
 
 [[package]]
@@ -184,6 +280,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -239,6 +344,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
+name = "pygls"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz", hash = "sha256:1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201", size = 55091, upload-time = "2026-03-25T11:19:10.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl", hash = "sha256:510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4", size = 68975, upload-time = "2026-03-25T11:19:11.374Z" },
 ]
 
 [[package]]
@@ -417,10 +536,60 @@ wheels = [
 ]
 
 [[package]]
+name = "typeshed-client"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-resources" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/7d/62fbae352d5fb7ce5ef4d9ca73bf7a9b02b790d2524ab6ef1e0e799a5d1b/typeshed_client-2.11.0.tar.gz", hash = "sha256:0b8f2ab88f611f5e97b70d2a8123942d3d7d5c74cee8ae694db83422f32f9481", size = 522774, upload-time = "2026-05-01T14:51:52.38Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/22/fa16b462157bd869dfad528f5637506b9430ca63d48fb536ecf4cc78481a/typeshed_client-2.11.0-py3-none-any.whl", hash = "sha256:5745e0990b80b29a286b22d68f81779c5c7adf1cac8969eeafba44b73b486c36", size = 787609, upload-time = "2026-05-01T14:51:51.005Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
+]
+
+[[package]]
+name = "z3-solver"
+version = "4.16.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/3b/2b714c40ef2ecf6d8aa080056b9c24a77fe4ca2c83abd83e9c93d34212ac/z3_solver-4.16.0.0.tar.gz", hash = "sha256:263d9ad668966e832c2b246ba0389298a599637793da2dc01cc5e4ef4b0b6c78", size = 5098891, upload-time = "2026-02-19T04:14:08.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/5d/9b277a80333db6b85fedd0f5082e311efcbaec47f2c44c57d38953c2d4d9/z3_solver-4.16.0.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:cc52843cfdd3d3f2cd24bedc62e71c18af8c8b7b23fb05e639ab60b01b5f8f2f", size = 36963251, upload-time = "2026-02-19T04:13:44.303Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c4/fc99aa544930fb7bfcd88947c2788f318acaf1b9704a7a914445e204436a/z3_solver-4.16.0.0-py3-none-macosx_15_0_x86_64.whl", hash = "sha256:e292df40951523e4ecfbc8dee549d93dee00a3fe4ee4833270d19876b713e210", size = 47523873, upload-time = "2026-02-19T04:13:48.154Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/98741b086b6e01630a55db1fbda596949f738204aac14ef35e64a9526ccb/z3_solver-4.16.0.0-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:afae2551f795670f0522cfce82132d129c408a2694adff71eb01ba0f2ece44f9", size = 31741807, upload-time = "2026-02-19T04:13:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2e/295d467c7c796c01337bff790dbedc28cf279f9d365ed64aa9f8ca6b2ba1/z3_solver-4.16.0.0-py3-none-manylinux_2_38_aarch64.whl", hash = "sha256:358648c3b5ef82b9ec9a25711cf4fc498c7881f03a9f4a2ea6ffa9304ca65d94", size = 27326531, upload-time = "2026-02-19T04:13:55.787Z" },
+    { url = "https://files.pythonhosted.org/packages/34/df/29816ce4de24cca3acb007412f9c6fba603e55fcc27ce8c2aade0939057a/z3_solver-4.16.0.0-py3-none-win32.whl", hash = "sha256:cc64c4d41fbebe419fccddb044979c3d95b41214547db65eecdaa67fafef7fe0", size = 13341643, upload-time = "2026-02-19T04:13:58.88Z" },
+    { url = "https://files.pythonhosted.org/packages/86/20/cef4f4d70845df24572d005d19995f92b7f527eb2ffb63a3f5f938a0de2e/z3_solver-4.16.0.0-py3-none-win_amd64.whl", hash = "sha256:eb5df383cb6a3d6b7767dbdca348ac71f6f41e82f76c9ac42002a1f55e35f462", size = 16419861, upload-time = "2026-02-19T04:14:03.232Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/18/7dc1051093abfd6db56ce9addb63c624bfa31946ccb9cfc9be5e75237a26/z3_solver-4.16.0.0-py3-none-win_arm64.whl", hash = "sha256:28729eae2c89112e37697acce4d4517f5e44c6c54d36fed9cf914b06f380cbd6", size = 15084866, upload-time = "2026-02-19T04:14:06.355Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary

This branch extracts pure line-splitting logic from `_emit_completed_lines` and adds property-based coverage for the completed-line and line-ending helpers.

Closes #65.

## Review walkthrough

- Start with [cuprum/_streams.py](https://github.com/leynos/cuprum/blob/issue-65-property-based-tests-for-emit-completed-lines-strip-line-ending-cuprum-streams-py/cuprum/_streams.py) to review `_split_complete_lines` and the `_emit_completed_lines` delegation.
- Then review [cuprum/_testing.py](https://github.com/leynos/cuprum/blob/issue-65-property-based-tests-for-emit-completed-lines-strip-line-ending-cuprum-streams-py/cuprum/_testing.py) for the internal helper re-exports.
- Finish with [cuprum/unittests/test_line_splitting.py](https://github.com/leynos/cuprum/blob/issue-65-property-based-tests-for-emit-completed-lines-strip-line-ending-cuprum-streams-py/cuprum/unittests/test_line_splitting.py) and [pyproject.toml](https://github.com/leynos/cuprum/blob/issue-65-property-based-tests-for-emit-completed-lines-strip-line-ending-cuprum-streams-py/pyproject.toml) for the Hypothesis, CrossHair, and dev dependency changes.

## Validation

- `uv run pytest -q cuprum/unittests/test_line_splitting.py`: 6 passed
- `make check-fmt`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make test`: 477 passed, 43 skipped
- `coderabbit review --agent`: concerns reviewed and addressed

## Notes

The Hypothesis tests keep the issue-requested `max_examples=30`. CrossHair covers bounded symbolic cases for the same invariants, including short multi-character split inputs.

## Summary by Sourcery

Extract benchmark ratchet dataclasses and benchmark profile metadata into dedicated modules, introduce batched pipeline worker iterations with platform-aware command rendering, and add property-based plus symbolic tests and documentation for stream line-splitting and benchmark behaviour.

New Features:
- Add reusable benchmark profile metadata helpers for validating and comparing batched worker benchmark plans.
- Introduce a dedicated ratchet types module encapsulating comparison and reporting dataclasses for Rust benchmark regressions.
- Add pure helper for splitting completed stream lines and expose it via the internal testing facade for direct property testing.
- Extend pipeline worker and benchmark configuration to support configurable batched pipeline iterations per worker process.

Bug Fixes:
- Ensure Rust benchmark ratchet skips incompatible historical baseline artefacts instead of failing CI when benchmark profile shapes differ.
- Fix environment-prefixed benchmark command rendering to be portable across POSIX shells and Windows cmd.exe, avoiding reliance on platform quoting helpers.

Enhancements:
- Refactor benchmark float validation logic to share finite and bound checks across positive and non-negative parameters.
- Change hyperfine pipeline benchmark commands to invoke the resolved Python interpreter directly rather than `uv run` for more representative throughput measurement.
- Enrich developer and user documentation with details of line-splitting contracts, batched benchmark profiles, and CI ratchet behaviour.

Documentation:
- Document the design and testing contracts for pure line-splitting helpers and their CrossHair-backed property tests in the developers and users guides.
- Describe the pipeline throughput benchmark configuration, including batched worker iterations, benchmark profile versioning, and deprecated `uv_bin` usage.
- Clarify Rust pump stream execution plan documentation formatting and return semantics.

Tests:
- Add Hypothesis-based property tests and CrossHair contracts for stream line-splitting helpers covering preservation, remainder handling, and idempotent stripping.
- Extend benchmark ratchet, suite, and behaviour tests to cover benchmark profile metadata, worker iteration handling, Windows command rendering, and legacy compatibility.
- Add tests ensuring filtered CI benchmark plans validate `rust_available` type and preserve benchmark profile and worker iteration metadata.

Chores:
- Introduce CrossHair as a development dependency for symbolic checking of pure helper contracts.