### PR TITLE
Stabilise invalid pymodule compile-fail baseline

### DIFF
--- a/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.rs
+++ b/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.rs
@@ -12,7 +12,7 @@ fn example() -> PyResult<i32> {
 
 #[pymodule]
 fn bad_module(_py: Python<'_>, module: &Bound<'_, PyModule>) -> i32 {
-    module.add_function(wrap_pyfunction!(example, module)?)?;
+    let _ = (_py, module);
     0
 }
 

--- a/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.rs
+++ b/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.rs
@@ -6,8 +6,7 @@
 use pyo3::prelude::*;
 
 #[pymodule]
-fn bad_module(_py: Python<'_>, module: &Bound<'_, PyModule>) -> i32 {
-    let _ = (_py, module);
+fn bad_module(_py: Python<'_>, _module: &Bound<'_, PyModule>) -> i32 {
     0
 }
 

--- a/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.rs
+++ b/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.rs
@@ -5,11 +5,6 @@
 
 use pyo3::prelude::*;
 
-#[pyfunction]
-fn example() -> PyResult<i32> {
-    Ok(1)
-}
-
 #[pymodule]
 fn bad_module(_py: Python<'_>, module: &Bound<'_, PyModule>) -> i32 {
     let _ = (_py, module);

--- a/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.stderr
+++ b/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.stderr
@@ -1,12 +1,12 @@
 error[E0308]: mismatched types
-  --> tests/ui/fail/invalid_pymodule_return.rs:13:1
-   |
-13 | #[pymodule]
-   | ^^^^^^^^^^^
-   | |
-   | expected `Result<(), PyErr>`, found `i32`
-   | expected `Result<(), PyErr>` because of return type
-   |
-   = note: expected enum `Result<(), PyErr>`
-              found type `i32`
-   = note: this error originates in the attribute macro `pymodule` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> tests/ui/fail/invalid_pymodule_return.rs:8:1
+  |
+8 | #[pymodule]
+  | ^^^^^^^^^^^
+  | |
+  | expected `Result<(), PyErr>`, found `i32`
+  | expected `Result<(), PyErr>` because of return type
+  |
+  = note: expected enum `Result<(), PyErr>`
+             found type `i32`
+  = note: this error originates in the attribute macro `pymodule` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.stderr
+++ b/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.stderr
@@ -1,23 +1,3 @@
-error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
-  --> tests/ui/fail/invalid_pymodule_return.rs:15:58
-   |
-14 | fn bad_module(_py: Python<'_>, module: &Bound<'_, PyModule>) -> i32 {
-   | ------------------------------------------------------------------- this function should return `Result` or `Option` to accept `?`
-15 |     module.add_function(wrap_pyfunction!(example, module)?)?;
-   |                                                          ^ cannot use the `?` operator in a function that returns `i32`
-   |
-   = help: the trait `FromResidual<Result<Infallible, PyErr>>` is not implemented for `i32`
-
-error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
-  --> tests/ui/fail/invalid_pymodule_return.rs:15:60
-   |
-14 | fn bad_module(_py: Python<'_>, module: &Bound<'_, PyModule>) -> i32 {
-   | ------------------------------------------------------------------- this function should return `Result` or `Option` to accept `?`
-15 |     module.add_function(wrap_pyfunction!(example, module)?)?;
-   |                                                            ^ cannot use the `?` operator in a function that returns `i32`
-   |
-   = help: the trait `FromResidual<Result<Infallible, PyErr>>` is not implemented for `i32`
-
 error[E0308]: mismatched types
   --> tests/ui/fail/invalid_pymodule_return.rs:13:1
    |


### PR DESCRIPTION
## Summary

This branch stabilises the `compile_time_ui` fixture for an invalid `#[pymodule]` return type by removing incidental diagnostics and preserving the intended mismatch check.

The previous fixture body used `?` operators, so compiler output included two extra `E0277` errors alongside the intended `E0308` mismatch. That coupling made the expected stderr brittle as diagnostics shifted.

## Review walkthrough

- Start with [rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.rs](https://github.com/leynos/cuprum/blob/35a26b1232eabff55f3806dcfcdfca7a9978b705/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.rs#L13-L17) to confirm the fixture now validates only the module return-type contract.
- Then review [rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.stderr](https://github.com/leynos/cuprum/blob/35a26b1232eabff55f3806dcfcdfca7a9978b705/rust/cuprum-rust/tests/ui/fail/invalid_pymodule_return.stderr#L1-L12) to ensure the expected diagnostic set matches the tightened fixture.

## Validation

- `git diff --stat origin/main..HEAD --`:

```text
 .../tests/ui/fail/invalid_pymodule_return.rs         |  2 +-
 .../tests/ui/fail/invalid_pymodule_return.stderr     | 20 --------------------
 2 files changed, 1 insertion(+), 21 deletions(-)
```

- `git status --short` before commit: reported only the two fixture files.

- PR creation: branch pushed and PR draft initialised.

## Notes

No linked issue or roadmap task was identified for this branch.
No follow-on execplan was provided in this change.
Validation suite was not run in this PR-creation pass.
