### PR TITLE
Collapse _IOBehaviour into the canonical RunOutputOptions (#120)

### DIFF
--- a/cuprum/sh.py
+++ b/cuprum/sh.py
@@ -294,19 +294,11 @@ class IOOptions(RunOutputOptions):
         )
 
 
-@dc.dataclass(frozen=True, slots=True)
-class _IOBehaviour:
-    """Runtime I/O behaviour flags for command execution."""
-
-    capture: bool
-    echo: bool
-
-
 def _prepare_execution_observation(
     cmd: SafeCmd,
     context: ExecutionContext,
     tracking: _ExecutionTracking,
-    io_behaviour: _IOBehaviour,
+    output: RunOutputOptions,
 ) -> _StageObservation:
     """Prepare the observation context for command execution."""
     cwd = Path(context.cwd) if context.cwd is not None else None
@@ -317,8 +309,8 @@ def _prepare_execution_observation(
     tags = _merge_tags(
         {
             "project": cmd.project.name,
-            "capture": io_behaviour.capture,
-            "echo": io_behaviour.echo,
+            "capture": output.capture,
+            "echo": output.echo,
         },
         context.tags,
     )
@@ -420,12 +412,11 @@ class SafeCmd:
             execution_hooks=_run_before_hooks(self),
             pending_tasks=[],
         )
-        io_behaviour = _IOBehaviour(capture=out.capture, echo=out.echo)
         observation = _prepare_execution_observation(
             self,
             ctx,
             tracking,
-            io_behaviour,
+            out,
         )
 
         observation.emit("plan", _EventDetails(pid=None))

--- a/cuprum/unittests/test_observe.py
+++ b/cuprum/unittests/test_observe.py
@@ -190,6 +190,43 @@ def test_observe_emits_stdout_stderr_timing_and_tags(tmp_path: Path) -> None:
     assert start_event.tags["run_id"] == "unit"
 
 
+@pytest.mark.parametrize("execution_strategy", ["async", "sync"])
+@pytest.mark.parametrize(
+    "output",
+    [
+        pytest.param(RunOutputOptions(capture=False, echo=False), id="discard"),
+        pytest.param(RunOutputOptions(capture=False, echo=True), id="echo"),
+        pytest.param(RunOutputOptions(capture=True, echo=False), id="capture"),
+        pytest.param(RunOutputOptions(capture=True, echo=True), id="tee"),
+    ],
+)
+def test_observe_tags_reflect_run_output_options(
+    output: RunOutputOptions,
+    execution_strategy: typ.Literal["async", "sync"],
+) -> None:
+    """Observation tags expose the selected ``RunOutputOptions`` values."""
+    builder, catalogue = _python_builder(project_name="observe-output-options")
+    cmd = builder("-c", "pass")
+    events: list[ExecEvent] = []
+
+    def hook(ev: ExecEvent) -> None:
+        """Record an emitted execution event."""
+        events.append(ev)
+
+    with scoped(ScopeConfig(allowlist=catalogue.allowlist)), sh.observe(hook):
+        if execution_strategy == "async":
+            result = asyncio.run(cmd.run(output=output))
+        else:
+            result = cmd.run_sync(output=output)
+
+    assert result.exit_code == 0
+    tagged_events = [ev for ev in events if ev.phase in {"plan", "start", "exit"}]
+    assert [ev.phase for ev in tagged_events] == ["plan", "start", "exit"]
+    for event in tagged_events:
+        assert event.tags["capture"] is output.capture
+        assert event.tags["echo"] is output.echo
+
+
 def test_pipeline_observe_emits_stage_tags_and_final_stdout() -> None:
     """Pipeline execution emits per-stage events with stage tags."""
     builder, catalogue = _python_builder(project_name="observe-pipeline")

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -751,7 +751,7 @@ The default scenario matrix order is fixed and documented. Callers, snapshot
 tests, and CI artefact directories all depend on it. It must not be reordered
 without updating snapshot files and any downstream tooling.
 
