### PR TITLE
Extract canonical _TokenRegistration base for scope handles (#113)

### DIFF
--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -541,37 +541,44 @@ def scoped(config: ScopeConfig) -> _ScopedContext:
     """
     return _ScopedContext(config)
 
+class _TokenRegistration:
+    """Canonical base for ContextVar-backed scope-registration handles.
 
-class AllowRegistration:
-    """Registration handle for dynamic allowlist extension.
-
-    Supports detach() and context manager usage for scoped allowing.
+    All scope-registration handles (allowlist extensions, hook
+    registrations, env overlays) derive from this base. Subclasses perform
+    only the context-derivation step in ``__init__`` and hand the derived
+    context to :meth:`_install`; the token capture, idempotent
+    :meth:`detach`, and context-manager protocol live here so the subtle
+    restoration discipline cannot drift between handle types.
 
     Token-based Restoration
     -----------------------
-    The registration captures a token at creation time. When detach() is called,
-    the original context is restored via the token, ensuring no context pollution
-    even when used outside scoped(ScopeConfig()) blocks. This means detach()
-    restores the exact context that existed when the registration was created,
-    regardless of subsequent context modifications. If multiple registrations are
-    created and detached in non-LIFO order, earlier tokens may restore states
-    that remove programs added by other registrations.
+    The registration captures a :class:`~contextvars.Token` when the derived
+    context is installed. When :meth:`detach` is called, the original context
+    is restored via the token, ensuring no context pollution even when used
+    outside ``scoped(ScopeConfig())`` blocks. This means :meth:`detach`
+    restores the exact context that existed when the registration was
+    created, regardless of subsequent context modifications. If multiple
+    registrations are created and detached in non-LIFO (last in, first out)
+    order, earlier tokens restore states that discard changes layered by
+    later registrations; prefer ``with`` blocks, which detach in LIFO order.
 
-    Detach in the same logical Context (thread or Task) in which the
-    registration was created. Resetting a ContextVar with a token from a
-    different Context raises ValueError and would break this guarantee.
+    Detach in the same logical :class:`~contextvars.Context` (thread or
+    task) in which the registration was created. Resetting a
+    :class:`~contextvars.ContextVar` with a token from a different context
+    raises :class:`ValueError`.
     """
 
-    __slots__ = ("_detached", "_programs", "_token")
+    __slots__ = ("_detached", "_token")
 
-    def __init__(self, *programs: Program) -> None:
-        """Create an allowlist registration and add programs to current context."""
-        self._programs = frozenset(programs)
+    def __init__(self) -> None:
+        """Initialise the handle in the attached, token-less state."""
         self._detached = False
-        # Add programs to current context and capture token for restoration
-        ctx = current_context()
-        new_ctx = dc.replace(ctx, allowlist=ctx.allowlist | self._programs)
-        self._token: Token[CuprumContext] | None = _set_context(new_ctx)
+        self._token: Token[CuprumContext] | None = None
+
+    def _install(self, new_ctx: CuprumContext) -> None:
+        """Set ``new_ctx`` as current and capture the restoration token."""
+        self._token = _set_context(new_ctx)
 
     def detach(self) -> None:
         """Restore the original context via the captured token."""
@@ -582,8 +589,8 @@ class AllowRegistration:
             _reset_context(self._token)
             self._token = None
 
-    def __enter__(self) -> AllowRegistration:
-        """Enter context manager; programs are already registered."""
+    def __enter__(self) -> typ.Self:
+        """Enter context manager; the registration is already installed."""
         return self
 
     def __exit__(
@@ -592,8 +599,24 @@ class AllowRegistration:
         exc_val: BaseException | None,
         exc_tb: object,
     ) -> None:
-        """Exit context manager; detach registered programs."""
+        """Exit context manager; detach the registration."""
         self.detach()
+class AllowRegistration(_TokenRegistration):
+    """Registration handle for dynamic allowlist extension.
+
+    Supports ``detach()`` and context-manager usage for scoped allowing. The
+    token-restoration discipline is documented on
+    :class:`_TokenRegistration`.
+    """
+
+    __slots__ = ("_programs",)
+
+    def __init__(self, *programs: Program) -> None:
+        """Create an allowlist registration and add programs to current context."""
+        super().__init__()
+        self._programs = frozenset(programs)
+        ctx = current_context()
+        self._install(dc.replace(ctx, allowlist=ctx.allowlist | self._programs))
 
 
 def allow(*programs: Program) -> AllowRegistration:
@@ -618,23 +641,14 @@ def allow(*programs: Program) -> AllowRegistration:
     return AllowRegistration(*programs)
 
 
-class HookRegistration:
-    """Registration handle for hooks with detach() and context manager support.
+class HookRegistration(_TokenRegistration):
+    """Registration handle for hooks with detach and context-manager support.
 
-    Token-based Restoration
-    -----------------------
-    The registration captures a token at creation time. When detach() is called,
-    the original context is restored via the token, ensuring no context pollution
-    even when used outside scoped(ScopeConfig()) blocks. This means detach()
-    restores the exact context that existed when the registration was created,
-    regardless of subsequent context modifications.
-
-    As with AllowRegistration, detach the hook only from the Context where
-    it was registered; using the token in a different Context will raise
-    ValueError in the standard library.
+    The token-restoration discipline is documented on
+    :class:`_TokenRegistration`.
     """
 
-    __slots__ = ("_detached", "_hook", "_hook_type", "_token")
+    __slots__ = ("_hook", "_hook_type")
 
     def __init__(
         self,
@@ -642,10 +656,9 @@ class HookRegistration:
         hook_type: typ.Literal["before", "after", "observe"],
     ) -> None:
         """Create a hook registration and add hook to current context."""
+        super().__init__()
         self._hook = hook
         self._hook_type = hook_type
-        self._detached = False
-        # Add hook to current context and capture token for restoration
         ctx = current_context()
         if hook_type == "before":
             new_ctx = ctx.with_before_hook(typ.cast("BeforeHook", hook))
@@ -653,29 +666,7 @@ class HookRegistration:
             new_ctx = ctx.with_after_hook(typ.cast("AfterHook", hook))
         else:
             new_ctx = ctx.with_observe_hook(typ.cast("ExecHook", hook))
-        self._token: Token[CuprumContext] | None = _set_context(new_ctx)
-
-    def detach(self) -> None:
-        """Restore the original context via the captured token."""
-        if self._detached:
-            return
-        self._detached = True
-        if self._token is not None:
-            _reset_context(self._token)
-            self._token = None
-
-    def __enter__(self) -> HookRegistration:
-        """Enter context manager; hook is already registered."""
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: object,
-    ) -> None:
-        """Exit context manager; detach registered hook."""
-        self.detach()
+        self._install(new_ctx)
 
 
 def before(hook: BeforeHook) -> HookRegistration:
@@ -728,74 +719,33 @@ def after(hook: AfterHook) -> HookRegistration:
     return HookRegistration(hook, "after")
 
 
-class EnvRegistration:
+class EnvRegistration(_TokenRegistration):
     """Registration handle for a scoped environment overlay.
 
-    Like :class:`AllowRegistration` and :class:`HookRegistration`, the handle
-    captures a :class:`~contextvars.Token` at creation time and uses it to
-    restore the previous context on :meth:`detach`. The overlay is layered on
-    top of any overlay already present in the current context; nested
-    registrations therefore behave as a stack.
+    The overlay is layered on top of any overlay already present in the
+    current context; nested registrations therefore behave as a stack. The
+    token-restoration discipline is documented on
+    :class:`_TokenRegistration`.
 
     The overlay itself is overlay-only. The live :func:`os.environ` is read at
     subprocess spawn time (see :func:`resolve_env`), so any updates to the
     process environment after the registration is created — for example via
     ``pytest``'s ``monkeypatch.setenv`` — remain visible to subprocesses
     spawned inside the scope. This is the behaviour the issue requires.
-
-    Token-based Restoration
-    -----------------------
-    Identical to :class:`AllowRegistration` and :class:`HookRegistration`,
-    :meth:`detach` resets the captured :class:`~contextvars.Token` and
-    therefore restores the exact context that existed when the registration
-    was created. Detach in LIFO order: detaching an outer registration before
-    an inner one resets the underlying ``ContextVar`` to the outer's snapshot
-    and silently discards the inner overlay along with any other context
-    updates layered after registration. Consumers that need finer control
-    should prefer ``with`` blocks, which already detach in LIFO order.
-
-    Detach in the same logical :class:`~contextvars.Context` (thread or
-    task) in which the registration was created. Resetting a
-    :class:`~contextvars.ContextVar` with a token from a different context
-    raises :class:`ValueError`.
     """
 
-    __slots__ = ("_detached", "_overlay", "_token")
+    __slots__ = ("_overlay",)
 
     def __init__(self, overlay: cabc.Mapping[str, str]) -> None:
         """Layer ``overlay`` onto the current context's env overlay."""
+        super().__init__()
         self._overlay = _coerce_env_overlay(overlay)
-        self._detached = False
-        ctx = current_context()
-        new_ctx = ctx.with_env_overlay(self._overlay)
-        self._token: Token[CuprumContext] | None = _set_context(new_ctx)
+        self._install(current_context().with_env_overlay(self._overlay))
 
     @property
     def overlay(self) -> cabc.Mapping[str, str] | None:
         """Return the immutable overlay this registration applied."""
         return self._overlay
-
-    def detach(self) -> None:
-        """Restore the original context via the captured token."""
-        if self._detached:
-            return
-        self._detached = True
-        if self._token is not None:
-            _reset_context(self._token)
-            self._token = None
-
-    def __enter__(self) -> EnvRegistration:
-        """Enter context manager; overlay is already applied."""
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: object,
-    ) -> None:
-        """Exit context manager; detach the overlay."""
-        self.detach()
 
 
 def env(

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -585,10 +585,10 @@ class _TokenRegistration:
         """Restore the original context via the captured token."""
         if self._detached:
             return
-        self._detached = True
         if self._token is not None:
             _reset_context(self._token)
             self._token = None
+        self._detached = True
 
     def __enter__(self) -> typ.Self:
         """Enter context manager; the registration is already installed."""

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -541,6 +541,7 @@ def scoped(config: ScopeConfig) -> _ScopedContext:
     """
     return _ScopedContext(config)
 
+
 class _TokenRegistration:
     """Canonical base for ContextVar-backed scope-registration handles.
 
@@ -601,6 +602,8 @@ class _TokenRegistration:
     ) -> None:
         """Exit context manager; detach the registration."""
         self.detach()
