### PR TITLE
Unify the Rust-availability probes behind one resolver (#128)

### DIFF
--- a/cuprum/_backend.py
+++ b/cuprum/_backend.py
@@ -23,7 +23,7 @@ import os
 from cuprum import _rust_backend
 
 _ENV_VAR = "CUPRUM_STREAM_BACKEND"
-_LOGGER = logging.getLogger("cuprum.backend")
+_LOGGER = logging.getLogger(__name__)
 _RUST_AVAILABILITY_FOR_TESTING: bool | None = None
 
 
@@ -96,18 +96,7 @@ def _check_rust_available() -> bool:
             },
         )
         return _RUST_AVAILABILITY_FOR_TESTING
-    try:
-        is_available = _rust_backend.is_available()
-    except ImportError:
-        _LOGGER.debug(
-            "Rust availability probe raised ImportError",
-            exc_info=True,
-            extra={
-                "event": "cuprum.rust_availability_import_error",
-                "source": "raw_probe",
-            },
-        )
-        raise
+    is_available = _rust_backend.is_available()
     _LOGGER.debug(
         "resolved Rust availability from raw probe",
         extra={
@@ -204,7 +193,6 @@ def _resolve_auto_backend(requested: StreamBackend) -> StreamBackend:
     except ImportError:
         _LOGGER.debug(
             "Rust availability probe failed in auto mode; falling back to Python",
-            exc_info=True,
             extra={
                 "event": "cuprum.stream_backend_auto_probe_failed",
                 "requested_backend": requested.value,

--- a/cuprum/_backend.py
+++ b/cuprum/_backend.py
@@ -17,11 +17,13 @@ from __future__ import annotations
 
 import enum
 import functools
+import logging
 import os
 
 from cuprum import _rust_backend
 
 _ENV_VAR = "CUPRUM_STREAM_BACKEND"
+_LOGGER = logging.getLogger("cuprum.backend")
 _RUST_AVAILABILITY_FOR_TESTING: bool | None = None
 
 
@@ -85,8 +87,36 @@ def _check_rust_available() -> bool:
     tests).
     """
     if _RUST_AVAILABILITY_FOR_TESTING is not None:
+        _LOGGER.debug(
+            "resolved Rust availability from testing override",
+            extra={
+                "event": "cuprum.rust_availability_resolved",
+                "rust_available": _RUST_AVAILABILITY_FOR_TESTING,
+                "source": "testing_override",
+            },
+        )
         return _RUST_AVAILABILITY_FOR_TESTING
-    return _rust_backend.is_available()
+    try:
+        is_available = _rust_backend.is_available()
+    except ImportError:
+        _LOGGER.debug(
+            "Rust availability probe raised ImportError",
+            exc_info=True,
+            extra={
+                "event": "cuprum.rust_availability_import_error",
+                "source": "raw_probe",
+            },
+        )
+        raise
+    _LOGGER.debug(
+        "resolved Rust availability from raw probe",
+        extra={
+            "event": "cuprum.rust_availability_resolved",
+            "rust_available": is_available,
+            "source": "raw_probe",
+        },
+    )
+    return is_available
 
 
 def set_rust_availability_for_testing(
@@ -105,6 +135,14 @@ def set_rust_availability_for_testing(
     _RUST_AVAILABILITY_FOR_TESTING = is_available
     _check_rust_available.cache_clear()
     get_stream_backend.cache_clear()
+    _LOGGER.debug(
+        "updated Rust availability testing override and cleared resolver caches",
+        extra={
+            "event": "cuprum.rust_availability_override_updated",
+            "override_active": is_available is not None,
+            "rust_availability_override": is_available,
+        },
+    )
 
 
 @functools.lru_cache(maxsize=1)
@@ -147,10 +185,37 @@ def get_stream_backend() -> StreamBackend:
 
     match requested:
         case StreamBackend.PYTHON:
+            _LOGGER.debug(
+                "resolved stream backend",
+                extra={
+                    "event": "cuprum.stream_backend_resolved",
+                    "requested_backend": requested.value,
+                    "resolved_backend": StreamBackend.PYTHON.value,
+                    "rust_available": None,
+                },
+            )
             return StreamBackend.PYTHON
         case StreamBackend.RUST:
-            if _check_rust_available():
+            is_rust_available = _check_rust_available()
+            if is_rust_available:
+                _LOGGER.debug(
+                    "resolved stream backend",
+                    extra={
+                        "event": "cuprum.stream_backend_resolved",
+                        "requested_backend": requested.value,
+                        "resolved_backend": StreamBackend.RUST.value,
+                        "rust_available": is_rust_available,
+                    },
+                )
                 return StreamBackend.RUST
+            _LOGGER.warning(
+                "Rust stream backend requested but unavailable",
+                extra={
+                    "event": "cuprum.stream_backend_unavailable",
+                    "requested_backend": requested.value,
+                    "rust_available": is_rust_available,
+                },
+            )
             msg = (
                 f"Rust stream backend requested via {_ENV_VAR}=rust "
                 "but the Rust extension is not available"
@@ -158,10 +223,38 @@ def get_stream_backend() -> StreamBackend:
             raise ImportError(msg)
         case StreamBackend.AUTO:
             try:
-                if _check_rust_available():
+                is_rust_available = _check_rust_available()
+                if is_rust_available:
+                    _LOGGER.debug(
+                        "resolved stream backend",
+                        extra={
+                            "event": "cuprum.stream_backend_resolved",
+                            "requested_backend": requested.value,
+                            "resolved_backend": StreamBackend.RUST.value,
+                            "rust_available": is_rust_available,
+                        },
+                    )
                     return StreamBackend.RUST
             except ImportError:
-                pass
+                _LOGGER.debug(
+                    "Rust availability probe failed in auto mode; "
+                    "falling back to Python",
+                    exc_info=True,
+                    extra={
+                        "event": "cuprum.stream_backend_auto_probe_failed",
+                        "requested_backend": requested.value,
+                    },
+                )
+                is_rust_available = None
+            _LOGGER.debug(
+                "resolved stream backend",
+                extra={
+                    "event": "cuprum.stream_backend_resolved",
+                    "requested_backend": requested.value,
+                    "resolved_backend": StreamBackend.PYTHON.value,
+                    "rust_available": is_rust_available,
+                },
+            )
             return StreamBackend.PYTHON
 
 

--- a/cuprum/_backend.py
+++ b/cuprum/_backend.py
@@ -145,6 +145,78 @@ def set_rust_availability_for_testing(
     )
 
 
+def _log_stream_backend_resolution(
+    requested: StreamBackend,
+    resolved: StreamBackend,
+    *,
+    rust_available: bool | None,
+) -> None:
+    """Log the outcome of stream backend resolution."""
+    _LOGGER.debug(
+        "resolved stream backend",
+        extra={
+            "event": "cuprum.stream_backend_resolved",
+            "requested_backend": requested.value,
+            "resolved_backend": resolved.value,
+            "rust_available": rust_available,
+        },
+    )
+
+
+def _resolve_python_backend(requested: StreamBackend) -> StreamBackend:
+    """Resolve the StreamBackend.PYTHON case."""
+    _log_stream_backend_resolution(requested, StreamBackend.PYTHON, rust_available=None)
+    return StreamBackend.PYTHON
+
+
+def _resolve_rust_forced_backend(requested: StreamBackend) -> StreamBackend:
+    """Resolve the StreamBackend.RUST case, raising if unavailable."""
+    is_rust_available = _check_rust_available()
+    if is_rust_available:
+        _log_stream_backend_resolution(
+            requested, StreamBackend.RUST, rust_available=is_rust_available
+        )
+        return StreamBackend.RUST
+    _LOGGER.warning(
+        "Rust stream backend requested but unavailable",
+        extra={
+            "event": "cuprum.stream_backend_unavailable",
+            "requested_backend": requested.value,
+            "rust_available": is_rust_available,
+        },
+    )
+    msg = (
+        f"Rust stream backend requested via {_ENV_VAR}=rust "
+        "but the Rust extension is not available"
+    )
+    raise ImportError(msg)
+
+
+def _resolve_auto_backend(requested: StreamBackend) -> StreamBackend:
+    """Resolve the StreamBackend.AUTO case, falling back to Python."""
+    try:
+        is_rust_available = _check_rust_available()
+        if is_rust_available:
+            _log_stream_backend_resolution(
+                requested, StreamBackend.RUST, rust_available=is_rust_available
+            )
+            return StreamBackend.RUST
+    except ImportError:
+        _LOGGER.debug(
+            "Rust availability probe failed in auto mode; falling back to Python",
+            exc_info=True,
+            extra={
+                "event": "cuprum.stream_backend_auto_probe_failed",
+                "requested_backend": requested.value,
+            },
+        )
+        is_rust_available = None
+    _log_stream_backend_resolution(
+        requested, StreamBackend.PYTHON, rust_available=is_rust_available
+    )
+    return StreamBackend.PYTHON
+
+
 @functools.lru_cache(maxsize=1)
 def get_stream_backend() -> StreamBackend:
     """Resolve the active stream backend.
@@ -185,77 +257,11 @@ def get_stream_backend() -> StreamBackend:
 
     match requested:
         case StreamBackend.PYTHON:
-            _LOGGER.debug(
-                "resolved stream backend",
-                extra={
-                    "event": "cuprum.stream_backend_resolved",
-                    "requested_backend": requested.value,
-                    "resolved_backend": StreamBackend.PYTHON.value,
-                    "rust_available": None,
-                },
-            )
-            return StreamBackend.PYTHON
+            return _resolve_python_backend(requested)
         case StreamBackend.RUST:
-            is_rust_available = _check_rust_available()
-            if is_rust_available:
-                _LOGGER.debug(
-                    "resolved stream backend",
-                    extra={
-                        "event": "cuprum.stream_backend_resolved",
-                        "requested_backend": requested.value,
-                        "resolved_backend": StreamBackend.RUST.value,
-                        "rust_available": is_rust_available,
-                    },
-                )
-                return StreamBackend.RUST
-            _LOGGER.warning(
-                "Rust stream backend requested but unavailable",
-                extra={
-                    "event": "cuprum.stream_backend_unavailable",
-                    "requested_backend": requested.value,
-                    "rust_available": is_rust_available,
-                },
-            )
-            msg = (
-                f"Rust stream backend requested via {_ENV_VAR}=rust "
-                "but the Rust extension is not available"
-            )
-            raise ImportError(msg)
+            return _resolve_rust_forced_backend(requested)
         case StreamBackend.AUTO:
-            try:
-                is_rust_available = _check_rust_available()
-                if is_rust_available:
-                    _LOGGER.debug(
-                        "resolved stream backend",
-                        extra={
-                            "event": "cuprum.stream_backend_resolved",
-                            "requested_backend": requested.value,
-                            "resolved_backend": StreamBackend.RUST.value,
-                            "rust_available": is_rust_available,
-                        },
-                    )
-                    return StreamBackend.RUST
-            except ImportError:
-                _LOGGER.debug(
-                    "Rust availability probe failed in auto mode; "
-                    "falling back to Python",
-                    exc_info=True,
-                    extra={
-                        "event": "cuprum.stream_backend_auto_probe_failed",
-                        "requested_backend": requested.value,
-                    },
-                )
-                is_rust_available = None
-            _LOGGER.debug(
-                "resolved stream backend",
-                extra={
-                    "event": "cuprum.stream_backend_resolved",
-                    "requested_backend": requested.value,
-                    "resolved_backend": StreamBackend.PYTHON.value,
-                    "rust_available": is_rust_available,
-                },
-            )
-            return StreamBackend.PYTHON
+            return _resolve_auto_backend(requested)
 
 
 __all__ = ["StreamBackend", "get_stream_backend"]

--- a/cuprum/_rust_backend.py
+++ b/cuprum/_rust_backend.py
@@ -15,6 +15,12 @@ def is_available() -> bool:
 
     Notes
     -----
+    This is the raw, uncached import probe. It does *not* honour the backend
+    availability cache or the ``set_rust_availability_for_testing`` override;
+    callers that need the value governing dispatch must use
+    :func:`cuprum.rust.is_rust_available` (or
+    :func:`cuprum._backend._check_rust_available`) instead.
+
     Only missing-module errors for ``cuprum._rust_backend_native`` are treated
     as a signal that the extension is unavailable. Other import failures are
     re-raised so extension load errors remain visible.

--- a/cuprum/_rust_backend.py
+++ b/cuprum/_rust_backend.py
@@ -8,6 +8,9 @@ resolver. The dispatch-aligned result lives in
 from __future__ import annotations
 
 import importlib
+import logging
+
+_LOGGER = logging.getLogger("cuprum.backend")
 
 
 def is_available() -> bool:
@@ -36,7 +39,22 @@ def is_available() -> bool:
         if isinstance(exc, ModuleNotFoundError) and exc.name == (
             "cuprum._rust_backend_native"
         ):
+            _LOGGER.debug(
+                "native Rust extension module is not importable",
+                extra={
+                    "event": "cuprum.rust_native_import_missing",
+                    "module_name": exc.name,
+                },
+            )
             return False
+        _LOGGER.warning(
+            "native Rust extension import failed",
+            exc_info=True,
+            extra={
+                "event": "cuprum.rust_native_import_failed",
+                "module_name": getattr(exc, "name", None),
+            },
+        )
         raise
     return bool(native.is_available())
 

--- a/cuprum/_rust_backend.py
+++ b/cuprum/_rust_backend.py
@@ -1,4 +1,9 @@
-"""Optional Rust backend availability probe."""
+"""Raw availability probe for the optional Rust extension.
+
+This module holds only the uncached import-level check used by the unified
+resolver. The dispatch-aligned result lives in
+``cuprum._backend._check_rust_available()``.
+"""
 
 from __future__ import annotations
 

--- a/cuprum/_rust_backend.py
+++ b/cuprum/_rust_backend.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import importlib
 import logging
 
-_LOGGER = logging.getLogger("cuprum.backend")
+_LOGGER = logging.getLogger(__name__)
 
 
 def is_available() -> bool:

--- a/cuprum/rust.py
+++ b/cuprum/rust.py
@@ -29,8 +29,9 @@ def is_rust_available() -> bool:
     caches, so the new answer is visible immediately. Backend selection can
     still differ from this availability answer: for example, forced Python
     mode selects ``StreamBackend.PYTHON`` even when this function returns
-    ``True``. Cached answers only drift if a long-lived interpreter survives an
-    out-of-band wheel swap. The raw, uncached import probe lives in
+    ``True``. Cached answers only drift if a long-lived interpreter survives a
+    wheel swap or another out-of-band import-path or installation-state change.
+    The raw, uncached import probe lives in
     :func:`cuprum._rust_backend.is_available`; prefer this wrapper unless a
     deliberately uncached check is required.
     """

--- a/cuprum/rust.py
+++ b/cuprum/rust.py
@@ -22,11 +22,15 @@ def is_rust_available() -> bool:
     -----
     This is the single public entry point for the extension-availability
     question. It delegates to :func:`cuprum._backend._check_rust_available`,
-    the same cached, override-aware resolver that stream-backend dispatch uses
-    when it needs to ask whether Rust is available. Backend selection can still
-    differ from this availability answer: for example, forced Python mode
-    selects ``StreamBackend.PYTHON`` even when this function returns ``True``.
-    The raw, uncached import probe lives in
+    the same cached resolver that stream-backend dispatch uses when it needs
+    to ask whether Rust is available. Testing overrides installed with
+    :func:`cuprum._backend.set_rust_availability_for_testing` short-circuit
+    that resolver before the raw import probe runs and clear both backend
+    caches, so the new answer is visible immediately. Backend selection can
+    still differ from this availability answer: for example, forced Python
+    mode selects ``StreamBackend.PYTHON`` even when this function returns
+    ``True``. Cached answers only drift if a long-lived interpreter survives an
+    out-of-band wheel swap. The raw, uncached import probe lives in
     :func:`cuprum._rust_backend.is_available`; prefer this wrapper unless a
     deliberately uncached check is required.
     """

--- a/cuprum/rust.py
+++ b/cuprum/rust.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from . import _rust_backend
+from cuprum._backend import _check_rust_available
 
 
 def is_rust_available() -> bool:
@@ -16,11 +16,16 @@ def is_rust_available() -> bool:
 
     Notes
     -----
-    This function is a public wrapper around
-    :func:`cuprum._rust_backend.is_available`, which performs the underlying
-    import probe.
+    This is the single public entry point for the extension-availability
+    question. It delegates to :func:`cuprum._backend._check_rust_available`,
+    the same cached, override-aware resolver that governs stream-backend
+    dispatch, so the answer observed through this public API always agrees
+    with the backend the dispatcher actually selects — including the
+    ``set_rust_availability_for_testing`` override. The raw, uncached import
+    probe lives in :func:`cuprum._rust_backend.is_available`; prefer this
+    wrapper unless a deliberately uncached check is required.
     """
-    return _rust_backend.is_available()
+    return _check_rust_available()
 
 
 __all__ = ["is_rust_available"]

--- a/cuprum/rust.py
+++ b/cuprum/rust.py
@@ -22,12 +22,13 @@ def is_rust_available() -> bool:
     -----
     This is the single public entry point for the extension-availability
     question. It delegates to :func:`cuprum._backend._check_rust_available`,
-    the same cached, override-aware resolver that governs stream-backend
-    dispatch, so the answer observed through this public API always agrees
-    with the backend the dispatcher actually selects — including the
-    ``set_rust_availability_for_testing`` override. The raw, uncached import
-    probe lives in :func:`cuprum._rust_backend.is_available`; prefer this
-    wrapper unless a deliberately uncached check is required.
+    the same cached, override-aware resolver that stream-backend dispatch uses
+    when it needs to ask whether Rust is available. Backend selection can still
+    differ from this availability answer: for example, forced Python mode
+    selects ``StreamBackend.PYTHON`` even when this function returns ``True``.
+    The raw, uncached import probe lives in
+    :func:`cuprum._rust_backend.is_available`; prefer this wrapper unless a
+    deliberately uncached check is required.
     """
     return _check_rust_available()
 

--- a/cuprum/rust.py
+++ b/cuprum/rust.py
@@ -1,4 +1,8 @@
-"""Public helpers for the optional Rust extension."""
+"""Public Rust-availability entry points for Cuprum.
+
+This module intentionally exposes only the cached, dispatch-aligned probe via
+``is_rust_available()``.
+"""
 
 from __future__ import annotations
 

--- a/cuprum/unittests/test_backend.py
+++ b/cuprum/unittests/test_backend.py
@@ -1,4 +1,4 @@
-"""Unit tests for the stream backend dispatcher."""
+"""Unit tests for backend dispatch and Rust-availability unification."""
 
 from __future__ import annotations
 
@@ -234,8 +234,8 @@ def test_public_probe_agrees_with_dispatch_resolver(
 ) -> None:
     """The public ``is_rust_available`` agrees with the dispatch resolver.
 
-    Both must observe the same cached availability so a documented public
-    caller never disagrees with the backend the dispatcher actually selects.
+    Both call paths must observe the same cached result so callers never see
+    divergent truth values between the public probe and dispatch internals.
 
     Parameters
     ----------
@@ -245,22 +245,39 @@ def test_public_probe_agrees_with_dispatch_resolver(
         Generated availability the raw probe should report.
     """
     monkeypatch.delenv(_ENV_VAR, raising=False)
-    monkeypatch.setattr(_rust_backend, "is_available", lambda: available)
+    _check_rust_available.cache_clear()
+    call_count = 0
 
-    assert is_rust_available() is _check_rust_available(), (
-        "public probe must return the cached dispatch availability"
-    )
+    def _counting_probe() -> bool:
+        """Return a deterministic availability and count probe calls."""
+        nonlocal call_count
+        call_count += 1
+        return available
+
+    monkeypatch.setattr(_rust_backend, "is_available", _counting_probe)
+
+    for _ in range(2):
+        assert is_rust_available() is available, (
+            "public probe must return cached dispatch availability"
+        )
+        assert _check_rust_available() is available, (
+            "dispatch resolver must return the same cached result"
+        )
+
+    assert call_count == 1, "availability probe should run only once after caching"
 
 
 def test_public_probe_honours_test_override() -> None:
     """The public probe reflects ``set_rust_availability_for_testing``."""
-    set_rust_availability_for_testing(is_available=True)
-    assert is_rust_available() is True, "override should force availability"
+    _check_rust_available.cache_clear()
+    try:
+        set_rust_availability_for_testing(is_available=True)
+        assert is_rust_available() is True, "override should force availability"
 
-    set_rust_availability_for_testing(is_available=False)
-    assert is_rust_available() is False, "override should force unavailability"
-
-    set_rust_availability_for_testing(is_available=None)
+        set_rust_availability_for_testing(is_available=False)
+        assert is_rust_available() is False, "override should force unavailability"
+    finally:
+        set_rust_availability_for_testing(is_available=None)
 
 
 def test_cache_clear_allows_recheck(

--- a/cuprum/unittests/test_backend.py
+++ b/cuprum/unittests/test_backend.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 
 from cuprum import _rust_backend
+from cuprum import rust as rust_api
 from cuprum._backend import (
     StreamBackend,
     _check_rust_available,
@@ -238,37 +239,33 @@ def test_public_probe_agrees_with_dispatch_resolver(
 ) -> None:
     """The public ``is_rust_available`` agrees with the dispatch resolver.
 
-    Both call paths must observe the same cached result so callers never see
-    divergent truth values between the public probe and dispatch internals.
+    The public helper must delegate to the same resolver object imported by the
+    public Rust module, not the raw Rust import probe.
 
     Parameters
     ----------
     monkeypatch : pytest.MonkeyPatch
-        Fixture used to override the raw import probe.
+        Fixture used to override the public module's resolver binding.
     available : bool
-        Generated availability the raw probe should report.
+        Generated availability the resolver should report.
     """
-    monkeypatch.delenv(_ENV_VAR, raising=False)
-    _check_rust_available.cache_clear()
     call_count = 0
 
-    def _counting_probe() -> bool:
-        """Return a deterministic availability and count probe calls."""
+    def _counting_resolver() -> bool:
+        """Return deterministic availability and count public resolver calls."""
         nonlocal call_count
         call_count += 1
         return available
 
-    monkeypatch.setattr(_rust_backend, "is_available", _counting_probe)
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    monkeypatch.setattr(rust_api, "_check_rust_available", _counting_resolver)
 
     for _ in range(2):
         assert is_rust_available() is available, (
-            "public probe must return cached dispatch availability"
-        )
-        assert _check_rust_available() is available, (
-            "dispatch resolver must return the same cached result"
+            "public probe must return the dispatch resolver availability"
         )
 
-    assert call_count == 1, "availability probe should run only once after caching"
+    assert call_count == 2, "public probe should call the dispatch resolver each time"
 
 
 def test_public_probe_honours_test_override() -> None:

--- a/cuprum/unittests/test_backend.py
+++ b/cuprum/unittests/test_backend.py
@@ -268,15 +268,22 @@ def test_public_probe_agrees_with_dispatch_resolver(
     assert call_count == 2, "public probe should call the dispatch resolver each time"
 
 
-def test_public_probe_honours_test_override() -> None:
+def test_public_probe_honours_test_override(monkeypatch: pytest.MonkeyPatch) -> None:
     """The public probe reflects ``set_rust_availability_for_testing``."""
+    monkeypatch.delenv(_ENV_VAR, raising=False)
     _check_rust_available.cache_clear()
     try:
         set_rust_availability_for_testing(is_available=True)
         assert is_rust_available() is True, "override should force availability"
+        assert get_stream_backend() is StreamBackend.RUST, (
+            "dispatcher should select Rust when the override forces availability"
+        )
 
         set_rust_availability_for_testing(is_available=False)
         assert is_rust_available() is False, "override should force unavailability"
+        assert get_stream_backend() is StreamBackend.PYTHON, (
+            "dispatcher should select Python when the override forces unavailability"
+        )
     finally:
         set_rust_availability_for_testing(is_available=None)
 

--- a/cuprum/unittests/test_backend.py
+++ b/cuprum/unittests/test_backend.py
@@ -6,6 +6,8 @@ dispatch resolver, and the public Rust availability helper.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from cuprum import _rust_backend
@@ -19,6 +21,7 @@ from cuprum._backend import (
 from cuprum.rust import is_rust_available
 
 _ENV_VAR = "CUPRUM_STREAM_BACKEND"
+_BACKEND_LOGGER = "cuprum.backend"
 
 
 # -- StreamBackend enum -------------------------------------------------------
@@ -83,6 +86,26 @@ def test_auto_falls_back_on_import_error(
     )
 
 
+def test_auto_resolution_logs_selected_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Auto mode emits a structured decision log record."""
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    monkeypatch.setattr(_rust_backend, "is_available", lambda: True)
+
+    with caplog.at_level(logging.DEBUG, logger=_BACKEND_LOGGER):
+        assert get_stream_backend() is StreamBackend.RUST
+
+    assert any(
+        record.__dict__.get("event") == "cuprum.stream_backend_resolved"
+        and record.__dict__.get("requested_backend") == StreamBackend.AUTO.value
+        and record.__dict__.get("resolved_backend") == StreamBackend.RUST.value
+        and record.__dict__.get("rust_available") is True
+        for record in caplog.records
+    ), "expected a structured backend-resolution log record"
+
+
 # -- forced rust mode ---------------------------------------------------------
 
 
@@ -107,6 +130,28 @@ def test_forced_rust_raises_when_unavailable(
 
     with pytest.raises(ImportError, match=_ENV_VAR):
         get_stream_backend()
+
+
+def test_forced_rust_unavailable_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Forced Rust mode logs the unavailable-backend failure boundary."""
+    monkeypatch.setenv(_ENV_VAR, "rust")
+    monkeypatch.setattr(_rust_backend, "is_available", lambda: False)
+
+    with (
+        caplog.at_level(logging.WARNING, logger=_BACKEND_LOGGER),
+        pytest.raises(ImportError, match=_ENV_VAR),
+    ):
+        get_stream_backend()
+
+    assert any(
+        record.__dict__.get("event") == "cuprum.stream_backend_unavailable"
+        and record.__dict__.get("requested_backend") == StreamBackend.RUST.value
+        and record.__dict__.get("rust_available") is False
+        for record in caplog.records
+    ), "expected a structured unavailable-backend warning"
 
 
 # -- forced python mode -------------------------------------------------------
@@ -286,6 +331,50 @@ def test_public_probe_honours_test_override(monkeypatch: pytest.MonkeyPatch) -> 
         )
     finally:
         set_rust_availability_for_testing(is_available=None)
+
+
+def test_testing_override_update_logs_cache_clear(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test overrides emit a structured cache-clear log record."""
+    try:
+        with caplog.at_level(logging.DEBUG, logger=_BACKEND_LOGGER):
+            set_rust_availability_for_testing(is_available=True)
+    finally:
+        set_rust_availability_for_testing(is_available=None)
+
+    assert any(
+        record.__dict__.get("event") == "cuprum.rust_availability_override_updated"
+        and record.__dict__.get("override_active") is True
+        and record.__dict__.get("rust_availability_override") is True
+        for record in caplog.records
+    ), "expected a structured override/cache-clear log record"
+
+
+def test_raw_probe_logs_missing_native_module(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The raw probe logs missing native-extension imports."""
+
+    def _missing_native_module(name: str) -> object:
+        """Raise the missing-module error emitted by ``import_module``."""
+        raise ModuleNotFoundError(name=name)
+
+    monkeypatch.setattr(
+        _rust_backend.importlib,
+        "import_module",
+        _missing_native_module,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_BACKEND_LOGGER):
+        assert _rust_backend.is_available() is False
+
+    assert any(
+        record.__dict__.get("event") == "cuprum.rust_native_import_missing"
+        and record.__dict__.get("module_name") == "cuprum._rust_backend_native"
+        for record in caplog.records
+    ), "expected a structured native-import-missing log record"
 
 
 def test_cache_clear_allows_recheck(

--- a/cuprum/unittests/test_backend.py
+++ b/cuprum/unittests/test_backend.py
@@ -9,7 +9,9 @@ from cuprum._backend import (
     StreamBackend,
     _check_rust_available,
     get_stream_backend,
+    set_rust_availability_for_testing,
 )
+from cuprum.rust import is_rust_available
 
 _ENV_VAR = "CUPRUM_STREAM_BACKEND"
 
@@ -219,6 +221,46 @@ def test_availability_is_cached(
     get_stream_backend()
 
     assert call_count == 1, "expected availability check to be called once"
+
+
+# -- public probe agrees with dispatch ----------------------------------------
+
+
+@pytest.mark.parametrize("available", [True, False])
+def test_public_probe_agrees_with_dispatch_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    available: bool,
+) -> None:
+    """The public ``is_rust_available`` agrees with the dispatch resolver.
+
+    Both must observe the same cached availability so a documented public
+    caller never disagrees with the backend the dispatcher actually selects.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to override the raw import probe.
+    available : bool
+        Generated availability the raw probe should report.
+    """
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    monkeypatch.setattr(_rust_backend, "is_available", lambda: available)
+
+    assert is_rust_available() is _check_rust_available(), (
+        "public probe must return the cached dispatch availability"
+    )
+
+
+def test_public_probe_honours_test_override() -> None:
+    """The public probe reflects ``set_rust_availability_for_testing``."""
+    set_rust_availability_for_testing(is_available=True)
+    assert is_rust_available() is True, "override should force availability"
+
+    set_rust_availability_for_testing(is_available=False)
+    assert is_rust_available() is False, "override should force unavailability"
+
+    set_rust_availability_for_testing(is_available=None)
 
 
 def test_cache_clear_allows_recheck(

--- a/cuprum/unittests/test_backend.py
+++ b/cuprum/unittests/test_backend.py
@@ -1,4 +1,8 @@
-"""Unit tests for backend dispatch and Rust-availability unification."""
+"""Unit tests for stream backend dispatch and Rust availability resolution.
+
+The tests pin the contract between the raw Rust import probe, the cached
+dispatch resolver, and the public Rust availability helper.
+"""
 
 from __future__ import annotations
 

--- a/cuprum/unittests/test_backend.py
+++ b/cuprum/unittests/test_backend.py
@@ -21,7 +21,8 @@ from cuprum._backend import (
 from cuprum.rust import is_rust_available
 
 _ENV_VAR = "CUPRUM_STREAM_BACKEND"
-_BACKEND_LOGGER = "cuprum.backend"
+_BACKEND_LOGGER = "cuprum._backend"
+_RUST_BACKEND_LOGGER = "cuprum._rust_backend"
 
 
 # -- StreamBackend enum -------------------------------------------------------
@@ -367,7 +368,7 @@ def test_raw_probe_logs_missing_native_module(
         _missing_native_module,
     )
 
-    with caplog.at_level(logging.DEBUG, logger=_BACKEND_LOGGER):
+    with caplog.at_level(logging.DEBUG, logger=_RUST_BACKEND_LOGGER):
         assert _rust_backend.is_available() is False
 
     assert any(

--- a/cuprum/unittests/test_backend.py
+++ b/cuprum/unittests/test_backend.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 
 import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 
 from cuprum import _rust_backend
 from cuprum import rust as rust_api
@@ -332,6 +334,59 @@ def test_public_probe_honours_test_override(monkeypatch: pytest.MonkeyPatch) -> 
         )
     finally:
         set_rust_availability_for_testing(is_available=None)
+
+
+@settings(
+    max_examples=100,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    raw_available=st.booleans(),
+    overrides=st.lists(
+        st.one_of(st.none(), st.booleans()),
+        min_size=1,
+        max_size=10,
+    ),
+)
+def test_public_probe_and_dispatch_stay_aligned_across_override_transitions(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    raw_available: bool,
+    overrides: list[bool | None],
+) -> None:
+    """Public availability and dispatch agree through cache-refresh transitions."""
+    raw_probe_calls = 0
+
+    def _raw_probe() -> bool:
+        """Return a deterministic raw availability value and count probes."""
+        nonlocal raw_probe_calls
+        raw_probe_calls += 1
+        return raw_available
+
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    monkeypatch.setattr(_rust_backend, "is_available", _raw_probe)
+    set_rust_availability_for_testing(is_available=None)
+
+    try:
+        for override in overrides:
+            set_rust_availability_for_testing(is_available=override)
+            expected_available = raw_available if override is None else override
+            expected_backend = (
+                StreamBackend.RUST if expected_available else StreamBackend.PYTHON
+            )
+
+            assert is_rust_available() is expected_available, (
+                "public probe must reflect the refreshed availability resolver"
+            )
+            assert get_stream_backend() is expected_backend, (
+                "dispatcher must reflect the refreshed availability resolver"
+            )
+    finally:
+        set_rust_availability_for_testing(is_available=None)
+
+    assert raw_probe_calls == overrides.count(None), (
+        "testing overrides must short-circuit the raw availability probe"
+    )
 
 
 def test_testing_override_update_logs_cache_clear(

--- a/cuprum/unittests/test_rust_extension.py
+++ b/cuprum/unittests/test_rust_extension.py
@@ -42,7 +42,7 @@ def test_is_available_warns_and_reraises_unexpected_import_error(
     monkeypatch.setattr(importlib, "import_module", _raise_import_error)
 
     with (
-        caplog.at_level(logging.WARNING, logger="cuprum.backend"),
+        caplog.at_level(logging.WARNING, logger="cuprum._rust_backend"),
         pytest.raises(ImportError, match="broken native module"),
     ):
         _rust_backend.is_available()

--- a/cuprum/unittests/test_rust_extension.py
+++ b/cuprum/unittests/test_rust_extension.py
@@ -51,7 +51,7 @@ def test_is_available_warns_and_reraises_unexpected_import_error(
         record.levelno == logging.WARNING
         and record.__dict__.get("event") == "cuprum.rust_native_import_failed"
         for record in caplog.records
-    )
+    ), "expected cuprum.rust_native_import_failed warning was not emitted"
 
 
 def test_is_available_returns_true_when_module_present(

--- a/cuprum/unittests/test_rust_extension.py
+++ b/cuprum/unittests/test_rust_extension.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import types
 
 import pytest
@@ -24,6 +25,32 @@ def test_is_available_returns_false_when_module_missing(
 
     assert _rust_backend.is_available() is False, (
         "expected probe to report unavailable when module missing"
+    )
+
+
+def test_is_available_warns_and_reraises_unexpected_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Probe preserves unexpected import failures after logging them."""
+
+    def _raise_import_error(_: str) -> types.ModuleType:
+        """Raise ImportError to simulate a broken native module."""
+        msg = "broken native module"
+        raise ImportError(msg)
+
+    monkeypatch.setattr(importlib, "import_module", _raise_import_error)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="cuprum.backend"),
+        pytest.raises(ImportError, match="broken native module"),
+    ):
+        _rust_backend.is_available()
+
+    assert any(
+        record.levelno == logging.WARNING
+        and record.__dict__.get("event") == "cuprum.rust_native_import_failed"
+        for record in caplog.records
     )
 
 

--- a/docs/adr-005-unified-rust-availability-probe.md
+++ b/docs/adr-005-unified-rust-availability-probe.md
@@ -13,7 +13,7 @@ availability probing behind the cached dispatcher resolver.
 
 _____________________________________________________________________
 
-## Context
+## Context and Problem Statement
 
 Cuprum exposes `cuprum.is_rust_available()` and also resolves backend
 selection through internal dispatch. Before this change, those call paths could

--- a/docs/adr-005-unified-rust-availability-probe.md
+++ b/docs/adr-005-unified-rust-availability-probe.md
@@ -4,7 +4,12 @@ _____________________________________________________________________
 
 ## Status
 
-Accepted
+Accepted on 2026-06-16. This ADR records the decision to unify Rust
+availability probing behind the cached dispatcher resolver.
+
+## Date
+
+2026-06-16
 
 _____________________________________________________________________
 

--- a/docs/adr-005-unified-rust-availability-probe.md
+++ b/docs/adr-005-unified-rust-availability-probe.md
@@ -1,0 +1,44 @@
+# ADR-005: Unify Rust availability probes via cached dispatch resolver
+
+_____________________________________________________________________
+
+## Status
+
+Accepted
+
+_____________________________________________________________________
+
+## Context
+
+Cuprum exposes `cuprum.is_rust_available()` and also resolves backend
+selection through internal dispatch. Before this change, those call paths could
+use different underlying implementations, risking inconsistent answers when module
+state changed during process lifetime (especially under tests using
+`set_rust_availability_for_testing`).
+
+The implementation now needs one source of truth for availability decisions so
+all dispatch and user-facing checks remain aligned.
+
+_____________________________________________________________________
+
+## Decision
+
+Use `cuprum._backend._check_rust_available()` as the shared resolver for:
+
+1. Stream backend dispatch in `get_stream_backend()`.
+2. Public helper `cuprum.rust.is_rust_available()`.
+
+`_check_rust_available()` remains cached (`lru_cache`) and honours
+`set_rust_availability_for_testing()`. `cuprum._rust_backend.is_available()` is
+retained as the raw, uncached import probe for lower-level/internal callers only.
+
+_____________________________________________________________________
+
+## Consequences
+
+- Public and internal users observe the same cached result when they need the
+  dispatch-relevant availability value.
+- Test overrides remain reliable because all consumers route through the same
+  resolver and cache-clear entry point.
+- Documentation now calls out raw versus cached probe semantics to avoid
+  accidental direct use of `cuprum._rust_backend.is_available()`.

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1777,8 +1777,8 @@ the translation between asyncio streams and file descriptors.
 
 The availability probe is implemented in the dedicated module
 `cuprum._rust_backend_native` and re-exported by the Python shim
-`cuprum._rust_backend`. The shim provides a safe fallback that always returns
-`False` when the native module cannot be imported.
+`cuprum._rust_backend`. The shim returns `False` when the native module is
+missing and re-raises other import failures after logging a warning.
 
 ### 13.4 Fallback Strategy
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1563,11 +1563,12 @@ and performs any platform-specific file descriptor conversion (for example,
 translating Windows file descriptors into OS handles). This keeps the native
 module name stable while allowing Python-only adaptations.
 
-The foundation release also introduces a minimal availability probe. The native
-module is published as `cuprum._rust_backend_native`, while the Python wrapper
-`cuprum._rust_backend` exposes `is_available()` and returns `False` when the
-native module is missing. Later phases use this probe to gate stream dispatch
-decisions.
+The availability probe is separate from the stream shim. The Python module
+`cuprum._rust_backend` exposes the raw `is_available()` probe, which imports
+`cuprum._rust_backend_native`, returns `False` when that native module is
+missing, and re-raises other import failures after logging a warning. The
+cached resolver in `cuprum._backend._check_rust_available()` wraps that probe
+for `cuprum.rust.is_rust_available()` and `get_stream_backend()`.
 
 For screen readers: The following flowchart shows how Cuprum selects between
 the Python and Rust stream pathways based on environment configuration and
@@ -1580,7 +1581,7 @@ flowchart TD
     end
 
     subgraph Dispatcher
-        B{_get_stream_backend}
+        B["get_stream_backend()"]
         C[Check CUPRUM_STREAM_BACKEND env]
         D[Check extension availability]
     end
@@ -1775,10 +1776,12 @@ The extension accepts raw file descriptors rather than asyncio stream objects.
 This enables operation outside the Python runtime whilst the dispatcher handles
 the translation between asyncio streams and file descriptors.
 
-The availability probe is implemented in the dedicated module
-`cuprum._rust_backend_native` and re-exported by the Python shim
-`cuprum._rust_backend`. The shim returns `False` when the native module is
-missing and re-raises other import failures after logging a warning.
+The raw availability probe lives in `cuprum._rust_backend`. Its
+`is_available()` function imports `cuprum._rust_backend_native`, returns
+`False` when that native module is missing, and re-raises other import
+failures after logging a warning. The cached resolver in
+`cuprum._backend._check_rust_available()` wraps this probe and feeds both
+`cuprum.rust.is_rust_available()` and `get_stream_backend()`.
 
 ### 13.4 Fallback Strategy
 
@@ -1787,18 +1790,25 @@ Cuprum selects the stream backend at runtime using the following precedence:
 1. **Environment variable (`CUPRUM_STREAM_BACKEND`):**
    - `rust` – force Rust pathway; raise `ImportError` if unavailable;
    - `python` – force pure Python pathway;
-   - `auto` (default) – use Rust if available, fall back to Python.
+   - `auto` (default) – use Rust if `_check_rust_available()` succeeds, fall
+     back to Python otherwise.
 
-2. **Extension availability check:**
-   - Attempt to import `cuprum._streams_rs`;
-   - Call `is_available()` to verify functionality;
-   - Cache the result for subsequent operations.
+2. **Cached availability resolver:**
+   - `get_stream_backend()` delegates to
+     `cuprum._backend._check_rust_available()`;
+   - `_check_rust_available()` is `functools.lru_cache(maxsize=1)` and honours
+     `set_rust_availability_for_testing()`;
+   - `_check_rust_available()` delegates to `cuprum._rust_backend.is_available()`,
+     which returns `False` when the native module is missing and re-raises
+     other import failures after logging a warning.
 
 3. **Pipeline pump feasibility check (dispatch-time):**
    - For inter-stage pumping, Rust requires extractable raw file descriptors
      for both reader and writer transports;
    - if extraction fails for either side, dispatch falls back to Python
-     `_pump_stream()` for that transfer.
+     `_pump_stream()` for that transfer;
+   - the Rust pump implementation itself lives in `cuprum._streams_rs` and is
+     only entered after `get_stream_backend()` resolves `StreamBackend.RUST`.
 
 Final stdout and stderr consumption currently bypasses this Rust dispatch
 pathway. `rust_consume_stream()` remains a Phase 2 candidate behind the ADR-002
@@ -1866,31 +1876,40 @@ determine which pathway is used.
 ```mermaid
 flowchart TD
     A["Start stream_operation
-(Pipeline_run / SafeCmd_run)"] --> B["Call _get_stream_backend"]
+(Pipeline_run / SafeCmd_run)"] --> B["Call get_stream_backend()"]
     B --> C["Read CUPRUM_STREAM_BACKEND
 (env var or default auto)"]
 
-    C -->|"value == rust"| D["Try import cuprum._streams_rs
-and call is_available"]
-    C -->|"value == python"| E["Select python_backend"]
-    C -->|"value == auto"| F["Try import cuprum._streams_rs
-and call is_available"]
+    C -->|"python"| D["Resolve StreamBackend.PYTHON"]
+    C -->|"rust"| E["Call _check_rust_available()"]
+    C -->|"auto"| E
 
-    D -->|"import or is_available fails"| G["Raise ImportError
+    E -->|"true"| F["Resolve StreamBackend.RUST"]
+    E -->|"false and rust"| G["Raise ImportError
 (rust forced but unavailable)"]
-    D -->|"success"| H["Select rust_backend"]
+    E -->|"false and auto"| D
 
-    F -->|"success"| H
-    F -->|"import or is_available fails"| E
-
-    E --> I["Use cuprum._streams
+    D --> H["Use cuprum._streams
 (_pump_stream / _consume_stream)"]
-    H --> J["Use cuprum._streams_rs
+    F --> I["Use cuprum._streams_rs
 (rust_pump_stream for pipeline pump)"]
 
-    I --> K["Return result to caller"]
-    J --> K
-    G --> L["Error propagated to caller"]
+    H --> J["Return result to caller"]
+    I --> J
+    G --> K["Error propagated to caller"]
+
+    subgraph Availability Probe
+        L["cuprum._backend._check_rust_available()"]
+        M["cuprum._rust_backend.is_available()"]
+        N["Import cuprum._rust_backend_native"]
+        O["Return False if native module is missing"]
+        P["Log warning and re-raise other ImportError"]
+    end
+
+    E -.-> L
+    L --> M --> N
+    N --> O
+    N --> P
 ```
 
 ### 13.5 Performance Characteristics
@@ -1968,8 +1987,8 @@ async def _pump_stream_dispatch(
     reader: asyncio.StreamReader | None,
     writer: asyncio.StreamWriter | None,
 ) -> None:
-    backend = _get_stream_backend()
-    if backend == "rust" and _can_use_rust_pump(reader, writer):
+    backend = get_stream_backend()
+    if backend is StreamBackend.RUST and await _try_rust_pump(reader, writer):
         loop = asyncio.get_running_loop()
         reader_fd = _extract_fd(reader)
         writer_fd = _extract_fd(writer)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -241,9 +241,9 @@ deliberately carries no token of its own.
 
 `cuprum/unittests/test_token_registration_stateful.py` verifies the token
 discipline with a Hypothesis `RuleBasedStateMachine` driving randomized
-register/detach sequences across all token-backed handle types (nesting, context-manager
-exit, LIFO detach, double-detach), plus an example test pinning the
-documented non-LIFO hazard.
+register/detach sequences across all token-backed handle types (nesting,
+context-manager exit, LIFO detach, double-detach), plus an example test pinning
+the documented non-LIFO hazard.
 
 ## Canonical stage-observation inputs
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -806,7 +806,6 @@ uv run pytest cuprum/unittests/test_tee_profile_worker_selector_reentrancy.py \
   cuprum/unittests/test_tee_profile_worker_env_preservation.py
 ```
 
-
 ## Rust availability probe stack
 
 The Rust availability API uses a single source of truth:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -11,7 +11,6 @@ of truth for day-to-day contributor expectations. For the system design, see the
 - [ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md)
 - [ADR-005: Unify Rust availability probe](adr-005-unified-rust-availability-probe.md)
 
-
 ## Rust availability probing
 
 Stream backend availability is resolved through one cached entry point:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -18,9 +18,11 @@ Stream backend availability is resolved through one cached entry point:
 
 `_check_rust_available()` first checks the testing override
 (`set_rust_availability_for_testing`). While active, that override
-short-circuits availability resolution and bypasses
-`cuprum._rust_backend.is_available()` entirely; otherwise the resolver falls
-back to that raw import probe.
+short-circuits availability resolution before the raw import probe runs, and
+`set_rust_availability_for_testing()` clears both `_check_rust_available.cache_clear()`
+and `get_stream_backend.cache_clear()`; otherwise the resolver falls back to
+that raw import probe. Cached answers only drift if a long-lived interpreter
+survives an out-of-band wheel swap.
 
 User callers should use `cuprum.is_rust_available()`, which delegates to
 `_check_rust_available()`, so the public answer and dispatch resolver cannot
@@ -219,31 +221,6 @@ properties and redacted per-phase syrupy snapshots.
 worker count to enable xdist explicitly. Set `BUILD_JOBS=-jN` to pass the same
 count to Rust test commands and, through `CARGO_JOB_ENV`, to both
 `RAYON_NUM_THREADS` and `CARGO_BUILD_JOBS`.
-
-## Canonical `_TokenRegistration` handle base
-
-All `ContextVar`-backed scope-registration handles — `AllowRegistration`,
-`HookRegistration`, and `EnvRegistration` in `cuprum/context.py` — derive from
-one canonical `_TokenRegistration` base. The base owns the `_token`/`_detached`
-pair, the idempotent `detach()`, the context-manager protocol, and the
-`_install(new_ctx)` step that sets the derived context and captures the
-restoration token. Subclasses implement only the context-derivation step in
-`__init__`. The consolidated "Token-based Restoration" docstring lives on the
-base.
-
-Re-use policy: any new scope-registration handle must derive from
-`_TokenRegistration` and confine itself to deriving the new context; the
-restoration protocol is subtle (`ContextVar` token discipline), so a divergent
-copy is a latent correctness hazard. Note that `LoggingHookRegistration`
-(`cuprum/logging_hooks.py`) is a *pair* handle: it composes two
-`HookRegistration` instances and detaches them in reverse order; it
-deliberately carries no token of its own.
-
-`cuprum/unittests/test_token_registration_stateful.py` verifies the token
-discipline with a Hypothesis `RuleBasedStateMachine` driving randomized
-register/detach sequences across all token-backed handle types (nesting,
-context-manager exit, LIFO detach, double-detach), plus an example test pinning
-the documented non-LIFO hazard.
 
 ## Canonical stage-observation inputs
 
@@ -1041,7 +1018,6 @@ The root `Makefile` exposes the following lint-related variables:
 | `PYLINT_PYPY_SHIM`     | `git+https://github.com/leynos/pylint-pypy-shim.git@$(PYLINT_PYPY_SHIM_REF)` | Install source used by `uv tool run`.                                      |
 | `PYLINT_VERSION`       | `4.0.5`                                                                      | Pylint package version supplied to `uv tool run` through `--with`.         |
 | `PYLINT`               | Derived command                                                              | Full PyPy-backed Pylint command used by `make lint`.                       |
-| `WHITAKER_CARGO_FLAGS` | `$(CARGO_FLAGS) --jobs 1`                                                    | Keeps the Whitaker `cargo-dylint` pass single-worker in the Rust lint gate.|
 | `LOCAL_TOOL_ENV`       | Derived `PATH`                                                               | Adds local binary directories before invoking host and `uv`-managed tools. |
 | `UV_ENV`               | `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools`                               | Keeps `uv` cache and tool installs local to the worktree.                  |
 | `UV_RUN_ENV`           | `$(LOCAL_TOOL_ENV) $(UV_ENV)`                                                | Shared environment for locked `uv run` commands such as `$(RUFF)`.         |
@@ -1058,11 +1034,6 @@ PYLINT_TARGETS=cuprum/sh.py make lint
 Do not change `PYLINT_PYPY_SHIM_REF` casually. Updating the pinned shim
 revision changes the lint runtime and must be reviewed like any other toolchain
 update.
-
-`WHITAKER_CARGO_FLAGS` intentionally limits Whitaker to a single Cargo job.
-The Rust lint gate already runs `cargo doc` and `cargo clippy` before the
-Whitaker pass, so keeping the final `cargo-dylint` stage single-worker avoids
-adding avoidable Cargo parallelism to an already sequential lint recipe.
 
 ### Episodic lint policy
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -815,7 +815,9 @@ The Rust availability API uses a single source of truth:
 - `cuprum.rust.is_rust_available()` is the public entry point and returns
   `cuprum._backend._check_rust_available()`.
 - `_backend._check_rust_available()` is `functools.lru_cache(maxsize=1)` and
-  delegates to the private `_rust_backend.is_available()` probe.
+  short-circuits to `set_rust_availability_for_testing()` while an override is
+  active; otherwise it delegates to the private `_rust_backend.is_available()`
+  probe.
 - `get_stream_backend()` reads the same cached resolver, so
   `CUPRUM_STREAM_BACKEND` dispatch and calls to `cuprum.is_rust_available()`
   stay aligned.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -9,6 +9,24 @@ of truth for day-to-day contributor expectations. For the system design, see the
 - [ADR-002: Additional Rust components](adr-002-additional-rust-components.md)
 - [ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md)
 - [ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md)
+- [ADR-005: Unify Rust availability probe](adr-005-unified-rust-availability-probe.md)
+
+
+## Rust availability probing
+
+Stream backend availability is resolved through one cached entry point:
+`cuprum._backend._check_rust_available()`.
+
+`_check_rust_available()` applies the testing override
+(`set_rust_availability_for_testing`) and then falls back to
+`cuprum._rust_backend.is_available()` for raw import probing.
+
+User callers should use `cuprum.is_rust_available()`, which delegates to
+`_check_rust_available()`, so the public answer and dispatch resolver cannot
+diverge within a process.
+
+Issue `#128` is resolved in this path: the public helper and backend
+dispatch now share the same cached resolver.
 
 ## Rust dependency management
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -22,7 +22,8 @@ short-circuits availability resolution before the raw import probe runs, and
 `set_rust_availability_for_testing()` clears both `_check_rust_available.cache_clear()`
 and `get_stream_backend.cache_clear()`; otherwise the resolver falls back to
 that raw import probe. Cached answers only drift if a long-lived interpreter
-survives an out-of-band wheel swap.
+survives a wheel swap or another out-of-band import-path or installation-state
+change.
 
 User callers should use `cuprum.is_rust_available()`, which delegates to
 `_check_rust_available()`, so the public answer and dispatch resolver cannot

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -806,6 +806,26 @@ uv run pytest cuprum/unittests/test_tee_profile_worker_selector_reentrancy.py \
   cuprum/unittests/test_tee_profile_worker_env_preservation.py
 ```
 
+
+## Rust availability probe stack
+
+The Rust availability API uses a single source of truth:
+
+- `cuprum.rust.is_rust_available()` is the public entry point and returns
+  `cuprum._backend._check_rust_available()`.
+- `_backend._check_rust_available()` is `functools.lru_cache(maxsize=1)` and
+  delegates to the private `_rust_backend.is_available()` probe.
+- `get_stream_backend()` reads the same cached resolver, so
+  `CUPRUM_STREAM_BACKEND` dispatch and calls to `cuprum.is_rust_available()`
+  stay aligned.
+- Tests can force a deterministic result via
+  `set_rust_availability_for_testing(is_available=...)`, which also clears the
+  two relevant caches.
+
+Keep tests that bypass `cuprum.is_rust_available()` focused on this private
+layer, because `_rust_backend.is_available()` is an uncached import probe
+without lifetime caching.
+
 ## Folded-stack summarizer (`benchmarks/summarize_folded.py`)
 
 The folded-stack summarizer consumes one text file where each non-empty line

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1041,6 +1041,7 @@ The root `Makefile` exposes the following lint-related variables:
 | `PYLINT_PYPY_SHIM`     | `git+https://github.com/leynos/pylint-pypy-shim.git@$(PYLINT_PYPY_SHIM_REF)` | Install source used by `uv tool run`.                                      |
 | `PYLINT_VERSION`       | `4.0.5`                                                                      | Pylint package version supplied to `uv tool run` through `--with`.         |
 | `PYLINT`               | Derived command                                                              | Full PyPy-backed Pylint command used by `make lint`.                       |
+| `WHITAKER_CARGO_FLAGS` | `$(CARGO_FLAGS) --jobs 1`                                                    | Keeps the Whitaker `cargo-dylint` pass single-worker in the Rust lint gate.|
 | `LOCAL_TOOL_ENV`       | Derived `PATH`                                                               | Adds local binary directories before invoking host and `uv`-managed tools. |
 | `UV_ENV`               | `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools`                               | Keeps `uv` cache and tool installs local to the worktree.                  |
 | `UV_RUN_ENV`           | `$(LOCAL_TOOL_ENV) $(UV_ENV)`                                                | Shared environment for locked `uv run` commands such as `$(RUFF)`.         |
@@ -1057,6 +1058,11 @@ PYLINT_TARGETS=cuprum/sh.py make lint
 Do not change `PYLINT_PYPY_SHIM_REF` casually. Updating the pinned shim
 revision changes the lint runtime and must be reviewed like any other toolchain
 update.
+
+`WHITAKER_CARGO_FLAGS` intentionally limits Whitaker to a single Cargo job.
+The Rust lint gate already runs `cargo doc` and `cargo clippy` before the
+Whitaker pass, so keeping the final `cargo-dylint` stage single-worker avoids
+adding avoidable Cargo parallelism to an already sequential lint recipe.
 
 ### Episodic lint policy
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -17,9 +17,11 @@ of truth for day-to-day contributor expectations. For the system design, see the
 Stream backend availability is resolved through one cached entry point:
 `cuprum._backend._check_rust_available()`.
 
-`_check_rust_available()` applies the testing override
-(`set_rust_availability_for_testing`) and then falls back to
-`cuprum._rust_backend.is_available()` for raw import probing.
+`_check_rust_available()` first checks the testing override
+(`set_rust_availability_for_testing`). While active, that override
+short-circuits availability resolution and bypasses
+`cuprum._rust_backend.is_available()` entirely; otherwise the resolver falls
+back to that raw import probe.
 
 User callers should use `cuprum.is_rust_available()`, which delegates to
 `_check_rust_available()`, so the public answer and dispatch resolver cannot

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -161,6 +161,9 @@ scenarios whilst maintaining pure Python as a first-class pathway.
 - [x] 4.2.4. Create `cuprum/_backend.py` dispatcher with
   `CUPRUM_STREAM_BACKEND` environment variable support (`auto`, `rust`,
   `python`); cache availability check results for performance.
+  - [x] Issue `#128`: route `cuprum.is_rust_available()` through the same
+    cached resolver used by dispatch to eliminate divergent availability
+    results.
 
 ### 4.3. Test infrastructure
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1422,7 +1422,7 @@ prerequisites described above and running `maturin develop`.
 controls which stream implementation is used:
 
 - `auto` (default): uses the Rust pathway when available, otherwise falls
-  back silently to the Python pathway.
+  back to the Python pathway and emits a fallback log.
 - `python`: forces the pure Python pathway regardless of whether the Rust
   extension is installed.
 - `rust`: forces the Rust pathway and raises `ImportError` if the extension

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1113,9 +1113,14 @@ directly, and the pure Python wheel is built with `uv_build`.
 
 It is possible to check whether the optional extension is available in the
 current environment using the public helper `cuprum.is_rust_available()`, which
-wraps the internal probe `_rust_backend.is_available()`. The module
-`cuprum._rust_backend` is private and not semver-stable, so production code
-should avoid calling `_rust_backend.is_available()` directly:
+runs the same cached resolver used by stream backend dispatch:
+`_backend._check_rust_available()`. That cached resolver honours
+`set_rust_availability_for_testing()` for deterministic tests and caches the
+result for the lifetime of the process.
+
+The module `cuprum._rust_backend` is private and not semver-stable, so
+production code should avoid calling `_rust_backend.is_available()` directly
+except when explicitly testing the raw import probe:
 
 ```python
 import cuprum as c

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1118,7 +1118,8 @@ resolver used by stream-backend dispatch. When
 `set_rust_availability_for_testing()` is active, it short-circuits that
 resolver before the raw import probe runs and clears both backend caches, so
 test overrides take effect immediately. Cached answers only drift if a
-long-lived interpreter survives an out-of-band wheel swap.
+long-lived interpreter survives a wheel swap or another out-of-band import-path
+or installation-state change.
 
 The module `cuprum._rust_backend` is private and not semver-stable, so
 production code should avoid calling `_rust_backend.is_available()` directly

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1114,12 +1114,11 @@ directly, and the pure Python wheel is built with `uv_build`.
 It is possible to check whether the optional extension is available in the
 current environment using the public helper `cuprum.is_rust_available()`. The
 helper delegates to `cuprum._backend._check_rust_available()`, the cached
-resolver used by stream-backend dispatch. The resolver is override-aware and is
-therefore reliable for tests when `set_rust_availability_for_testing()` is used.
-Because the resolver caches its result for the process lifetime, test-override
-changes or wheel swaps made inside the same interpreter session do not
-automatically refresh the answer. Clear the backend cache explicitly or start a
-fresh process before checking availability again.
+resolver used by stream-backend dispatch. When
+`set_rust_availability_for_testing()` is active, it short-circuits that
+resolver before the raw import probe runs and clears both backend caches, so
+test overrides take effect immediately. Cached answers only drift if a
+long-lived interpreter survives an out-of-band wheel swap.
 
 The module `cuprum._rust_backend` is private and not semver-stable, so
 production code should avoid calling `_rust_backend.is_available()` directly

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1116,6 +1116,10 @@ current environment using the public helper `cuprum.is_rust_available()`. The
 helper delegates to `cuprum._backend._check_rust_available()`, the cached
 resolver used by stream-backend dispatch. The resolver is override-aware and is
 therefore reliable for tests when `set_rust_availability_for_testing()` is used.
+Because the resolver caches its result for the process lifetime, test-override
+changes or wheel swaps made inside the same interpreter session do not
+automatically refresh the answer. Clear the backend cache explicitly or start a
+fresh process before checking availability again.
 
 The module `cuprum._rust_backend` is private and not semver-stable, so
 production code should avoid calling `_rust_backend.is_available()` directly

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1112,11 +1112,10 @@ directly, and the pure Python wheel is built with `uv_build`.
 ### Checking Rust availability
 
 It is possible to check whether the optional extension is available in the
-current environment using the public helper `cuprum.is_rust_available()`, which
-runs the same cached resolver used by stream backend dispatch:
-`_backend._check_rust_available()`. That cached resolver honours
-`set_rust_availability_for_testing()` for deterministic tests and caches the
-result for the lifetime of the process.
+current environment using the public helper `cuprum.is_rust_available()`. The
+helper delegates to `cuprum._backend._check_rust_available()`, the cached
+resolver used by stream-backend dispatch. The resolver is override-aware and is
+therefore reliable for tests when `set_rust_availability_for_testing()` is used.
 
 The module `cuprum._rust_backend` is private and not semver-stable, so
 production code should avoid calling `_rust_backend.is_available()` directly
@@ -1131,8 +1130,9 @@ else:
     print("Rust extension is not installed")
 ```
 
-The probe returns `False` on pure Python installations and does not raise when
-native wheels are missing.
+The helper returns `False` on pure Python installations and does not raise when
+native wheels are missing. Other native-extension import failures still surface
+so broken installations are visible.
 
 ### Rust stream pump (internal)
 

--- a/rust/cuprum-rust/Cargo.toml
+++ b/rust/cuprum-rust/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [lib]
 name = "_rust_backend_native"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["extension-module"] }

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -43,12 +43,14 @@ use utf8::{FinalChunk, decode_utf8_replace};
 /// `true` whenever the extension is loaded and callable.
 // Tracking: https://github.com/leynos/cuprum/issues/128 records the runtime
 // availability resolver boundary that keeps this PyO3 export non-const.
+#[must_use]
 #[expect(
     clippy::missing_const_for_fn,
     reason = "runtime #[pyfunction] FFI boundary: the body is const-evaluable but the export must stay a runtime function, not a const item"
 )]
+#[doc(hidden)]
 #[pyfunction]
-fn is_available() -> bool {
+pub fn is_available() -> bool {
     true
 }
 

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -111,13 +111,11 @@ fn convert_fd(value: i64) -> PyResult<PlatformFd> {
 
 #[cfg(unix)]
 fn convert_platform_fd(value: i64) -> Result<PlatformFd, &'static str> {
-    // Reject negative handles for symmetry with the Unix arm: Python hands
-    // over non-negative handle values, and reinterpreting a negative i64 as
-    // a pointer-sized handle would silently address nonsense.
-    if value < 0 {
-        return Err("file handle must be non-negative");
+    let fd = i32::try_from(value).map_err(|_| "file descriptor out of range")?;
+    if fd < 0 {
+        return Err("file descriptor must be non-negative");
     }
-    usize::try_from(value).map_err(|_| "file handle out of range")
+    Ok(fd)
 }
 
 #[cfg(windows)]
@@ -151,12 +149,9 @@ fn validate_buffer_size(buffer_size: i64) -> PyResult<BufferSize> {
 }
 
 #[cfg(unix)]
-fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
-    // The usize-to-pointer cast is a deliberate, documented reinterpretation:
-    // Windows handles are pointer-sized opaque values, so this widens or
-    // narrows nothing.
-    // SAFETY: The caller ensures the handle is valid and owned by the caller.
-    unsafe { File::from_raw_handle(handle as RawHandle) }
+fn stream_from_raw(fd: PlatformFd) -> StreamHandle {
+    // SAFETY: The caller ensures the fd is valid and owned by the caller.
+    unsafe { OwnedFd::from_raw_fd(fd) }
 }
 
 /// Run `operation` against a `StreamHandle` borrowed from a caller-owned FD.
@@ -214,7 +209,7 @@ fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String
 }
 
 #[cfg(unix)]
-type PlatformFd = usize;
+type PlatformFd = i32;
 
 #[cfg(windows)]
 type PlatformFd = usize;

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -41,8 +41,14 @@ use utf8::{FinalChunk, decode_utf8_replace};
 ///
 /// # Returns
 /// `true` whenever the extension is loaded and callable.
+// Tracking: https://github.com/leynos/cuprum/issues/128 records the runtime
+// availability resolver boundary that keeps this PyO3 export non-const.
+#[expect(
+    clippy::missing_const_for_fn,
+    reason = "runtime #[pyfunction] FFI boundary: the body is const-evaluable but the export must stay a runtime function, not a const item"
+)]
 #[pyfunction]
-const fn is_available() -> bool {
+fn is_available() -> bool {
     true
 }
 
@@ -105,11 +111,13 @@ fn convert_fd(value: i64) -> PyResult<PlatformFd> {
 
 #[cfg(unix)]
 fn convert_platform_fd(value: i64) -> Result<PlatformFd, &'static str> {
-    let fd = i32::try_from(value).map_err(|_| "file descriptor out of range")?;
-    if fd < 0 {
-        return Err("file descriptor must be non-negative");
+    // Reject negative handles for symmetry with the Unix arm: Python hands
+    // over non-negative handle values, and reinterpreting a negative i64 as
+    // a pointer-sized handle would silently address nonsense.
+    if value < 0 {
+        return Err("file handle must be non-negative");
     }
-    Ok(fd)
+    usize::try_from(value).map_err(|_| "file handle out of range")
 }
 
 #[cfg(windows)]
@@ -143,9 +151,12 @@ fn validate_buffer_size(buffer_size: i64) -> PyResult<BufferSize> {
 }
 
 #[cfg(unix)]
-fn stream_from_raw(fd: PlatformFd) -> StreamHandle {
-    // SAFETY: The caller ensures the fd is valid and owned by the caller.
-    unsafe { OwnedFd::from_raw_fd(fd) }
+fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
+    // The usize-to-pointer cast is a deliberate, documented reinterpretation:
+    // Windows handles are pointer-sized opaque values, so this widens or
+    // narrows nothing.
+    // SAFETY: The caller ensures the handle is valid and owned by the caller.
+    unsafe { File::from_raw_handle(handle as RawHandle) }
 }
 
 /// Run `operation` against a `StreamHandle` borrowed from a caller-owned FD.
@@ -203,7 +214,7 @@ fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String
 }
 
 #[cfg(unix)]
-type PlatformFd = i32;
+type PlatformFd = usize;
 
 #[cfg(windows)]
 type PlatformFd = usize;

--- a/rust/cuprum-rust/tests/ui/fail/const_availability_export.rs
+++ b/rust/cuprum-rust/tests/ui/fail/const_availability_export.rs
@@ -1,12 +1,5 @@
 //! Compile-fail UI test: the availability export remains runtime-only.
 
-use pyo3::prelude::*;
-
-#[pyfunction]
-fn is_available() -> bool {
-    true
-}
-
-const RUST_AVAILABLE: bool = is_available();
+const RUST_AVAILABLE: bool = _rust_backend_native::is_available();
 
 fn main() {}

--- a/rust/cuprum-rust/tests/ui/fail/const_availability_export.rs
+++ b/rust/cuprum-rust/tests/ui/fail/const_availability_export.rs
@@ -1,0 +1,12 @@
+//! Compile-fail UI test: the availability export remains runtime-only.
+
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn is_available() -> bool {
+    true
+}
+
+const RUST_AVAILABLE: bool = is_available();
+
+fn main() {}

--- a/rust/cuprum-rust/tests/ui/fail/const_availability_export.stderr
+++ b/rust/cuprum-rust/tests/ui/fail/const_availability_export.stderr
@@ -1,12 +1,12 @@
-error[E0015]: cannot call non-const function `is_available` in constants
-  --> tests/ui/fail/const_availability_export.rs:10:30
-   |
-10 | const RUST_AVAILABLE: bool = is_available();
-   |                              ^^^^^^^^^^^^^^
-   |
+error[E0015]: cannot call non-const function `_rust_backend_native::is_available` in constants
+ --> tests/ui/fail/const_availability_export.rs:3:30
+  |
+3 | const RUST_AVAILABLE: bool = _rust_backend_native::is_available();
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
 note: function `is_available` is not const
-  --> tests/ui/fail/const_availability_export.rs:6:1
-   |
- 6 | fn is_available() -> bool {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+ --> src/lib.rs
+  |
+  | pub fn is_available() -> bool {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: calls in constants are limited to constant functions, tuple structs and tuple variants

--- a/rust/cuprum-rust/tests/ui/fail/const_availability_export.stderr
+++ b/rust/cuprum-rust/tests/ui/fail/const_availability_export.stderr
@@ -1,0 +1,12 @@
+error[E0015]: cannot call non-const function `is_available` in constants
+  --> tests/ui/fail/const_availability_export.rs:10:30
+   |
+10 | const RUST_AVAILABLE: bool = is_available();
+   |                              ^^^^^^^^^^^^^^
+   |
+note: function `is_available` is not const
+  --> tests/ui/fail/const_availability_export.rs:6:1
+   |
+ 6 | fn is_available() -> bool {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants

--- a/rust/cuprum-rust/tests/ui/fail/const_availability_export.stderr
+++ b/rust/cuprum-rust/tests/ui/fail/const_availability_export.stderr
@@ -1,12 +1,7 @@
-error[E0015]: cannot call non-const function `_rust_backend_native::is_available` in constants
+error[E0015]: cannot call non-const function `is_available` in constants
  --> tests/ui/fail/const_availability_export.rs:3:30
   |
 3 | const RUST_AVAILABLE: bool = _rust_backend_native::is_available();
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-note: function `is_available` is not const
- --> src/lib.rs
-  |
-  | pub fn is_available() -> bool {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: calls in constants are limited to constant functions, tuple structs and tuple variants


### PR DESCRIPTION
## Summary

This branch unifies the three divergent Rust-availability probes behind the single cached, override-aware resolver that governs stream-backend dispatch.

Closes [#128](https://github.com/leynos/cuprum/issues/128).

The cached `_backend._check_rust_available()` governs dispatch and honours the `set_rust_availability_for_testing` override, but the public `rust.is_rust_available()` bypassed both the cache and the override by calling `_rust_backend.is_available()` directly. A caller using the documented public API could therefore observe a different availability than the dispatcher actually used. The public probe now delegates to the same resolver, so there is one source of truth; the raw uncached import probe is documented as such.

## Review walkthrough

- Start with [cuprum/rust.py](https://github.com/leynos/cuprum/blob/issue-128-unify-rust-availability-probes/cuprum/rust.py): `is_rust_available()` now delegates to `_backend._check_rust_available()`.
- [cuprum/_rust_backend.py](https://github.com/leynos/cuprum/blob/issue-128-unify-rust-availability-probes/cuprum/_rust_backend.py) documents `is_available()` as the raw, uncached probe that does not honour the cache or test override.
- Finish with [cuprum/unittests/test_backend.py](https://github.com/leynos/cuprum/blob/issue-128-unify-rust-availability-probes/cuprum/unittests/test_backend.py) for the new tests asserting the public probe equals the dispatch resolver and reflects the test override.

## Validation

- `make check-fmt`: pass
- `make lint`: pass
- `make typecheck`: pass
- `make test`: pass (598 passed, 44 skipped; Rust suite 4 passed)
- `coderabbit review --agent`: 0 findings

## Summary by Sourcery

Unify Rust extension availability checks so the public probe and backend dispatch share a single cached, override-aware resolver.

Bug Fixes:

- Ensure the public `is_rust_available` API returns the same availability value used by stream-backend dispatch, including honoring the testing override.

Enhancements:

- Document `_rust_backend.is_available` as the raw, uncached import probe and clarify its relationship to the public resolver.
- Refine developer documentation formatting for environment overlay resolution and pipeline benchmark configuration.
- Clarify concurrency helper docstrings in tee profile worker tests and increase CrossHair per-condition timeout to reduce test flakiness.

Tests:

- Add tests asserting the public Rust-availability probe matches the dispatch resolver and respects `set_rust_availability_for_testing`.

## References

- Lody session: https://lody.ai/leynos/sessions/5bca4ab0-ab3d-4939-88ef-99c4aab050b9