-## Output-behaviour carrier
+## Output behaviour carrier
 
 `RunOutputOptions` (`capture`, `echo`) is the single canonical carrier for a
 command's output-stream behaviour. `SafeCmd.run` / `run_sync` accept it via the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -751,6 +751,19 @@ The default scenario matrix order is fixed and documented. Callers, snapshot
 tests, and CI artefact directories all depend on it. It must not be reordered
 without updating snapshot files and any downstream tooling.
 
+
+## Output-behaviour carrier
+
+`RunOutputOptions` (`capture`, `echo`) is the single canonical carrier for a
+command's output-stream behaviour. `SafeCmd.run` / `run_sync` accept it via the
+`output` parameter and pass it straight through to
+`_prepare_execution_observation`, which reads `output.capture` / `output.echo`
+for the observation tags. There is no parallel internal `(capture, echo)` value
+object: the former `_IOBehaviour` was redundant with `RunOutputOptions` and has
+been removed. `IOOptions` remains only as a deprecated subclass alias that
+emits a `DeprecationWarning`. New code — internal or public — should carry
+output behaviour as a `RunOutputOptions`, not as loose `capture` / `echo` flags.
+
 ## Subprocess stdin injection
 
 When `stdin: StdinInput` is passed to `SafeCmd.run()`, the following sequence

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -753,15 +753,19 @@ without updating snapshot files and any downstream tooling.
 
 ## Output behaviour carrier
 
-`RunOutputOptions` (`capture`, `echo`) is the single canonical carrier for a
-command's output-stream behaviour. `SafeCmd.run` / `run_sync` accept it via the
-`output` parameter and pass it straight through to
-`_prepare_execution_observation`, which reads `output.capture` / `output.echo`
-for the observation tags. There is no parallel internal `(capture, echo)` value
-object: the former `_IOBehaviour` was redundant with `RunOutputOptions` and has
-been removed. `IOOptions` remains only as a deprecated subclass alias that
-emits a `DeprecationWarning`. New code — internal or public — should carry
-output behaviour as a `RunOutputOptions`, not as loose `capture` / `echo` flags.
+`RunOutputOptions` (`capture`, `echo`) is the canonical carrier for `SafeCmd`
+output-stream behaviour. `SafeCmd.run` / `run_sync` accept it via the `output`
+parameter and pass it straight through to `_prepare_execution_observation`,
+which reads `output.capture` / `output.echo` for the observation tags. There is
+no parallel internal `(capture, echo)` value object: the former `_IOBehaviour`
+was redundant with `RunOutputOptions` and has been removed. `IOOptions` remains
+only as a deprecated subclass alias that emits a `DeprecationWarning`. New code
+— internal or public — should carry output behaviour as a `RunOutputOptions`,
+not as loose `capture` / `echo` flags.
+
+`Pipeline.run` and `Pipeline.run_sync` currently retain `capture` and `echo`
+keyword arguments for compatibility; migration to `output=RunOutputOptions` is
+deferred until issue #95 lands.
 
 ## Subprocess stdin injection
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -751,7 +751,6 @@ The default scenario matrix order is fixed and documented. Callers, snapshot
 tests, and CI artefact directories all depend on it. It must not be reordered
 without updating snapshot files and any downstream tooling.
 
-
 ## Output-behaviour carrier
 
 `RunOutputOptions` (`capture`, `echo`) is the single canonical carrier for a

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -211,10 +211,11 @@ Notes:
 `SafeCmd.run` executes curated commands asynchronously with predictable capture
 and echo semantics and returns a structured `CommandResult`:
 
-- `stdout` and `stderr` are captured by default. Set `capture=False` to stream
-  only; the result will carry `None` for output fields.
-- `echo=True` tees stdout/stderr to the parent process while still capturing
-  them when `capture=True`.
+- `stdout` and `stderr` are captured by default. Set
+  `output=RunOutputOptions(capture=False)` to stream only; the result will carry
+  `None` for output fields.
+- `output=RunOutputOptions(echo=True)` tees stdout/stderr to the parent process
+  while still capturing them when `capture=True`.
 - Pass an `ExecutionContext` via the `context` parameter to override execution
   details:
   - `env` overlays key/value pairs on top of the current environment without