+
+
 class AllowRegistration(_TokenRegistration):
     """Registration handle for dynamic allowlist extension.
 

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -663,12 +663,16 @@ class HookRegistration(_TokenRegistration):
         self._hook = hook
         self._hook_type = hook_type
         ctx = current_context()
-        if hook_type == "before":
-            new_ctx = ctx.with_before_hook(typ.cast("BeforeHook", hook))
-        elif hook_type == "after":
-            new_ctx = ctx.with_after_hook(typ.cast("AfterHook", hook))
-        else:
-            new_ctx = ctx.with_observe_hook(typ.cast("ExecHook", hook))
+        match hook_type:
+            case "before":
+                new_ctx = ctx.with_before_hook(typ.cast("BeforeHook", hook))
+            case "after":
+                new_ctx = ctx.with_after_hook(typ.cast("AfterHook", hook))
+            case "observe":
+                new_ctx = ctx.with_observe_hook(typ.cast("ExecHook", hook))
+            case _:
+                msg = f"Unsupported hook type: {hook_type}"
+                raise ValueError(msg)
         self._install(new_ctx)
 
 

--- a/cuprum/context.py
+++ b/cuprum/context.py
@@ -560,9 +560,9 @@ class _TokenRegistration:
     outside ``scoped(ScopeConfig())`` blocks. This means :meth:`detach`
     restores the exact context that existed when the registration was
     created, regardless of subsequent context modifications. If multiple
-    registrations are created and detached in non-LIFO (last in, first out)
-    order, earlier tokens restore states that discard changes layered by
-    later registrations; prefer ``with`` blocks, which detach in LIFO order.
+    registrations are created and detached out of LIFO order, earlier tokens
+    restore states that discard changes layered by later registrations;
+    prefer ``with`` blocks, which detach in LIFO order.
 
     Detach in the same logical :class:`~contextvars.Context` (thread or
     task) in which the registration was created. Resetting a

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -102,6 +102,7 @@
       'cuprum/unittests/test_tee_profile_worker_selector_metrics.py',
       'cuprum/unittests/test_tee_profile_worker_selector_reentrancy.py',
       'cuprum/unittests/test_timeout_resolution.py',
+      'cuprum/unittests/test_token_registration_stateful.py',
     ]),
     'generator': '1.13.3',
     'metadata': dict({

--- a/cuprum/unittests/test_token_registration_stateful.py
+++ b/cuprum/unittests/test_token_registration_stateful.py
@@ -27,6 +27,7 @@ from cuprum.context import (
     EnvRegistration,
     HookRegistration,
     ScopeConfig,
+    after,
     allow,
     before,
     current_context,
@@ -43,6 +44,10 @@ def _noop_before(_cmd: object) -> None:
     """Before-hook that records nothing."""
 
 
+def _noop_after(_cmd: object, _result: object) -> None:
+    """After-hook that records nothing."""
+
+
 def _noop_observe(_event: object) -> None:
     """Observe-hook that records nothing."""
 
@@ -54,6 +59,7 @@ _FACTORIES: tuple[tuple[str, _HandleFactory], ...] = (
     ("allow", lambda: allow(ECHO)),
     ("allow-two", lambda: allow(ECHO, LS)),
     ("before", lambda: before(_noop_before)),
+    ("after", lambda: after(_noop_after)),
     ("observe", lambda: observe(_noop_observe)),
     ("env", lambda: env(CUPRUM_TEST_FLAG="1")),
     ("env-mapping", lambda: env({"CUPRUM_TEST_OTHER": "2"})),

--- a/cuprum/unittests/test_token_registration_stateful.py
+++ b/cuprum/unittests/test_token_registration_stateful.py
@@ -133,6 +133,34 @@ class TokenRegistrationMachine(RuleBasedStateMachine):
             "first detach must restore the captured prior context"
         )
 
+    @rule(
+        outer_factory_entry=st.sampled_from(_FACTORIES),
+        inner_factory_entry=st.sampled_from(_FACTORIES),
+    )
+    def non_lifo_detach_restores_captured_snapshots(
+        self,
+        outer_factory_entry: tuple[str, _HandleFactory],
+        inner_factory_entry: tuple[str, _HandleFactory],
+    ) -> None:
+        """Out-of-order detaches restore each handle's captured snapshot."""
+        with scoped(ScopeConfig()):
+            outer_prior = current_context()
+            _outer_name, outer_factory = outer_factory_entry
+            outer = outer_factory()
+            inner_prior = current_context()
+            _inner_name, inner_factory = inner_factory_entry
+            inner = inner_factory()
+
+            outer.detach()
+            assert current_context() is outer_prior, (
+                "outer non-LIFO detach must restore its captured prior context"
+            )
+
+            inner.detach()
+            assert current_context() is inner_prior, (
+                "inner non-LIFO detach must restore its captured prior context"
+            )
+
     @invariant()
     def stack_depth_matches_context_nesting(self) -> None:
         """With an empty stack the baseline context is active again."""
