### PR TITLE
Make ConcurrentResult failure-to-submission mapping uniform (#121)

### DIFF
--- a/cuprum/concurrent.py
+++ b/cuprum/concurrent.py
@@ -82,13 +82,33 @@ class ConcurrentResult:
         may be a subset of the originally submitted commands.
     failures:
         Indices into ``results`` for commands that exited non-zero, in
-        ascending order. Note: these are indices into the ``results``
-        tuple, not the original submission indices.
+        ascending order. These are positions within the (possibly compacted)
+        ``results`` tuple, **not** original submission positions; in fail-fast
+        mode ``results`` omits cancelled commands, so a ``failures`` index does
+        not equal the submitted command's position. Use
+        :attr:`failure_submission_indices` for the submission-stable mapping.
+    submission_indices:
+        Original submission index of each entry in ``results``, parallel to it.
+        In collect-all mode this is the identity ``(0, 1, …, n-1)``; in
+        fail-fast mode it lists the submission positions of the completed
+        commands. Lets callers map any result — or failure — back to the
+        command they submitted, uniformly across both execution modes. Defaults
+        to the identity sequence when not supplied.
 
     """
 
     results: tuple[CommandResult, ...]
     failures: tuple[int, ...] = ()
+    submission_indices: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Default ``submission_indices`` to the identity sequence."""
+        if not self.submission_indices and self.results:
+            object.__setattr__(
+                self,
+                "submission_indices",
+                tuple(range(len(self.results))),
+            )
 
     @property
     def ok(self) -> bool:
@@ -101,6 +121,16 @@ class ConcurrentResult:
         if not self.failures:
             return None
         return self.results[self.failures[0]]
+
+    @property
+    def failure_submission_indices(self) -> tuple[int, ...]:
+        """Original submission indices of failed commands, ascending.
+
+        Unlike :attr:`failures` (positions within the compacted ``results``),
+        these are stable across both collect-all and fail-fast modes: each
+        value is the position at which the failing command was submitted.
+        """
+        return tuple(self.submission_indices[index] for index in self.failures)
 
 
 class _FirstFailureError(Exception):
@@ -124,7 +154,41 @@ async def _run_with_semaphore(
             return await cmd.run(output=config.output, context=config.context)
     return await cmd.run(output=config.output, context=config.context)
 
+def _collect_results_and_failures(
+    indexed_results: cabc.Iterable[tuple[int, CommandResult | None]],
+) -> tuple[list[CommandResult], list[int], list[int]]:
+    """Compact completed results, recording submission and failure indices.
 
+    This is the single canonical "append result, record index if not ok" loop
+    shared by the collect-all and fail-fast paths, so the two cannot drift.
+
+    Parameters
+    ----------
+    indexed_results:
+        Pairs of ``(submission_index, result)``. A ``None`` result marks a
+        command that was cancelled (fail-fast) and is skipped.
+
+    Returns
+    -------
+    tuple[list[CommandResult], list[int], list[int]]
+        ``(results, submission_indices, failures)`` where ``results`` holds the
+        completed commands in encounter order, ``submission_indices`` is the
+        original submission index of each entry in ``results``, and
+        ``failures`` holds positions within ``results`` for non-zero exits, in
+        ascending order.
+    """
+    results: list[CommandResult] = []
+    submission_indices: list[int] = []
+    failures: list[int] = []
+    for submission_index, result in indexed_results:
+        if result is None:
+            continue
+        position = len(results)
+        results.append(result)
+        submission_indices.append(submission_index)
+        if not result.ok:
+            failures.append(position)
+    return results, submission_indices, failures
 async def _run_collect_all(
     commands: cabc.Sequence[SafeCmd],
     semaphore: asyncio.Semaphore | None,
@@ -139,44 +203,45 @@ async def _run_collect_all(
     # Gather results, capturing exceptions
     raw_results = await asyncio.gather(*tasks, return_exceptions=True)
 
-    # Process results and identify failures
-    results: list[CommandResult] = []
-    failures: list[int] = []
-
     # Re-raise the first BaseException to propagate critical exceptions like
     # CancelledError immediately. This is an intentional trade-off: any
     # subsequent exceptions from other tasks are dropped and not preserved
     # for diagnostics, but it ensures cancellation signals propagate promptly.
-    for idx, raw in enumerate(raw_results):
+    completed: list[CommandResult | None] = []
+    for raw in raw_results:
         if isinstance(raw, BaseException):
             raise raw
-        results.append(raw)
-        if not raw.ok:
-            failures.append(idx)
+        completed.append(raw)
 
+    results, submission_indices, failures = _collect_results_and_failures(
+        enumerate(completed),
+    )
     return ConcurrentResult(
         results=tuple(results),
         failures=tuple(failures),
+        submission_indices=tuple(submission_indices),
     )
 
 
 def _build_final_results(
     results: list[CommandResult | None],
-) -> tuple[list[CommandResult], list[int]]:
-    """Build final results and remapped failure indices from partial results.
+) -> tuple[list[CommandResult], list[int], list[int]]:
+    """Build final results, submission indices, and failures from partial results.
 
     Parameters
     ----------
     results:
-        List of CommandResult or None for cancelled commands.
+        List of CommandResult or None for cancelled commands, indexed by
+        original submission position.
 
     Returns
     -------
-    tuple[list[CommandResult], list[int]]
-        Tuple of (final_results, remapped_failures) where final_results contains
-        only completed commands and remapped_failures contains indices into
-        final_results (not original positions) for failed commands, in ascending
-        order.
+    tuple[list[CommandResult], list[int], list[int]]
+        ``(final_results, submission_indices, failures)`` where ``final_results``
+        contains only completed commands, ``submission_indices`` records each
+        completed command's original submission position, and ``failures``
+        contains indices into ``final_results`` (not original positions) for
+        failed commands, in ascending order.
 
     post: all(result is not None for result in __return__[0])
     post: __return__[0] == [result for result in results if result is not None]
@@ -186,18 +251,7 @@ def _build_final_results(
     post: __return__[1] == sorted(__return__[1])
 
     """
-    final_results: list[CommandResult] = []
-    failures: list[int] = []
-
-    for result in results:
-        if result is not None:
-            compacted_idx = len(final_results)
-            final_results.append(result)
-            if not result.ok:
-                failures.append(compacted_idx)
-
-    # failures are already in ascending order since we process sequentially
-    return final_results, failures
+    return _collect_results_and_failures(enumerate(results))
 
 
 async def _run_fail_fast(
@@ -223,11 +277,12 @@ async def _run_fail_fast(
         # Expected when a command fails; continue to build result
         pass
 
-    final_results, failures = _build_final_results(results)
+    final_results, submission_indices, failures = _build_final_results(results)
 
     return ConcurrentResult(
         results=tuple(final_results),
         failures=tuple(failures),
+        submission_indices=tuple(submission_indices),
     )
 
 

--- a/cuprum/concurrent.py
+++ b/cuprum/concurrent.py
@@ -190,6 +190,8 @@ def _collect_results_and_failures(
         if not result.ok:
             failures.append(position)
     return results, submission_indices, failures
+
+
 async def _run_collect_all(
     commands: cabc.Sequence[SafeCmd],
     semaphore: asyncio.Semaphore | None,

--- a/cuprum/concurrent.py
+++ b/cuprum/concurrent.py
@@ -93,7 +93,8 @@ class ConcurrentResult:
         fail-fast mode it lists the submission positions of the completed
         commands. Lets callers map any result — or failure — back to the
         command they submitted, uniformly across both execution modes. Defaults
-        to the identity sequence when not supplied.
+        to the identity sequence when not supplied; a supplied sequence whose
+        length differs from ``results`` raises :class:`ValueError`.
 
     """
 
@@ -102,13 +103,23 @@ class ConcurrentResult:
     submission_indices: tuple[int, ...] = ()
 
     def __post_init__(self) -> None:
-        """Populate ``submission_indices`` with the identity when unset."""
-        if not self.submission_indices and self.results:
-            object.__setattr__(
-                self,
-                "submission_indices",
-                tuple(range(len(self.results))),
+        """Backfill or validate ``submission_indices`` against ``results``.
+
+        Populate the identity sequence when ``submission_indices`` is omitted;
+        reject a supplied sequence whose length differs from ``results`` so
+        misuse fails fast here rather than raising ``IndexError`` later.
+        """
+        if not self.submission_indices:
+            if self.results:
+                identity = tuple(range(len(self.results)))
+                object.__setattr__(self, "submission_indices", identity)
+            return
+        if len(self.submission_indices) != len(self.results):
+            msg = (
+                f"submission_indices length ({len(self.submission_indices)}) "
+                f"must match results length ({len(self.results)})"
             )
+            raise ValueError(msg)
 
     @property
     def ok(self) -> bool:

--- a/cuprum/concurrent.py
+++ b/cuprum/concurrent.py
@@ -154,6 +154,7 @@ async def _run_with_semaphore(
             return await cmd.run(output=config.output, context=config.context)
     return await cmd.run(output=config.output, context=config.context)
 
+
 def _collect_results_and_failures(
     indexed_results: cabc.Iterable[tuple[int, CommandResult | None]],
 ) -> tuple[list[CommandResult], list[int], list[int]]:
@@ -246,9 +247,10 @@ def _build_final_results(
     post: all(result is not None for result in __return__[0])
     post: __return__[0] == [result for result in results if result is not None]
     post: len(__return__[0]) == sum(1 for result in results if result is not None)
-    post: all(0 <= idx < len(__return__[0]) for idx in __return__[1])
-    post: all(not __return__[0][idx].ok for idx in __return__[1])
-    post: __return__[1] == sorted(__return__[1])
+    post: __return__[1] == [i for i, result in enumerate(results) if result is not None]
+    post: all(0 <= idx < len(__return__[0]) for idx in __return__[2])
+    post: all(not __return__[0][idx].ok for idx in __return__[2])
+    post: __return__[2] == sorted(__return__[2])
 
     """
     return _collect_results_and_failures(enumerate(results))

--- a/cuprum/concurrent.py
+++ b/cuprum/concurrent.py
@@ -102,7 +102,7 @@ class ConcurrentResult:
     submission_indices: tuple[int, ...] = ()
 
     def __post_init__(self) -> None:
-        """Default ``submission_indices`` to the identity sequence."""
+        """Populate ``submission_indices`` with the identity when unset."""
         if not self.submission_indices and self.results:
             object.__setattr__(
                 self,

--- a/cuprum/concurrent.py
+++ b/cuprum/concurrent.py
@@ -92,27 +92,27 @@ class ConcurrentResult:
         In collect-all mode this is the identity ``(0, 1, …, n-1)``; in
         fail-fast mode it lists the submission positions of the completed
         commands. Lets callers map any result — or failure — back to the
-        command they submitted, uniformly across both execution modes. Defaults
-        to the identity sequence when not supplied; a supplied sequence whose
-        length differs from ``results`` raises :class:`ValueError`.
+        command they submitted, uniformly across both execution modes. Pass
+        ``None`` (the default) to backfill the identity sequence (even for
+        empty ``results``); any supplied sequence — including an empty tuple —
+        whose length differs from ``results`` raises :class:`ValueError`.
 
     """
 
     results: tuple[CommandResult, ...]
     failures: tuple[int, ...] = ()
-    submission_indices: tuple[int, ...] = ()
+    submission_indices: tuple[int, ...] | None = None
 
     def __post_init__(self) -> None:
         """Backfill or validate ``submission_indices`` against ``results``.
 
-        Populate the identity sequence when ``submission_indices`` is omitted;
-        reject a supplied sequence whose length differs from ``results`` so
-        misuse fails fast here rather than raising ``IndexError`` later.
+        Treat ``None`` as "omitted" and backfill the identity sequence (even
+        for empty ``results``); validate any supplied sequence, so a length
+        mismatch fails fast here rather than as a later ``IndexError``.
         """
-        if not self.submission_indices:
-            if self.results:
-                identity = tuple(range(len(self.results)))
-                object.__setattr__(self, "submission_indices", identity)
+        if self.submission_indices is None:
+            identity = tuple(range(len(self.results)))
+            object.__setattr__(self, "submission_indices", identity)
             return
         if len(self.submission_indices) != len(self.results):
             msg = (
@@ -141,7 +141,8 @@ class ConcurrentResult:
         these are stable across both collect-all and fail-fast modes: each
         value is the position at which the failing command was submitted.
         """
-        return tuple(self.submission_indices[index] for index in self.failures)
+        # ``__post_init__`` backfills the mapping, so it is never None here.
+        return tuple((self.submission_indices or ())[index] for index in self.failures)
 
 
 class _FirstFailureError(Exception):

--- a/cuprum/unittests/test_build_final_results_property.py
+++ b/cuprum/unittests/test_build_final_results_property.py
@@ -132,13 +132,13 @@ def _submission_indices_preserved(
     return submission_indices == expected_indices
 
 
-def _build_final_results_invariants_hold(
+def _compaction_and_failure_invariants_hold(
+    final_results: list[CommandResult],
+    failures: list[int],
     inputs: list[CommandResult | None],
+    expected_results: list[CommandResult],
 ) -> bool:
-    """Return whether the reducer satisfies its compaction invariants."""
-    final_results, submission_indices, failures = _build_final_results(inputs)
-    expected_results = [result for result in inputs if result is not None]
-
+    """Return whether the compaction and failure-index invariants hold."""
     return (
         _failure_indices_in_bounds(failures, final_results)
         and _failure_indices_point_to_failures(failures, final_results)
@@ -147,8 +147,19 @@ def _build_final_results_invariants_hold(
         and _no_cancelled_entries(final_results)
         and _result_count_matches(final_results, inputs)
         and _order_preserved(final_results, expected_results)
-        and _submission_indices_preserved(submission_indices, inputs)
     )
+
+
+def _build_final_results_invariants_hold(
+    inputs: list[CommandResult | None],
+) -> bool:
+    """Return whether the reducer satisfies its compaction invariants."""
+    final_results, submission_indices, failures = _build_final_results(inputs)
+    expected_results = [result for result in inputs if result is not None]
+
+    return _compaction_and_failure_invariants_hold(
+        final_results, failures, inputs, expected_results
+    ) and _submission_indices_preserved(submission_indices, inputs)
 
 
 def _assert_build_final_results_invariants(

--- a/cuprum/unittests/test_build_final_results_property.py
+++ b/cuprum/unittests/test_build_final_results_property.py
@@ -121,11 +121,22 @@ def _order_preserved(
     return final_results == expected_results
 
 
+def _submission_indices_preserved(
+    submission_indices: list[int],
+    inputs: list[CommandResult | None],
+) -> bool:
+    """Return whether compacted results retain original submission positions."""
+    expected_indices = [
+        index for index, result in enumerate(inputs) if result is not None
+    ]
+    return submission_indices == expected_indices
+
+
 def _build_final_results_invariants_hold(
     inputs: list[CommandResult | None],
 ) -> bool:
     """Return whether the reducer satisfies its compaction invariants."""
-    final_results, failures = _build_final_results(inputs)
+    final_results, submission_indices, failures = _build_final_results(inputs)
     expected_results = [result for result in inputs if result is not None]
 
     return (
@@ -136,6 +147,7 @@ def _build_final_results_invariants_hold(
         and _no_cancelled_entries(final_results)
         and _result_count_matches(final_results, inputs)
         and _order_preserved(final_results, expected_results)
+        and _submission_indices_preserved(submission_indices, inputs)
     )
 
 

--- a/cuprum/unittests/test_concurrency.py
+++ b/cuprum/unittests/test_concurrency.py
@@ -453,6 +453,20 @@ def test_fail_fast_failure_maps_to_original_submission() -> None:
     assert concurrent_result.failure_submission_indices == (1,)
 
 
+def test_mismatched_submission_indices_length_is_rejected() -> None:
+    """A supplied submission_indices must match the results length."""
+    from cuprum import CommandResult, Program
+
+    results = (
+        CommandResult(Program("echo"), (), 0, 1, "out", ""),
+        CommandResult(Program("echo"), (), 1, 2, "out", ""),
+    )
+    # Two results but only one submission index: fail fast in __post_init__
+    # rather than defer to an IndexError from failure_submission_indices.
+    with pytest.raises(ValueError, match="submission_indices length"):
+        ConcurrentResult(results=results, failures=(1,), submission_indices=(0,))
+
+
 @given(
     items=st.lists(
         st.one_of(st.none(), st.integers(min_value=0, max_value=5)),

--- a/cuprum/unittests/test_concurrency.py
+++ b/cuprum/unittests/test_concurrency.py
@@ -467,6 +467,19 @@ def test_mismatched_submission_indices_length_is_rejected() -> None:
         ConcurrentResult(results=results, failures=(1,), submission_indices=(0,))
 
 
+def test_explicit_empty_submission_indices_with_results_is_rejected() -> None:
+    """An explicit empty submission_indices differs from omitting it."""
+    from cuprum import CommandResult, Program
+
+    results = (CommandResult(Program("echo"), (), 0, 1, "out", ""),)
+    # Omitting submission_indices (None) backfills the identity sequence...
+    assert ConcurrentResult(results=results, failures=()).submission_indices == (0,)
+    # ...but an explicit empty tuple is a supplied length-0 sequence, so it is
+    # rejected against the single result rather than silently backfilled.
+    with pytest.raises(ValueError, match="submission_indices length"):
+        ConcurrentResult(results=results, failures=(), submission_indices=())
+
+
 @given(
     items=st.lists(
         st.one_of(st.none(), st.integers(min_value=0, max_value=5)),

--- a/cuprum/unittests/test_concurrency.py
+++ b/cuprum/unittests/test_concurrency.py
@@ -8,6 +8,8 @@ import time
 import typing as typ
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -414,6 +416,93 @@ def test_concurrent_result_first_failure_property() -> None:
     # No failures
     ok_result = ConcurrentResult(results=(result1,), failures=())
     assert ok_result.first_failure is None
+
+
+def test_collect_all_submission_indices_are_identity() -> None:
+    """In collect-all mode submission indices match result positions."""
+    from cuprum import CommandResult, Program
+
+    results = (
+        CommandResult(Program("echo"), (), 0, 1, "out", ""),
+        CommandResult(Program("echo"), (), 1, 2, "out", ""),
+        CommandResult(Program("echo"), (), 0, 3, "out", ""),
+    )
+    concurrent_result = ConcurrentResult(results=results, failures=(1,))
+
+    assert concurrent_result.submission_indices == (0, 1, 2)
+    # With identity submission indices the two failure views coincide.
+    assert concurrent_result.failure_submission_indices == concurrent_result.failures
+
+
+def test_fail_fast_failure_maps_to_original_submission() -> None:
+    """A compacted fail-fast failure maps back to its submission position."""
+    from cuprum import CommandResult, Program
+
+    # The first command (submission index 0) was cancelled, so only the second
+    # (submission index 1), which failed, is present in ``results``.
+    failed = CommandResult(Program("echo"), (), 99, 2, None, None)
+    concurrent_result = ConcurrentResult(
+        results=(failed,),
+        failures=(0,),
+        submission_indices=(1,),
+    )
+
+    # The position-based view says "result 0"; the submission-stable view
+    # correctly identifies the originally-submitted command 1.
+    assert concurrent_result.failures == (0,)
+    assert concurrent_result.failure_submission_indices == (1,)
+
+
+@given(
+    items=st.lists(
+        st.one_of(st.none(), st.integers(min_value=0, max_value=5)),
+        max_size=10,
+    )
+)
+def test_failure_submission_mapping_is_uniform(items: list[int | None]) -> None:
+    """Property: every failure maps back to the correct original submission.
+
+    Each generated item is either ``None`` (a cancelled command) or an exit
+    code at its submission index. Across arbitrary mixes the shared collect
+    loop must record completed results in order and expose a
+    ``failure_submission_indices`` that names exactly the originally-submitted
+    commands that exited non-zero.
+
+    Parameters
+    ----------
+    items : list[int | None]
+        Generated per-submission exit codes; ``None`` marks a cancelled command.
+    """
+    from cuprum import CommandResult, Program
+    from cuprum.concurrent import _collect_results_and_failures
+
+    indexed = [
+        (
+            submission_index,
+            None
+            if code is None
+            else CommandResult(Program("x"), (), code, 1, None, None),
+        )
+        for submission_index, code in enumerate(items)
+    ]
+    results, submission_indices, failures = _collect_results_and_failures(indexed)
+
+    completed = [code for code in items if code is not None]
+    assert len(results) == len(completed)
+    assert len(submission_indices) == len(results)
+    assert all(not results[position].ok for position in failures)
+
+    concurrent_result = ConcurrentResult(
+        results=tuple(results),
+        failures=tuple(failures),
+        submission_indices=tuple(submission_indices),
+    )
+    expected = tuple(
+        submission_index
+        for submission_index, code in enumerate(items)
+        if code is not None and code != 0
+    )
+    assert concurrent_result.failure_submission_indices == expected
 
 
 def test_single_command_works() -> None:

--- a/cuprum/unittests/test_concurrency.py
+++ b/cuprum/unittests/test_concurrency.py
@@ -614,3 +614,73 @@ def test_fail_fast_first_failure_indexes_correctly_when_earlier_cancelled() -> N
     assert result.first_failure is not None
     assert result.first_failure is result.results[result.failures[0]]
     assert result.first_failure.exit_code == 99
+
+
+def test_fail_fast_submission_indices_map_to_original_positions() -> None:
+    """End-to-end fail-fast run exposes submission-stable failure indices.
+
+    When fail-fast cancels an earlier, slower command, ``results`` is compacted,
+    so ``failures`` (positions within ``results``) diverges from the original
+    submission positions. ``submission_indices`` and
+    ``failure_submission_indices`` must still name the originally-submitted
+    command that failed.
+    """
+    catalogue, python_program = python_catalogue()
+    python = sh.make(python_program, catalogue=catalogue)
+
+    # cmd0 sleeps (submission index 0, will be cancelled); cmd1 fails fast.
+    cmd0 = python("-c", "import time; time.sleep(2); print('slow')")
+    cmd1 = python("-c", "import sys; sys.exit(7)")
+
+    with scoped(ScopeConfig(allowlist=frozenset([python_program]))):
+        start = time.perf_counter()
+        result = run_concurrent_sync(
+            cmd0, cmd1, config=ConcurrentConfig(fail_fast=True)
+        )
+        elapsed = time.perf_counter() - start
+
+    # Fail-fast must cancel the 2s sleeper long before it could finish.
+    assert elapsed < 1.0, f"Expected < 1.0s with fail-fast, got {elapsed:.3f}s"
+    assert result.ok is False
+
+    # Invariants that hold regardless of scheduling. __post_init__ always
+    # backfills the mapping, so it is never None here.
+    indices = result.submission_indices
+    assert indices is not None
+    assert len(indices) == len(result.results)
+    assert result.failure_submission_indices == tuple(
+        indices[position] for position in result.failures
+    )
+
+    # The sleeper cannot have completed within the elapsed bound, so results is
+    # compacted to the single failed command (originally submitted at index 1).
+    assert len(result.results) == 1
+    assert result.failures == (0,)
+    assert result.submission_indices == (1,)
+    # The position-based view says "result 0"; the submission-stable view names
+    # the originally-submitted command 1 — the regression this guards.
+    assert result.failure_submission_indices == (1,)
+    assert result.first_failure is not None
+    assert result.first_failure.exit_code == 7
+
+
+def test_collect_all_submission_indices_are_identity_end_to_end() -> None:
+    """A completed collect-all run exposes identity submission indices.
+
+    Without cancellation, ``results`` is not compacted, so every submission
+    index equals its result position and the two failure views coincide.
+    """
+    catalogue, python_program = python_catalogue()
+    python = sh.make(python_program, catalogue=catalogue)
+
+    cmd0 = python("-c", "print('ok')")
+    cmd1 = python("-c", "import sys; sys.exit(3)")
+    cmd2 = python("-c", "print('ok')")
+
+    with scoped(ScopeConfig(allowlist=frozenset([python_program]))):
+        result = run_concurrent_sync(cmd0, cmd1, cmd2)
+
+    assert len(result.results) == 3
+    assert result.submission_indices == (0, 1, 2)
+    assert result.failures == (1,)
+    assert result.failure_submission_indices == (1,)

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1174,11 +1174,18 @@ concurrently with optional concurrency limits. The implementation uses
 
 **ConcurrentResult structure:**
 
-- `results`: Tuple of `CommandResult` in submission order.
-- `failures`: Tuple of indices where commands exited non-zero.
+- `results`: Tuple of `CommandResult` in submission order. In fail-fast mode it
+  is compacted to the completed (non-cancelled) commands.
+- `failures`: Tuple of positions within `results` where commands exited
+  non-zero, ascending. Because `results` is compacted in fail-fast mode, these
+  are not original submission positions.
+- `submission_indices`: Tuple parallel to `results` giving each result's
+  original submission index (the identity sequence in collect-all mode).
 - `ok`: Property returning `True` when `failures` is empty.
 - `first_failure`: Property returning the first failed `CommandResult`, or
   `None` if all succeeded.
+- `failure_submission_indices`: Property mapping each failure back to its
+  original submission position, uniformly across both execution modes.
 
 Figure 4: Concurrent execution flow with allowlist validation and semaphore
 gating
@@ -1486,6 +1493,7 @@ than a rigid class diagram, and should favour boring, explicit implementations
 over cleverness—especially in the type‑system and configuration layers.
 
 ______________________________________________________________________
+
 
 ## 13. Performance-Optimized Stream Operations
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1180,7 +1180,9 @@ concurrently with optional concurrency limits. The implementation uses
   non-zero, ascending. Because `results` is compacted in fail-fast mode, these
   are not original submission positions.
 - `submission_indices`: Tuple parallel to `results` giving each result's
-  original submission index (the identity sequence in collect-all mode).
+  original submission index (the identity sequence in collect-all mode). It
+  defaults to the identity sequence when omitted; a supplied sequence whose
+  length differs from `results` raises `ValueError` so misuse fails fast.
 - `ok`: Property returning `True` when `failures` is empty.
 - `first_failure`: Property returning the first failed `CommandResult`, or
   `None` if all succeeded.
@@ -1493,7 +1495,6 @@ than a rigid class diagram, and should favour boring, explicit implementations
 over cleverness—especially in the type‑system and configuration layers.
 
 ______________________________________________________________________
-
 
 ## 13. Performance-Optimized Stream Operations
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -342,6 +342,8 @@ carries explicit postcondition-style contracts in its docstring:
 - Every index in `failures` points at an entry with `ok == False`.
 - `failures` contains *all* such indices — no non-ok entry is omitted.
 - The relative order of non-`None` inputs is preserved in `final_results`.
+- `submission_indices[i]` is the original position of `final_results[i]` in
+  `inputs`, so the submission order is recoverable after compaction.
 
 These invariants are verified at two levels:
 
@@ -368,6 +370,23 @@ These invariants are verified at two levels:
 
 When changing `_build_final_results`, run both verification paths before
 committing.
+
+## ConcurrentResult submission mapping
+
+`ConcurrentResult` (in `cuprum/concurrent.py`) exposes the compacted
+results alongside a submission-stable mapping so callers can relate any
+result — or failure — back to the command they submitted:
+
+- `submission_indices` is a tuple parallel to `results`; each entry is
+  the original submission index of the corresponding result. It
+  defaults to the identity sequence when omitted (the constructor
+  treats `None` as "omitted"), and a supplied sequence whose length
+  differs from `results` raises `ValueError`.
+- `failure_submission_indices` maps each entry of `failures` through
+  `submission_indices`, yielding the original submission positions of
+  the failed commands. Unlike `failures` (positions within the
+  possibly-compacted `results`), it is stable across collect-all and
+  fail-fast modes.
 
 ## Environment overlay resolution
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -385,7 +385,7 @@ result — or failure — back to the command they submitted:
 - `failure_submission_indices` maps each entry of `failures` through
   `submission_indices`, yielding the original submission positions of
   the failed commands. Unlike `failures` (positions within the
-  possibly-compacted `results`), it is stable across collect-all and
+  possibly compacted `results`), it is stable across collect-all and
   fail-fast modes.
 
 ## Environment overlay resolution

--- a/docs/execplans/4-1-1-performance-extension-foundation.md
+++ b/docs/execplans/4-1-1-performance-extension-foundation.md
@@ -342,7 +342,7 @@ Acceptance is satisfied when all of the following are true:
   in `pyproject.toml`, document the failure in the Decision Log, and
   re-evaluate the backend approach before continuing.
 
-## Artefacts and Notes
+## Artefacts and notes
 
 Expected artefacts after CI configuration:
 

--- a/docs/execplans/4-1-1-performance-extension-foundation.md
+++ b/docs/execplans/4-1-1-performance-extension-foundation.md
@@ -342,6 +342,18 @@ Acceptance is satisfied when all of the following are true:
   in `pyproject.toml`, document the failure in the Decision Log, and
   re-evaluate the backend approach before continuing.
 
+
+## Artefacts and Notes
+
+Expected artefacts after CI configuration:
+
+- New Rust workspace files under `rust/` (Cargo workspace and crate).
+- Updated `pyproject.toml` build-system configuration supporting `uv_build`
+  and maturin.
+- Updated CI workflows or actions to build native and pure-Python wheels.
+- Updated documentation in `docs/cuprum-design.md`, `docs/users-guide.md`, and
+  roadmap changes in `docs/roadmap.md`.
+
 ## Artefacts and notes
 
 Expected artefacts after CI configuration:

--- a/docs/execplans/4-1-1-performance-extension-foundation.md
+++ b/docs/execplans/4-1-1-performance-extension-foundation.md
@@ -342,19 +342,7 @@ Acceptance is satisfied when all of the following are true:
   in `pyproject.toml`, document the failure in the Decision Log, and
   re-evaluate the backend approach before continuing.
 
-
 ## Artefacts and Notes
-
-Expected artefacts after CI configuration:
-
-- New Rust workspace files under `rust/` (Cargo workspace and crate).
-- Updated `pyproject.toml` build-system configuration supporting `uv_build`
-  and maturin.
-- Updated CI workflows or actions to build native and pure-Python wheels.
-- Updated documentation in `docs/cuprum-design.md`, `docs/users-guide.md`, and
-  roadmap changes in `docs/roadmap.md`.
-
-## Artefacts and notes
 
 Expected artefacts after CI configuration:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1042,6 +1042,7 @@ with scoped(allowlist=...):
 
 if not result.ok:
     print(f"Failed command indices: {result.failures}")
+    print(f"Original submission positions: {result.failure_submission_indices}")
     print(f"First failure: {result.first_failure}")
 ```
 
@@ -1107,7 +1108,7 @@ The `ConcurrentResult` dataclass provides:
   completed command.
 - `failure_submission_indices`: Tuple mapping each failure back to its
   original submission position. Unlike `failures` (positions within the
-  possibly-compacted `results`), these are stable across collect-all and
+  possibly compacted `results`), these are stable across collect-all and
   fail-fast modes.
 
 ## Performance extensions (optional Rust)

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1029,7 +1029,10 @@ with scoped(allowlist=frozenset([ECHO])):
 
 By default, `run_concurrent` uses collect-all mode: all commands run to
 completion regardless of failures. The `ConcurrentResult.failures` tuple
-contains indices of commands that exited non-zero:
+contains indices of commands that exited non-zero. In fail-fast mode,
+`results` may omit cancelled commands, so `failures` indices are positions
+within the compacted `results`, whereas `failure_submission_indices`
+recovers the original submission positions:
 
 ```python
 from cuprum import run_concurrent_sync, scoped
@@ -1098,6 +1101,14 @@ The `ConcurrentResult` dataclass provides:
 - `ok`: `True` when all commands succeeded.
 - `first_failure`: The first failed `CommandResult`, or `None` if all
   succeeded.
+- `submission_indices`: Tuple parallel to `results` giving each result's
+  original submission index. In collect-all mode this is the identity
+  sequence; in fail-fast mode it records the submission position of each
+  completed command.
+- `failure_submission_indices`: Tuple mapping each failure back to its
+  original submission position. Unlike `failures` (positions within the
+  possibly-compacted `results`), these are stable across collect-all and
+  fail-fast modes.
 
 ## Performance extensions (optional Rust)
 


### PR DESCRIPTION
## Summary

This branch makes `ConcurrentResult`'s failure-to-submission mapping uniform across both execution modes and de-duplicates the shared collect loop.

Closes #121.

`failures` holds indices into `results`, but `results` means different things per path: collect-all returns full submission order, while fail-fast returns a compacted subset (cancelled commands omitted). A caller could not reliably map a failure back to its original submission position, and the "append result, record index if not ok" loop was duplicated across `_run_collect_all` and `_build_final_results`.

- A new `submission_indices` field (parallel to `results`) records each result's original submission index, and a `failure_submission_indices` property maps each failure back to its submission position uniformly. `failures` keeps its existing "position within results" meaning, so the `results[failures[0]]` idiom and `first_failure` are unchanged.
- The shared loop is extracted into `_collect_results_and_failures`, used by both paths; `_build_final_results` becomes a thin wrapper.

## Review walkthrough

- Start with [cuprum/concurrent.py](https://github.com/leynos/cuprum/blob/issue-121-concurrent-failures-semantics/cuprum/concurrent.py) for the `ConcurrentResult` fields/properties, the `_collect_results_and_failures` helper, and the routed paths.
- Then [cuprum/unittests/test_concurrency.py](https://github.com/leynos/cuprum/blob/issue-121-concurrent-failures-semantics/cuprum/unittests/test_concurrency.py) for the identity/compacted unit tests and the Hypothesis property asserting `failure_submission_indices` names exactly the originally-submitted commands that exited non-zero.
- [docs/cuprum-design.md](https://github.com/leynos/cuprum/blob/issue-121-concurrent-failures-semantics/docs/cuprum-design.md) documents the `ConcurrentResult` structure.

## Validation

- `make check-fmt`: pass
- `make lint`: pass
- `make typecheck`: pass
- `make test`: pass (562 passed, 43 skipped; Rust suite 4 passed)
- `make markdownlint`: pass
- `coderabbit review --agent`: pending (rate-limited at push time; will re-run)

## Notes

This relates to #67 (property tests for `_build_final_results`, PR #92); `_build_final_results` now returns the three parallel lists, so #92 should be coordinated/rebased on top.

## Summary by Sourcery

Unify ConcurrentResult failure-to-submission mapping across execution modes and centralize result/failure collection logic.

New Features:
- Expose submission_indices on ConcurrentResult to track each result's original submission position.
- Expose failure_submission_indices on ConcurrentResult to map failures back to original submission indices uniformly across collect-all and fail-fast modes.

Enhancements:
- Introduce a shared _collect_results_and_failures helper used by both collect-all and fail-fast paths to compact results, track submission indices, and record failures.
- Extend _build_final_results to return submission indices alongside compacted results and failure positions.
- Clarify documentation of ConcurrentResult semantics in the design docs, including result compaction and failure index meanings.

Documentation:
- Update cuprum-design documentation to describe the new submission_indices field and failure_submission_indices property on ConcurrentResult, and to clarify failure index semantics.
- Add roadmap/design execution plan notes outlining expected build and CI artefacts for future Rust workspace and packaging changes.

Tests:
- Add unit tests and Hypothesis-based property tests to verify submission index identity in collect-all mode, correct failure-to-submission mapping in fail-fast mode, and invariants of the shared collection logic.
- Extend existing _build_final_results property tests to cover preservation of original submission indices.

Chores:
- Add artefact and notes section to the performance extension foundation execution plan describing expected Rust workspace, build-system, CI, and documentation updates.

## References

- [Lody session](https://lody.ai/leynos/sessions/26a47b61-7fb0-46fc-bafe-83dcc5610423)