@@ -248,6 +249,12 @@ async def greet() -> None:
 
 ### Migrating from `capture`/`echo` keyword arguments
 
+`IOOptions` is a deprecated alias for `RunOutputOptions`; keep using
+`RunOutputOptions` in new code.
+
+`Pipeline.run()` and `Pipeline.run_sync()` keep legacy `capture` / `echo`
+keyword arguments until issue #95 lands.
+
 Prior to this release, `run()` and `run_sync()` accepted `capture` and `echo`
 directly:
 
@@ -266,6 +273,11 @@ from cuprum import RunOutputOptions
 result = await cmd.run(output=RunOutputOptions(capture=True, echo=False))
 result = cmd.run_sync(output=RunOutputOptions(capture=False))
 ```
+
+`IOOptions` remains available only as a compatibility alias and emits a
+`DeprecationWarning` on construction; migrate by replacing any
+`IOOptions(capture=..., echo=...)` usage with
+`RunOutputOptions(capture=..., echo=...)` passed as `output=...`.
 
 `RunOutputOptions(capture=True, echo=False)` is the default; you only need to
 supply it explicitly when overriding either flag.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -279,8 +279,8 @@ result = cmd.run_sync(output=RunOutputOptions(capture=False))
 `IOOptions(capture=..., echo=...)` usage with
 `RunOutputOptions(capture=..., echo=...)` passed as `output=...`.
 
-`RunOutputOptions(capture=True, echo=False)` is the default; you only need to
-supply it explicitly when overriding either flag.
+`RunOutputOptions(capture=True, echo=False)` is the default. Supply it
+explicitly only when overriding either flag.
 
 If the awaiting task is cancelled while a command is running, Cuprum sends
 `SIGTERM` to the subprocess, waits for a short grace period, and then escalates


### PR DESCRIPTION
## Summary

This branch makes `RunOutputOptions` the single canonical `(capture, echo)` carrier, deleting the redundant internal `_IOBehaviour`.

Closes #120.

`cuprum/sh.py` defined two two-boolean carriers for the same `(capture, echo)` pair — `RunOutputOptions` and `_IOBehaviour` — and `SafeCmd.run` re-wrapped one into the other purely to feed `_prepare_execution_observation`. The branch deletes `_IOBehaviour`, makes `_prepare_execution_observation` accept a `RunOutputOptions` directly, and passes the call's `output` straight through.

## Review walkthrough

- [cuprum/sh.py](https://github.com/leynos/cuprum/blob/issue-120-collapse-iobehaviour/cuprum/sh.py): `_IOBehaviour` is removed; `_prepare_execution_observation` now takes `output: RunOutputOptions` and reads `output.capture` / `output.echo`; the `SafeCmd.run` call site drops the re-wrap.
- [docs/developers-guide.md](https://github.com/leynos/cuprum/blob/issue-120-collapse-iobehaviour/docs/developers-guide.md) documents `RunOutputOptions` as the canonical output-behaviour carrier.

## Validation

- `make check-fmt`: pass
- `make lint`: pass
- `make typecheck`: pass
- `make test`: pass (557 passed, 43 skipped; Rust suite 4 passed)
- `make markdownlint`: pass
- `coderabbit review --agent`: pending (rate-limited at push time; will re-run)

## Notes

This is the de-duplication half of the audit item. Aligning `Pipeline.run` / `run_sync` to accept `RunOutputOptions` (replacing their loose `capture` / `echo` kwargs) is the separate concern tracked in #95, to land in sequence.

## Summary by Sourcery

Collapse the internal I/O behaviour carrier into the public RunOutputOptions and update documentation accordingly.

Enhancements:
- Remove the redundant internal _IOBehaviour value object and use RunOutputOptions as the single carrier for capture/echo flags in command execution.
- Pass RunOutputOptions directly from SafeCmd.run to the execution observation preparation logic, simplifying the data flow.

Documentation:
- Document RunOutputOptions as the canonical output-behaviour carrier and clarify that new code should use it instead of loose capture/echo flags or deprecated aliases.