@@ -146,6 +174,9 @@ class TokenRegistrationMachine(RuleBasedStateMachine):
         while self._stack:
             handle, _prior = self._stack.pop()
             handle.detach()
+        assert current_context() is self._baseline, (
+            "teardown must restore the exact baseline context"
+        )
 
 
 TestTokenRegistrationMachine = TokenRegistrationMachine.TestCase

--- a/cuprum/unittests/test_token_registration_stateful.py
+++ b/cuprum/unittests/test_token_registration_stateful.py
@@ -147,79 +147,80 @@ TestTokenRegistrationMachine.settings = settings(
 )
 
 
-def test_unsupported_hook_type_is_rejected() -> None:
-    """Invalid hook types must not be silently installed as observe hooks."""
-    baseline = current_context()
-    invalid_hook_type = typ.cast(
-        "typ.Literal['before', 'after', 'observe']",
-        "invalid",
-    )
+class TestTokenRegistrationExamples:
+    """Pinned example scenarios for token-restoration edge cases."""
 
-    with pytest.raises(ValueError, match="Unsupported hook type: invalid"):
-        HookRegistration(_noop_observe, invalid_hook_type)
-
-    assert current_context() is baseline
-
-
-def test_out_of_order_detach_restores_outer_snapshot() -> None:
-    """Example: non-LIFO detach restores the outer snapshot, as documented.
-
-    Detaching an outer registration while an inner one is still attached
-    resets the ``ContextVar`` to the outer handle's snapshot, discarding the
-    inner overlay — the documented hazard that motivates preferring ``with``
-    blocks. The experiment runs inside a ``scoped`` guard so the leaked
-    state cannot pollute other tests: the late ``inner.detach()`` restores
-    inner's own snapshot, which still carries the outer overlay, before the
-    surrounding registrations are cleaned up in LIFO order.
-    """
-    with scoped(ScopeConfig()):
+    def test_unsupported_hook_type_is_rejected(self) -> None:
+        """Invalid hook types must not be silently installed as observe hooks."""
         baseline = current_context()
-        allow_registration = allow(ECHO)
-        hook_registration = before(_noop_before)
-        pre_env = current_context()
-        outer = env(CUPRUM_TEST_OUTER="outer")
-        inner = env(CUPRUM_TEST_INNER="inner")
-
-        outer.detach()
-
-        restored = current_context()
-        assert restored is pre_env, (
-            "outer detach must restore the pre-outer snapshot, discarding inner"
+        invalid_hook_type = typ.cast(
+            "typ.Literal['before', 'after', 'observe']",
+            "invalid",
         )
-        assert restored.is_allowed(ECHO)
-        assert _noop_before in restored.before_hooks
-        overlay = restored.env_overlay or {}
-        assert "CUPRUM_TEST_INNER" not in overlay
 
-        # The inner detach stays safe (idempotent token discipline) but
-        # restores its own snapshot — the context with the outer overlay
-        # attached. This is exactly the documented non-LIFO hazard.
-        inner.detach()
-        leaked_context = current_context()
-        assert leaked_context.is_allowed(ECHO)
-        assert _noop_before in leaked_context.before_hooks
-        leaked = leaked_context.env_overlay or {}
-        assert leaked.get("CUPRUM_TEST_OUTER") == "outer"
+        with pytest.raises(ValueError, match="Unsupported hook type: invalid"):
+            HookRegistration(_noop_observe, invalid_hook_type)
 
-        hook_registration.detach()
-        allow_registration.detach()
         assert current_context() is baseline
 
+    def test_out_of_order_detach_restores_outer_snapshot(self) -> None:
+        """Example: non-LIFO detach restores the outer snapshot, as documented.
 
-def test_failed_cross_context_detach_can_be_retried() -> None:
-    """A failed reset must not poison a registration handle.
+        Detaching an outer registration while an inner one is still attached
+        resets the ``ContextVar`` to the outer handle's snapshot, discarding the
+        inner overlay — the documented hazard that motivates preferring ``with``
+        blocks. The experiment runs inside a ``scoped`` guard so the leaked
+        state cannot pollute other tests: the late ``inner.detach()`` restores
+        inner's own snapshot, which still carries the outer overlay, before the
+        surrounding registrations are cleaned up in LIFO order.
+        """
+        with scoped(ScopeConfig()):
+            baseline = current_context()
+            allow_registration = allow(ECHO)
+            hook_registration = before(_noop_before)
+            pre_env = current_context()
+            outer = env(CUPRUM_TEST_OUTER="outer")
+            inner = env(CUPRUM_TEST_INNER="inner")
 
-    ``ContextVar`` tokens can only be reset inside the context that created
-    them. A cross-context detach raises ``ValueError``; the original context
-    must still be able to detach the handle afterwards.
-    """
-    with scoped(ScopeConfig()):
-        baseline = current_context()
-        handle = env(CUPRUM_TEST_RETRY="retry")
+            outer.detach()
 
-        with pytest.raises(ValueError, match="different Context"):
-            contextvars.Context().run(handle.detach)
+            restored = current_context()
+            assert restored is pre_env, (
+                "outer detach must restore the pre-outer snapshot, discarding inner"
+            )
+            assert restored.is_allowed(ECHO)
+            assert _noop_before in restored.before_hooks
+            overlay = restored.env_overlay or {}
+            assert "CUPRUM_TEST_INNER" not in overlay
 
-        assert current_context() is not baseline
-        handle.detach()
-        assert current_context() is baseline
+            # The inner detach stays safe (idempotent token discipline) but
+            # restores its own snapshot — the context with the outer overlay
+            # attached. This is exactly the documented non-LIFO hazard.
+            inner.detach()
+            leaked_context = current_context()
+            assert leaked_context.is_allowed(ECHO)
+            assert _noop_before in leaked_context.before_hooks
+            leaked = leaked_context.env_overlay or {}
+            assert leaked.get("CUPRUM_TEST_OUTER") == "outer"
+
+            hook_registration.detach()
+            allow_registration.detach()
+            assert current_context() is baseline
+
+    def test_failed_cross_context_detach_can_be_retried(self) -> None:
+        """A failed reset must not poison a registration handle.
+
+        ``ContextVar`` tokens can only be reset inside the context that created
+        them. A cross-context detach raises ``ValueError``; the original context
+        must still be able to detach the handle afterwards.
+        """
+        with scoped(ScopeConfig()):
+            baseline = current_context()
+            handle = env(CUPRUM_TEST_RETRY="retry")
+
+            with pytest.raises(ValueError, match="different Context"):
+                contextvars.Context().run(handle.detach)
+
+            assert current_context() is not baseline
+            handle.detach()
+            assert current_context() is baseline

--- a/cuprum/unittests/test_token_registration_stateful.py
+++ b/cuprum/unittests/test_token_registration_stateful.py
@@ -101,9 +101,14 @@ class TokenRegistrationMachine(RuleBasedStateMachine):
                 "registering a handle must install a derived context"
             )
 
-        assert current_context() is prior
+        assert current_context() is prior, (
+            "context-manager exit must restore the original context"
+        )
         handle.detach()
-        assert current_context() is prior
+        assert current_context() is prior, (
+            "detaching after context-manager exit must leave the original "
+            "context unchanged"
+        )
 
     @precondition(lambda self: self._stack)
     @rule()
@@ -124,13 +129,17 @@ class TokenRegistrationMachine(RuleBasedStateMachine):
         after_first = current_context()
         handle.detach()
         assert current_context() is after_first, "second detach must be a no-op"
-        assert after_first is prior
+        assert after_first is prior, (
+            "first detach must restore the captured prior context"
+        )
 
     @invariant()
     def stack_depth_matches_context_nesting(self) -> None:
         """With an empty stack the baseline context is active again."""
         if not self._stack:
-            assert current_context() is self._baseline
+            assert current_context() is self._baseline, (
+                "an empty stack must leave the baseline context active"
+            )
 
     def teardown(self) -> None:
         """Detach any remaining handles in LIFO order."""
@@ -161,7 +170,9 @@ class TestTokenRegistrationExamples:
         with pytest.raises(ValueError, match="Unsupported hook type: invalid"):
             HookRegistration(_noop_observe, invalid_hook_type)
 
-        assert current_context() is baseline
+        assert current_context() is baseline, (
+            "rejecting an unsupported hook type must not change the active context"
+        )
 
     def test_out_of_order_detach_restores_outer_snapshot(self) -> None:
         """Example: non-LIFO detach restores the outer snapshot, as documented.
@@ -188,24 +199,38 @@ class TestTokenRegistrationExamples:
             assert restored is pre_env, (
                 "outer detach must restore the pre-outer snapshot, discarding inner"
             )
-            assert restored.is_allowed(ECHO)
-            assert _noop_before in restored.before_hooks
+            assert restored.is_allowed(ECHO), (
+                "outer detach must preserve ECHO access in the restored context"
+            )
+            assert _noop_before in restored.before_hooks, (
+                "outer detach must preserve the before hook in the restored context"
+            )
             overlay = restored.env_overlay or {}
-            assert "CUPRUM_TEST_INNER" not in overlay
+            assert "CUPRUM_TEST_INNER" not in overlay, (
+                "outer detach must drop the inner env overlay"
+            )
 
             # The inner detach stays safe (idempotent token discipline) but
             # restores its own snapshot — the context with the outer overlay
             # attached. This is exactly the documented non-LIFO hazard.
             inner.detach()
             leaked_context = current_context()
-            assert leaked_context.is_allowed(ECHO)
-            assert _noop_before in leaked_context.before_hooks
+            assert leaked_context.is_allowed(ECHO), (
+                "inner detach must still preserve ECHO access"
+            )
+            assert _noop_before in leaked_context.before_hooks, (
+                "inner detach must still preserve the before hook"
+            )
             leaked = leaked_context.env_overlay or {}
-            assert leaked.get("CUPRUM_TEST_OUTER") == "outer"
+            assert leaked.get("CUPRUM_TEST_OUTER") == "outer", (
+                "inner detach must restore the outer env overlay"
+            )
 
             hook_registration.detach()
             allow_registration.detach()
-            assert current_context() is baseline
+            assert current_context() is baseline, (
+                "cleanup must restore the scoped baseline context"
+            )
 
     def test_failed_cross_context_detach_can_be_retried(self) -> None:
         """A failed reset must not poison a registration handle.
@@ -221,6 +246,12 @@ class TestTokenRegistrationExamples:
             with pytest.raises(ValueError, match="different Context"):
                 contextvars.Context().run(handle.detach)
 
-            assert current_context() is not baseline
+            assert current_context() is not baseline, (
+                "failed cross-context detach must leave the handle active in "
+                "the original context"
+            )
             handle.detach()
-            assert current_context() is baseline
+            assert current_context() is baseline, (
+                "retrying detach in the original context must restore the "
+                "baseline context"
+            )

--- a/cuprum/unittests/test_token_registration_stateful.py
+++ b/cuprum/unittests/test_token_registration_stateful.py
@@ -3,10 +3,11 @@
 All scope-registration handles (`AllowRegistration`, `HookRegistration`,
 `EnvRegistration`) share one token-restoration implementation (#113). The
 Hypothesis ``RuleBasedStateMachine`` below drives randomized sequences of
-nested registrations and LIFO detaches across the handle types and asserts
-the ``ContextVar`` is always restored to the exact prior context — token
-discipline holds under nesting and double-detach. Out-of-order detach (a
-documented hazard, not an error) is pinned by a separate example test.
+nested registrations, context-manager exits, and LIFO detaches across the
+handle types and asserts the ``ContextVar`` is always restored to the exact
+prior context — token discipline holds under nesting, context-manager exit,
+and double-detach. Out-of-order detach (a documented hazard, not an error)
+is pinned by a separate example test.
 """
 
 from __future__ import annotations

--- a/cuprum/unittests/test_token_registration_stateful.py
+++ b/cuprum/unittests/test_token_registration_stateful.py
@@ -12,8 +12,10 @@ documented hazard, not an error) is pinned by a separate example test.
 from __future__ import annotations
 
 import collections.abc as cabc
+import contextvars
 import typing as typ
 
+import pytest
 from hypothesis import settings
 from hypothesis import strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, invariant, precondition, rule
@@ -152,3 +154,22 @@ def test_out_of_order_detach_restores_outer_snapshot() -> None:
         inner.detach()
         leaked = current_context().env_overlay or {}
         assert leaked.get("CUPRUM_TEST_OUTER") == "outer"
+
+
+def test_failed_cross_context_detach_can_be_retried() -> None:
+    """A failed reset must not poison a registration handle.
+
+    ``ContextVar`` tokens can only be reset inside the context that created
+    them. A cross-context detach raises ``ValueError``; the original context
+    must still be able to detach the handle afterwards.
+    """
+    with scoped(ScopeConfig()):
+        baseline = current_context()
+        handle = env(CUPRUM_TEST_RETRY="retry")
+
+        with pytest.raises(ValueError, match="different Context"):
+            contextvars.Context().run(handle.detach)
+
+        assert current_context() is not baseline
+        handle.detach()
+        assert current_context() is baseline

--- a/cuprum/unittests/test_token_registration_stateful.py
+++ b/cuprum/unittests/test_token_registration_stateful.py
@@ -87,6 +87,23 @@ class TokenRegistrationMachine(RuleBasedStateMachine):
             "registering a handle must install a derived context"
         )
 
+    @rule(factory_entry=st.sampled_from(_FACTORIES))
+    def context_manager_restores_context(
+        self, factory_entry: tuple[str, _HandleFactory]
+    ) -> None:
+        """Context-manager exit restores the context and detaches idempotently."""
+        prior = current_context()
+        _name, factory = factory_entry
+
+        with factory() as handle:
+            assert current_context() is not prior, (
+                "registering a handle must install a derived context"
+            )
+
+        assert current_context() is prior
+        handle.detach()
+        assert current_context() is prior
+
     @precondition(lambda self: self._stack)
     @rule()
     def detach_innermost(self) -> None:
@@ -151,20 +168,25 @@ def test_out_of_order_detach_restores_outer_snapshot() -> None:
     inner overlay — the documented hazard that motivates preferring ``with``
     blocks. The experiment runs inside a ``scoped`` guard so the leaked
     state cannot pollute other tests: the late ``inner.detach()`` restores
-    inner's own snapshot (which still carries the outer overlay), and only
-    the scope exit returns to the baseline.
+    inner's own snapshot, which still carries the outer overlay, before the
+    surrounding registrations are cleaned up in LIFO order.
     """
     with scoped(ScopeConfig()):
         baseline = current_context()
+        allow_registration = allow(ECHO)
+        hook_registration = before(_noop_before)
+        pre_env = current_context()
         outer = env(CUPRUM_TEST_OUTER="outer")
         inner = env(CUPRUM_TEST_INNER="inner")
 
         outer.detach()
 
         restored = current_context()
-        assert restored is baseline, (
+        assert restored is pre_env, (
             "outer detach must restore the pre-outer snapshot, discarding inner"
         )
+        assert restored.is_allowed(ECHO)
+        assert _noop_before in restored.before_hooks
         overlay = restored.env_overlay or {}
         assert "CUPRUM_TEST_INNER" not in overlay
 
@@ -172,8 +194,15 @@ def test_out_of_order_detach_restores_outer_snapshot() -> None:
         # restores its own snapshot — the context with the outer overlay
         # attached. This is exactly the documented non-LIFO hazard.
         inner.detach()
-        leaked = current_context().env_overlay or {}
+        leaked_context = current_context()
+        assert leaked_context.is_allowed(ECHO)
+        assert _noop_before in leaked_context.before_hooks
+        leaked = leaked_context.env_overlay or {}
         assert leaked.get("CUPRUM_TEST_OUTER") == "outer"
+
+        hook_registration.detach()
+        allow_registration.detach()
+        assert current_context() is baseline
 
 
 def test_failed_cross_context_detach_can_be_retried() -> None:

--- a/cuprum/unittests/test_token_registration_stateful.py
+++ b/cuprum/unittests/test_token_registration_stateful.py
@@ -1,0 +1,154 @@
+"""Stateful tests for the canonical ``_TokenRegistration`` handle base.
+
+All scope-registration handles (`AllowRegistration`, `HookRegistration`,
+`EnvRegistration`) share one token-restoration implementation (#113). The
+Hypothesis ``RuleBasedStateMachine`` below drives randomized sequences of
+nested registrations and LIFO detaches across the handle types and asserts
+the ``ContextVar`` is always restored to the exact prior context — token
+discipline holds under nesting and double-detach. Out-of-order detach (a
+documented hazard, not an error) is pinned by a separate example test.
+"""
+
+from __future__ import annotations
+
+import collections.abc as cabc
+import typing as typ
+
+from hypothesis import settings
+from hypothesis import strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, invariant, precondition, rule
+
+from cuprum import ECHO, LS
+from cuprum.context import (
+    AllowRegistration,
+    CuprumContext,
+    EnvRegistration,
+    HookRegistration,
+    ScopeConfig,
+    allow,
+    before,
+    current_context,
+    env,
+    observe,
+    scoped,
+)
+
+if typ.TYPE_CHECKING:
+    from cuprum.context import _TokenRegistration
+
+
+def _noop_before(_cmd: object) -> None:
+    """Before-hook that records nothing."""
+
+
+def _noop_observe(_event: object) -> None:
+    """Observe-hook that records nothing."""
+
+
+type _Handle = AllowRegistration | HookRegistration | EnvRegistration
+type _HandleFactory = cabc.Callable[[], _Handle]
+
+_FACTORIES: tuple[tuple[str, _HandleFactory], ...] = (
+    ("allow", lambda: allow(ECHO)),
+    ("allow-two", lambda: allow(ECHO, LS)),
+    ("before", lambda: before(_noop_before)),
+    ("observe", lambda: observe(_noop_observe)),
+    ("env", lambda: env(CUPRUM_TEST_FLAG="1")),
+    ("env-mapping", lambda: env({"CUPRUM_TEST_OTHER": "2"})),
+)
+
+
+class TokenRegistrationMachine(RuleBasedStateMachine):
+    """Drive nested register/detach sequences across all handle types."""
+
+    def __init__(self) -> None:
+        """Record the baseline context and an empty handle stack."""
+        super().__init__()
+        self._baseline: CuprumContext = current_context()
+        # Stack of (handle, context-before-registration) pairs.
+        self._stack: list[tuple[_TokenRegistration, CuprumContext]] = []
+
+    @rule(choice=st.integers(min_value=0, max_value=len(_FACTORIES) - 1))
+    def register(self, choice: int) -> None:
+        """Create a registration of the chosen kind, recording the prior context."""
+        prior = current_context()
+        _name, factory = _FACTORIES[choice]
+        handle = factory()
+        self._stack.append((handle, prior))
+        assert current_context() is not prior, (
+            "registering a handle must install a derived context"
+        )
+
+    @precondition(lambda self: self._stack)
+    @rule()
+    def detach_innermost(self) -> None:
+        """Detach the most recent registration; the prior context returns."""
+        handle, prior = self._stack.pop()
+        handle.detach()
+        assert current_context() is prior, (
+            "detach must restore the exact context captured at registration"
+        )
+
+    @precondition(lambda self: self._stack)
+    @rule()
+    def double_detach_is_idempotent(self) -> None:
+        """Detaching the innermost handle twice changes nothing further."""
+        handle, prior = self._stack.pop()
+        handle.detach()
+        after_first = current_context()
+        handle.detach()
+        assert current_context() is after_first, "second detach must be a no-op"
+        assert after_first is prior
+
+    @invariant()
+    def stack_depth_matches_context_nesting(self) -> None:
+        """With an empty stack the baseline context is active again."""
+        if not self._stack:
+            assert current_context() is self._baseline
+
+    def teardown(self) -> None:
+        """Detach any remaining handles in LIFO order."""
+        while self._stack:
+            handle, _prior = self._stack.pop()
+            handle.detach()
+
+
+TestTokenRegistrationMachine = TokenRegistrationMachine.TestCase
+TestTokenRegistrationMachine.settings = settings(
+    max_examples=40,
+    stateful_step_count=20,
+    deadline=None,
+)
+
+
+def test_out_of_order_detach_restores_outer_snapshot() -> None:
+    """Example: non-LIFO detach restores the outer snapshot, as documented.
+
+    Detaching an outer registration while an inner one is still attached
+    resets the ``ContextVar`` to the outer handle's snapshot, discarding the
+    inner overlay — the documented hazard that motivates preferring ``with``
+    blocks. The experiment runs inside a ``scoped`` guard so the leaked
+    state cannot pollute other tests: the late ``inner.detach()`` restores
+    inner's own snapshot (which still carries the outer overlay), and only
+    the scope exit returns to the baseline.
+    """
+    with scoped(ScopeConfig()):
+        baseline = current_context()
+        outer = env(CUPRUM_TEST_OUTER="outer")
+        inner = env(CUPRUM_TEST_INNER="inner")
+
+        outer.detach()
+
+        restored = current_context()
+        assert restored is baseline, (
+            "outer detach must restore the pre-outer snapshot, discarding inner"
+        )
+        overlay = restored.env_overlay or {}
+        assert "CUPRUM_TEST_INNER" not in overlay
+
+        # The inner detach stays safe (idempotent token discipline) but
+        # restores its own snapshot — the context with the outer overlay
+        # attached. This is exactly the documented non-LIFO hazard.
+        inner.detach()
+        leaked = current_context().env_overlay or {}
+        assert leaked.get("CUPRUM_TEST_OUTER") == "outer"

--- a/cuprum/unittests/test_token_registration_stateful.py
+++ b/cuprum/unittests/test_token_registration_stateful.py
@@ -70,11 +70,11 @@ class TokenRegistrationMachine(RuleBasedStateMachine):
         # Stack of (handle, context-before-registration) pairs.
         self._stack: list[tuple[_TokenRegistration, CuprumContext]] = []
 
-    @rule(choice=st.integers(min_value=0, max_value=len(_FACTORIES) - 1))
-    def register(self, choice: int) -> None:
+    @rule(factory_entry=st.sampled_from(_FACTORIES))
+    def register(self, factory_entry: tuple[str, _HandleFactory]) -> None:
         """Create a registration of the chosen kind, recording the prior context."""
         prior = current_context()
-        _name, factory = _FACTORIES[choice]
+        _name, factory = factory_entry
         handle = factory()
         self._stack.append((handle, prior))
         assert current_context() is not prior, (
@@ -121,6 +121,20 @@ TestTokenRegistrationMachine.settings = settings(
     stateful_step_count=20,
     deadline=None,
 )
+
+
+def test_unsupported_hook_type_is_rejected() -> None:
+    """Invalid hook types must not be silently installed as observe hooks."""
+    baseline = current_context()
+    invalid_hook_type = typ.cast(
+        "typ.Literal['before', 'after', 'observe']",
+        "invalid",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported hook type: invalid"):
+        HookRegistration(_noop_observe, invalid_hook_type)
+
+    assert current_context() is baseline
 
 
 def test_out_of_order_detach_restores_outer_snapshot() -> None:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -130,8 +130,9 @@ deliberately carries no token of its own.
 
 `cuprum/unittests/test_token_registration_stateful.py` verifies the token
 discipline with a Hypothesis `RuleBasedStateMachine` driving randomized
-register/detach sequences across all handle types (nesting, LIFO detach,
-double-detach), plus an example test pinning the documented non-LIFO hazard.
+register/detach sequences across all handle types (nesting, context-manager
+exit, LIFO detach, double-detach), plus an example test pinning the
+documented non-LIFO hazard.
 
 ## Canonical stage-observation inputs
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -109,7 +109,6 @@ uv run pytest -q cuprum/unittests/test_line_splitting.py
 Run `make test` before committing so the stream behaviour and the pure helper
 contracts stay aligned.
 
-
 ## Canonical `_TokenRegistration` handle base
 
 All `ContextVar`-backed scope-registration handles — `AllowRegistration`,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -109,6 +109,31 @@ uv run pytest -q cuprum/unittests/test_line_splitting.py
 Run `make test` before committing so the stream behaviour and the pure helper
 contracts stay aligned.
 
+
+## Canonical `_TokenRegistration` handle base
+
+All `ContextVar`-backed scope-registration handles — `AllowRegistration`,
+`HookRegistration`, and `EnvRegistration` in `cuprum/context.py` — derive from
+one canonical `_TokenRegistration` base. The base owns the `_token`/`_detached`
+pair, the idempotent `detach()`, the context-manager protocol, and the
+`_install(new_ctx)` step that sets the derived context and captures the
+restoration token. Subclasses implement only the context-derivation step in
+`__init__`. The consolidated "Token-based Restoration" docstring lives on the
+base.
+
+Re-use policy: any new scope-registration handle must derive from
+`_TokenRegistration` and confine itself to deriving the new context; the
+restoration protocol is subtle (`ContextVar` token discipline), so a divergent
+copy is a latent correctness hazard. Note that `LoggingHookRegistration`
+(`cuprum/logging_hooks.py`) is a *pair* handle: it composes two
+`HookRegistration` instances and detaches them in reverse order; it
+deliberately carries no token of its own.
+
+`cuprum/unittests/test_token_registration_stateful.py` verifies the token
+discipline with a Hypothesis `RuleBasedStateMachine` driving randomized
+register/detach sequences across all handle types (nesting, LIFO detach,
+double-detach), plus an example test pinning the documented non-LIFO hazard.
+
 ## Canonical stage-observation inputs
 
 The observation tag schema is a wire contract for observability, so the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -130,7 +130,7 @@ deliberately carries no token of its own.
 
 `cuprum/unittests/test_token_registration_stateful.py` verifies the token
 discipline with a Hypothesis `RuleBasedStateMachine` driving randomized
-register/detach sequences across all handle types (nesting, context-manager
+register/detach sequences across all token-backed handle types (nesting, context-manager
 exit, LIFO detach, double-detach), plus an example test pinning the
 documented non-LIFO hazard.
 


### PR DESCRIPTION
## Summary

This branch extracts the canonical `_TokenRegistration` base class for the `ContextVar`-backed scope-registration handles.

Closes #113.

The registration-handle protocol was duplicated across `AllowRegistration`, `HookRegistration`, and `EnvRegistration`: identical `_detached`/`_token` pairs, byte-identical `detach()` bodies, identical `__enter__`/`__exit__` implementations, and near-copies of the "Token-based Restoration" docstring. The base now owns the token capture (`_install`), the idempotent `detach()`, and the context-manager protocol; subclasses implement only the context-derivation step in `__init__`. `LoggingHookRegistration` remains a deliberate composite pair handle (two `HookRegistration`s, no token of its own).

## Review walkthrough

- Start with [cuprum/context.py](https://github.com/leynos/cuprum/blob/issue-113-token-registration-base/cuprum/context.py): the `_TokenRegistration` base (with the consolidated Token-based Restoration docstring) and the three slimmed subclasses.
- Then [cuprum/unittests/test_token_registration_stateful.py](https://github.com/leynos/cuprum/blob/issue-113-token-registration-base/cuprum/unittests/test_token_registration_stateful.py): the Hypothesis `RuleBasedStateMachine` driving randomized register/detach sequences across all handle types (the stateful exploration that stands in for model checking here), plus the example pinning the documented non-LIFO detach hazard.
- Finish with [docs/developers-guide.md](https://github.com/leynos/cuprum/blob/issue-113-token-registration-base/docs/developers-guide.md) for the rule that all scope-registration handles derive from the base.

## Validation

- `make check-fmt`: pass
- `make test`: pass (642 passed, 44 skipped; Rust suite 4 passed)
- `make typecheck`: pass
- `make lint`: pass

## Notes

This brings `cuprum/context.py` from 807 to 718 lines; the full sub-400-line split into a `context/` package is the separate #116, which should land after this so `registration.py` arrives already de-duplicated. Related: #66 (context-narrowing property tests, PR #91).

## References

- Lody session: https://lody.ai/leynos/sessions/97e77aca-ff34-4364-82d0-3b57a802caec

