### PR TITLE
Unify the splice loop and fix drain_reader EINTR handling (#124)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1042,19 +1042,29 @@ ends the transfer, `Ok(n)` accumulates, a non-fatal write error (broken pipe /
 connection reset) drains the reader and reports the bytes transferred so far,
 and anything else propagates.
 
+`splice_once` retries at the syscall level: an interrupted splice (`EINTR`) is
+re-issued rather than surfaced, matching the Unix read and write policies, so a
+signal delivered mid-transfer does not spuriously fail an otherwise-healthy
+pump. The retry loop is factored into `splice_once_with`, which a regression
+test drives with an injected `EINTR`, mirroring the `read_raw_fd` coverage.
+
 `drain_reader` routes through the canonical raw-fd read helper
 (`io_utils::read_raw_fd`), so it shares the Unix read policy with the
 read/write fallback: interrupted reads (`EINTR`) retry instead of silently
 ending the drain, end of file terminates it, and other errors propagate.
 Behavioural tests in the module cover full pipe-to-pipe transfer, the fallback
-signal for regular files, broken-pipe draining, and the drain's EOF
-termination. These outcomes and `PumpError` values are intentionally returned
-to the Python boundary, where command observation owns telemetry, so this
-internal Rust path does not add a second logging or metrics surface.
+signal for regular files, broken-pipe draining, the drain's EOF termination,
+and the syscall-level `EINTR` retry. These outcomes and `PumpError` values are
+intentionally returned to the Python boundary, where command observation owns
+telemetry, so this internal Rust path does not add a second logging or metrics
+surface.
 
 Unix Rust tests share pipe creation, duplicated-file wrapping, result helpers,
 and descriptor-state checks through `test_support`. Re-use that module for
 descriptor-backed test setup; keep production code independent of test helpers.
+The splice behavioural tests expose that shared `make_pipe` as an rstest `pipe`
+fixture, so scenarios needing several independent pipes inject it once per
+`#[from(pipe)]` parameter.
 
 ## Rust property testing and verification
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1048,8 +1048,12 @@ signal delivered mid-transfer does not spuriously fail an otherwise-healthy
 pump. The retry loop is factored into `splice_once_with`, which a regression
 test drives with an injected `EINTR`, mirroring the `read_raw_fd` coverage, and
 a proptest exercises the retry across any number of interruptions and either
-terminal outcome. Bounded model-checking of the loop accumulation and the drain
-policy is tracked separately in issues `#87` and `#88`.
+terminal outcome. The accumulation loop is factored the same way into
+`accumulate_splices`, whose `next` (splice) and `drain` side effects are
+injected so a proptest can assert the `Ok(0)` / `Ok(n)` / broken-pipe-drain /
+fatal transitions over generated outcome sequences. Exhaustive bounded
+model-checking of these paths with Kani remains tracked in issues `#87` and
+`#88`.
 
 `drain_reader` routes through the canonical raw-fd read helper
 (`io_utils::read_raw_fd`), so it shares the Unix read policy with the
@@ -1059,17 +1063,18 @@ Behavioural tests in the module cover full pipe-to-pipe transfer, the fallback
 signal for regular files, broken-pipe draining, the drain's EOF termination,
 and the syscall-level `EINTR` retry.
 
-These outcomes and `PumpError` values are intentionally returned to the Python
-boundary, where command observation owns telemetry, so this internal Rust path
-adds no second logging or metrics surface. That silence is deliberate at the
-three boundaries where instrumentation might be expected — support detection
-(the `EINVAL` fallback), the `splice_once` `EINTR` retry, and the broken-pipe
-reader drain: emitting per-syscall telemetry inside the crate would duplicate
-the Python boundary's observation and add high-frequency noise, since an
-`EINTR` retry can fire repeatedly under signal pressure. The crate therefore
-carries no `tracing` or `metrics` dependency, and any operator-facing signal
-for these paths belongs at the Python command-observation boundary rather than
-here.
+The path emits bounded `tracing` diagnostics at the three boundaries operators
+need visibility into: support detection logs a `debug` event when the
+descriptors cannot splice and the read/write fallback takes over; the
+`splice_once` `EINTR` retry logs a `trace` event per re-issue (the lowest
+level, filtered out by default, so signal-heavy workloads stay quiet unless
+trace is enabled); and the broken-pipe drain logs a `debug` event carrying the
+`bytes_transferred` so far. Messages are static and low-cardinality. Following
+the library convention, the crate emits instrumentation but installs no
+subscriber — the embedding application (the Python command boundary) owns
+subscriber configuration and higher-level command observation, and `PumpError`
+values with transfer counts are still returned across that boundary as the
+primary signal.
 
 Unix Rust tests share pipe creation, duplicated-file wrapping, result helpers,
 and descriptor-state checks through `test_support`. Re-use that module for

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1046,7 +1046,10 @@ and anything else propagates.
 re-issued rather than surfaced, matching the Unix read and write policies, so a
 signal delivered mid-transfer does not spuriously fail an otherwise-healthy
 pump. The retry loop is factored into `splice_once_with`, which a regression
-test drives with an injected `EINTR`, mirroring the `read_raw_fd` coverage.
+test drives with an injected `EINTR`, mirroring the `read_raw_fd` coverage, and
+a proptest exercises the retry across any number of interruptions and either
+terminal outcome. Bounded model-checking of the loop accumulation and the drain
+policy is tracked separately in issues `#87` and `#88`.
 
 `drain_reader` routes through the canonical raw-fd read helper
 (`io_utils::read_raw_fd`), so it shares the Unix read policy with the
@@ -1054,10 +1057,19 @@ read/write fallback: interrupted reads (`EINTR`) retry instead of silently
 ending the drain, end of file terminates it, and other errors propagate.
 Behavioural tests in the module cover full pipe-to-pipe transfer, the fallback
 signal for regular files, broken-pipe draining, the drain's EOF termination,
-and the syscall-level `EINTR` retry. These outcomes and `PumpError` values are
-intentionally returned to the Python boundary, where command observation owns
-telemetry, so this internal Rust path does not add a second logging or metrics
-surface.
+and the syscall-level `EINTR` retry.
+
+These outcomes and `PumpError` values are intentionally returned to the Python
+boundary, where command observation owns telemetry, so this internal Rust path
+adds no second logging or metrics surface. That silence is deliberate at the
+three boundaries where instrumentation might be expected — support detection
+(the `EINVAL` fallback), the `splice_once` `EINTR` retry, and the broken-pipe
+reader drain: emitting per-syscall telemetry inside the crate would duplicate
+the Python boundary's observation and add high-frequency noise, since an
+`EINTR` retry can fire repeatedly under signal pressure. The crate therefore
+carries no `tracing` or `metrics` dependency, and any operator-facing signal
+for these paths belongs at the Python command-observation boundary rather than
+here.
 
 Unix Rust tests share pipe creation, duplicated-file wrapping, result helpers,
 and descriptor-state checks through `test_support`. Re-use that module for

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "proptest",
  "pyo3",
  "rstest",
+ "tempfile",
  "thiserror",
  "trybuild",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "rstest",
  "tempfile",
  "thiserror",
+ "tracing",
  "trybuild",
 ]
 
@@ -679,6 +680,25 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "trybuild"

--- a/rust/cuprum-rust/Cargo.toml
+++ b/rust/cuprum-rust/Cargo.toml
@@ -20,6 +20,7 @@ libc = "0.2.186"
 [dev-dependencies]
 proptest = "1.11.0"
 rstest = "0.26.1"
+tempfile = "3.27.0"
 trybuild = { version = "1.0.116", features = ["diff"] }
 
 [lints]

--- a/rust/cuprum-rust/Cargo.toml
+++ b/rust/cuprum-rust/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["extension-module"] }
 thiserror = "2.0.18"
+tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.186"

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -185,10 +185,12 @@ mod tests {
     use std::io;
     use std::os::fd::{AsRawFd, OwnedFd};
 
+    use proptest::prelude::*;
     use rstest::{fixture, rstest};
     use tempfile::NamedTempFile;
 
     use super::{drain_reader, splice_once_with, try_splice_pump};
+    use crate::errors::PumpError;
     use crate::test_support::{make_pipe, read_all_from, unwrap_ok, write_all_to};
 
     /// A connected `pipe(2)` pair: `(read_end, write_end)`.
@@ -307,5 +309,45 @@ mod tests {
 
         assert_eq!(transferred, 7);
         assert_eq!(attempts, 2);
+    }
+
+    proptest! {
+        /// Across any number of leading `EINTR`s and either terminal outcome,
+        /// `splice_once_with` issues exactly one syscall per attempt and
+        /// returns the first non-interrupted result. This exercises the retry
+        /// state space the deterministic case above only samples at one point.
+        #[test]
+        fn splice_once_with_retries_through_interruptions(
+            interruptions in 0_u32..64,
+            terminal_ok in any::<bool>(),
+        ) {
+            let mut remaining = interruptions;
+            let mut calls = 0_u32;
+
+            let result = splice_once_with(|| {
+                calls = calls.saturating_add(1);
+                if remaining > 0 {
+                    remaining = remaining.saturating_sub(1);
+                    return Err(io::Error::from(io::ErrorKind::Interrupted));
+                }
+                if terminal_ok {
+                    Ok(7)
+                } else {
+                    Err(io::Error::from(io::ErrorKind::BrokenPipe))
+                }
+            });
+
+            prop_assert_eq!(calls, interruptions.saturating_add(1));
+            match result {
+                Ok(transferred) => {
+                    prop_assert!(terminal_ok);
+                    prop_assert_eq!(transferred, 7);
+                }
+                Err(err) => {
+                    prop_assert!(!terminal_ok);
+                    prop_assert!(matches!(err, PumpError::Io(_)));
+                }
+            }
+        }
     }
 }

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -59,11 +59,15 @@ pub(crate) fn try_splice_pump(
     Some(splice_loop(reader_fd, writer_fd, chunk_size, first))
 }
 
-/// Perform a single splice call.
+/// Perform a single splice call, retrying on `EINTR`.
+///
+/// The `EINTR` retry lives at the syscall level, matching the Unix read and
+/// write policies in [`crate::io_utils`]: a signal delivered mid-transfer
+/// re-issues the splice rather than surfacing a spurious failure that would
+/// abort an otherwise-healthy pump.
 fn splice_once(fd_in: libc::c_int, fd_out: libc::c_int, len: usize) -> Result<usize, PumpError> {
     let flags = SPLICE_F_MOVE | SPLICE_F_MORE;
-
-    loop {
+    splice_once_with(|| {
         // SAFETY: splice is a well-defined syscall; null offsets are valid for pipes.
         let result = unsafe {
             libc::splice(
@@ -77,13 +81,30 @@ fn splice_once(fd_in: libc::c_int, fd_out: libc::c_int, len: usize) -> Result<us
         };
 
         if result >= 0 {
-            // Non-negative ssize_t fits in usize on Linux.
-            return usize::try_from(result).map_err(|_| PumpError::LengthOverflow);
+            Ok(result)
+        } else {
+            Err(io::Error::last_os_error())
         }
+    })
+}
 
-        let err = io::Error::last_os_error();
-        if err.kind() != io::ErrorKind::Interrupted {
-            return Err(PumpError::from(err));
+/// Retry an interrupted splice syscall and map its result into [`PumpError`].
+///
+/// Factored out of [`splice_once`] so the `EINTR` retry policy can be
+/// exercised deterministically without provoking a real signal, mirroring
+/// [`crate::io_utils::read_raw_fd_with`]. Interrupted calls retry, a
+/// non-negative result is the byte count, and every other error propagates.
+fn splice_once_with(
+    mut splice_call: impl FnMut() -> Result<libc::ssize_t, io::Error>,
+) -> Result<usize, PumpError> {
+    loop {
+        match splice_call() {
+            // Non-negative ssize_t fits in usize on Linux.
+            Ok(transferred) => {
+                return usize::try_from(transferred).map_err(|_| PumpError::LengthOverflow);
+            }
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+            Err(err) => return Err(PumpError::from(err)),
         }
     }
 }
@@ -161,12 +182,13 @@ mod tests {
     //! unsupported descriptor types, and broken-pipe draining.
 
     use std::fs::File;
+    use std::io;
     use std::os::fd::{AsRawFd, OwnedFd};
 
     use rstest::{fixture, rstest};
     use tempfile::NamedTempFile;
 
-    use super::{drain_reader, try_splice_pump};
+    use super::{drain_reader, splice_once_with, try_splice_pump};
     use crate::test_support::{make_pipe, read_all_from, unwrap_ok, write_all_to};
 
     /// A connected `pipe(2)` pair: `(read_end, write_end)`.
@@ -266,5 +288,24 @@ mod tests {
 
         let leftover = read_all_from(&read_end);
         assert!(leftover.is_empty(), "drain must consume the pipe to EOF");
+    }
+
+    #[rstest]
+    fn splice_once_retries_after_interruption() {
+        // A signal delivered mid-transfer surfaces as `EINTR`; the syscall
+        // wrapper must re-issue the splice rather than fail. Inject one
+        // interruption, then a successful transfer, and confirm the retry.
+        let mut attempts = 0_u8;
+
+        let transferred = unwrap_ok(splice_once_with(|| {
+            attempts = attempts.saturating_add(1);
+            if attempts == 1 {
+                return Err(io::Error::from(io::ErrorKind::Interrupted));
+            }
+            Ok(7)
+        }));
+
+        assert_eq!(transferred, 7);
+        assert_eq!(attempts, 2);
     }
 }

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -163,13 +163,33 @@ mod tests {
     use std::fs::File;
     use std::os::fd::{AsRawFd, OwnedFd};
 
+    use rstest::{fixture, rstest};
+    use tempfile::NamedTempFile;
+
     use super::{drain_reader, try_splice_pump};
     use crate::test_support::{make_pipe, read_all_from, unwrap_ok, write_all_to};
 
-    #[test]
-    fn splice_transfers_all_bytes_between_pipes() {
-        let (source_read, source_write) = make_pipe();
-        let (sink_read, sink_write) = make_pipe();
+    /// A connected `pipe(2)` pair: `(read_end, write_end)`.
+    type PipePair = (OwnedFd, OwnedFd);
+
+    /// A `pipe(2)` pair as an [`rstest`] fixture wrapping
+    /// [`crate::test_support::make_pipe`].
+    ///
+    /// Exposing the shared pipe setup as a fixture keeps its construction in
+    /// one place; tests needing several independent pipes request it once per
+    /// `#[from(pipe)]` parameter.
+    #[fixture]
+    fn pipe() -> PipePair {
+        make_pipe()
+    }
+
+    #[rstest]
+    fn splice_transfers_all_bytes_between_pipes(
+        #[from(pipe)] source: PipePair,
+        #[from(pipe)] sink: PipePair,
+    ) {
+        let (source_read, source_write) = source;
+        let (sink_read, sink_write) = sink;
         let payload = b"unified splice loop payload";
 
         write_all_to(&source_write, payload);
@@ -188,14 +208,16 @@ mod tests {
         assert_eq!(read_all_from(&sink_read), payload);
     }
 
-    #[test]
+    #[rstest]
     fn unsupported_descriptors_signal_fallback() {
-        let dir = std::env::temp_dir();
-        let reader_path = dir.join("cuprum-splice-test-reader");
-        let writer_path = dir.join("cuprum-splice-test-writer");
-        unwrap_ok(std::fs::write(&reader_path, b"file payload"));
-        let reader = OwnedFd::from(unwrap_ok(File::open(&reader_path)));
-        let writer = OwnedFd::from(unwrap_ok(File::create(&writer_path)));
+        // Unique temp files avoid name collisions between concurrent test
+        // runs; each `NamedTempFile` removes itself on drop, so a mid-test
+        // panic leaves nothing behind.
+        let reader_file = unwrap_ok(NamedTempFile::new());
+        let writer_file = unwrap_ok(NamedTempFile::new());
+        unwrap_ok(std::fs::write(reader_file.path(), b"file payload"));
+        let reader = OwnedFd::from(unwrap_ok(File::open(reader_file.path())));
+        let writer = OwnedFd::from(unwrap_ok(File::create(writer_file.path())));
 
         // Two regular files cannot splice; the first call must signal the
         // read/write fallback rather than erroring.
@@ -204,15 +226,15 @@ mod tests {
             outcome.is_none(),
             "expected fallback signal, got {outcome:?}"
         );
-
-        unwrap_ok(std::fs::remove_file(&reader_path));
-        unwrap_ok(std::fs::remove_file(&writer_path));
     }
 
-    #[test]
-    fn broken_pipe_drains_reader_and_reports_transferred_bytes() {
-        let (source_read, source_write) = make_pipe();
-        let (sink_read, sink_write) = make_pipe();
+    #[rstest]
+    fn broken_pipe_drains_reader_and_reports_transferred_bytes(
+        #[from(pipe)] source: PipePair,
+        #[from(pipe)] sink: PipePair,
+    ) {
+        let (source_read, source_write) = source;
+        let (sink_read, sink_write) = sink;
         let payload = b"bytes that can no longer be delivered";
 
         write_all_to(&source_write, payload);
@@ -234,9 +256,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn drain_reader_consumes_to_eof() {
-        let (read_end, write_end) = make_pipe();
+    #[rstest]
+    fn drain_reader_consumes_to_eof(pipe: PipePair) {
+        let (read_end, write_end) = pipe;
         write_all_to(&write_end, b"residual data");
         drop(write_end);
 

--- a/rust/cuprum-rust/src/splice/mod.rs
+++ b/rust/cuprum-rust/src/splice/mod.rs
@@ -54,6 +54,7 @@ pub(crate) fn try_splice_pump(
     // the loop below treats it as fatal like any other error.
     let first = splice_once(reader_fd, writer_fd, chunk_size);
     if matches!(&first, Err(e) if is_splice_unsupported(e)) {
+        tracing::debug!("splice unsupported for these descriptors; using read/write fallback");
         return None;
     }
     Some(splice_loop(reader_fd, writer_fd, chunk_size, first))
@@ -103,7 +104,9 @@ fn splice_once_with(
             Ok(transferred) => {
                 return usize::try_from(transferred).map_err(|_| PumpError::LengthOverflow);
             }
-            Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => {
+                tracing::trace!("splice interrupted by a signal (EINTR); retrying");
+            }
             Err(err) => return Err(PumpError::from(err)),
         }
     }
@@ -121,9 +124,30 @@ fn splice_loop(
     fd_in: libc::c_int,
     fd_out: libc::c_int,
     chunk_size: usize,
-    mut outcome: Result<usize, PumpError>,
+    first: Result<usize, PumpError>,
+) -> Result<u64, PumpError> {
+    accumulate_splices(
+        first,
+        || splice_once(fd_in, fd_out, chunk_size),
+        || drain_reader(fd_in, chunk_size),
+    )
+}
+
+/// Accumulate transferred bytes across splice outcomes until EOF or error.
+///
+/// This holds the loop's control flow with its side effects injected: `next`
+/// yields each subsequent outcome (`splice_once` in production) and `drain`
+/// empties the reader after a broken pipe (`drain_reader` in production).
+/// Injecting them lets the accumulation and `Ok(0)` / `Ok(n)` / non-fatal /
+/// fatal transitions be property-tested without real descriptors, while
+/// production wiring keeps the single canonical loop.
+fn accumulate_splices(
+    first: Result<usize, PumpError>,
+    mut next: impl FnMut() -> Result<usize, PumpError>,
+    mut drain: impl FnMut() -> Result<(), PumpError>,
 ) -> Result<u64, PumpError> {
     let mut total = 0_u64;
+    let mut outcome = first;
 
     loop {
         match outcome {
@@ -134,12 +158,13 @@ fn splice_loop(
             }
             Err(e) if e.is_nonfatal_write() => {
                 // Broken pipe: drain reader and return bytes written so far.
-                drain_reader(fd_in, chunk_size)?;
+                tracing::debug!(bytes_transferred = total, "broken pipe; draining reader");
+                drain()?;
                 break;
             }
             Err(e) => return Err(e),
         }
-        outcome = splice_once(fd_in, fd_out, chunk_size);
+        outcome = next();
     }
 
     Ok(total)
@@ -176,178 +201,4 @@ fn is_splice_unsupported(err: &PumpError) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    //! Behavioural tests for the unified splice loop and the EINTR-correct
-    //! drain: full transfer between pipes, fallback signalling for
-    //! unsupported descriptor types, and broken-pipe draining.
-
-    use std::fs::File;
-    use std::io;
-    use std::os::fd::{AsRawFd, OwnedFd};
-
-    use proptest::prelude::*;
-    use rstest::{fixture, rstest};
-    use tempfile::NamedTempFile;
-
-    use super::{drain_reader, splice_once_with, try_splice_pump};
-    use crate::errors::PumpError;
-    use crate::test_support::{make_pipe, read_all_from, unwrap_ok, write_all_to};
-
-    /// A connected `pipe(2)` pair: `(read_end, write_end)`.
-    type PipePair = (OwnedFd, OwnedFd);
-
-    /// A `pipe(2)` pair as an [`rstest`] fixture wrapping
-    /// [`crate::test_support::make_pipe`].
-    ///
-    /// Exposing the shared pipe setup as a fixture keeps its construction in
-    /// one place; tests needing several independent pipes request it once per
-    /// `#[from(pipe)]` parameter.
-    #[fixture]
-    fn pipe() -> PipePair {
-        make_pipe()
-    }
-
-    #[rstest]
-    fn splice_transfers_all_bytes_between_pipes(
-        #[from(pipe)] source: PipePair,
-        #[from(pipe)] sink: PipePair,
-    ) {
-        let (source_read, source_write) = source;
-        let (sink_read, sink_write) = sink;
-        let payload = b"unified splice loop payload";
-
-        write_all_to(&source_write, payload);
-        drop(source_write); // EOF for the splice loop.
-
-        let outcome = try_splice_pump(&source_read, &sink_write, 4096);
-        drop(sink_write); // EOF for the verification read.
-
-        let expected_len = unwrap_ok(u64::try_from(payload.len()));
-        match outcome {
-            Some(Ok(transferred)) => {
-                assert_eq!(transferred, expected_len);
-            }
-            other => panic!("expected Some(Ok(_)) from pipe splice, got {other:?}"),
-        }
-        assert_eq!(read_all_from(&sink_read), payload);
-    }
-
-    #[rstest]
-    fn unsupported_descriptors_signal_fallback() {
-        // Unique temp files avoid name collisions between concurrent test
-        // runs; each `NamedTempFile` removes itself on drop, so a mid-test
-        // panic leaves nothing behind.
-        let reader_file = unwrap_ok(NamedTempFile::new());
-        let writer_file = unwrap_ok(NamedTempFile::new());
-        unwrap_ok(std::fs::write(reader_file.path(), b"file payload"));
-        let reader = OwnedFd::from(unwrap_ok(File::open(reader_file.path())));
-        let writer = OwnedFd::from(unwrap_ok(File::create(writer_file.path())));
-
-        // Two regular files cannot splice; the first call must signal the
-        // read/write fallback rather than erroring.
-        let outcome = try_splice_pump(&reader, &writer, 4096);
-        assert!(
-            outcome.is_none(),
-            "expected fallback signal, got {outcome:?}"
-        );
-    }
-
-    #[rstest]
-    fn broken_pipe_drains_reader_and_reports_transferred_bytes(
-        #[from(pipe)] source: PipePair,
-        #[from(pipe)] sink: PipePair,
-    ) {
-        let (source_read, source_write) = source;
-        let (sink_read, sink_write) = sink;
-        let payload = b"bytes that can no longer be delivered";
-
-        write_all_to(&source_write, payload);
-        drop(source_write);
-        drop(sink_read); // Break the downstream pipe before pumping.
-
-        let outcome = try_splice_pump(&source_read, &sink_write, 4096);
-        match outcome {
-            Some(Ok(0)) => {}
-            other => panic!("expected Some(Ok(0)) after broken pipe, got {other:?}"),
-        }
-
-        // The drain must have consumed the source to EOF so upstream writers
-        // cannot block on a full pipe buffer.
-        let leftover = read_all_from(&source_read);
-        assert!(
-            leftover.is_empty(),
-            "reader must be drained, got {leftover:?}"
-        );
-    }
-
-    #[rstest]
-    fn drain_reader_consumes_to_eof(pipe: PipePair) {
-        let (read_end, write_end) = pipe;
-        write_all_to(&write_end, b"residual data");
-        drop(write_end);
-
-        unwrap_ok(drain_reader(read_end.as_raw_fd(), 8));
-
-        let leftover = read_all_from(&read_end);
-        assert!(leftover.is_empty(), "drain must consume the pipe to EOF");
-    }
-
-    #[rstest]
-    fn splice_once_retries_after_interruption() {
-        // A signal delivered mid-transfer surfaces as `EINTR`; the syscall
-        // wrapper must re-issue the splice rather than fail. Inject one
-        // interruption, then a successful transfer, and confirm the retry.
-        let mut attempts = 0_u8;
-
-        let transferred = unwrap_ok(splice_once_with(|| {
-            attempts = attempts.saturating_add(1);
-            if attempts == 1 {
-                return Err(io::Error::from(io::ErrorKind::Interrupted));
-            }
-            Ok(7)
-        }));
-
-        assert_eq!(transferred, 7);
-        assert_eq!(attempts, 2);
-    }
-
-    proptest! {
-        /// Across any number of leading `EINTR`s and either terminal outcome,
-        /// `splice_once_with` issues exactly one syscall per attempt and
-        /// returns the first non-interrupted result. This exercises the retry
-        /// state space the deterministic case above only samples at one point.
-        #[test]
-        fn splice_once_with_retries_through_interruptions(
-            interruptions in 0_u32..64,
-            terminal_ok in any::<bool>(),
-        ) {
-            let mut remaining = interruptions;
-            let mut calls = 0_u32;
-
-            let result = splice_once_with(|| {
-                calls = calls.saturating_add(1);
-                if remaining > 0 {
-                    remaining = remaining.saturating_sub(1);
-                    return Err(io::Error::from(io::ErrorKind::Interrupted));
-                }
-                if terminal_ok {
-                    Ok(7)
-                } else {
-                    Err(io::Error::from(io::ErrorKind::BrokenPipe))
-                }
-            });
-
-            prop_assert_eq!(calls, interruptions.saturating_add(1));
-            match result {
-                Ok(transferred) => {
-                    prop_assert!(terminal_ok);
-                    prop_assert_eq!(transferred, 7);
-                }
-                Err(err) => {
-                    prop_assert!(!terminal_ok);
-                    prop_assert!(matches!(err, PumpError::Io(_)));
-                }
-            }
-        }
-    }
-}
+mod tests;

--- a/rust/cuprum-rust/src/splice/mod.rs
+++ b/rust/cuprum-rust/src/splice/mod.rs
@@ -154,7 +154,7 @@ fn accumulate_splices(
             Ok(0) => break, // EOF
             Ok(n) => {
                 let chunk = u64::try_from(n).map_err(|_| PumpError::LengthOverflow)?;
-                total = total.saturating_add(chunk);
+                total = total.checked_add(chunk).ok_or(PumpError::LengthOverflow)?;
             }
             Err(e) if e.is_nonfatal_write() => {
                 // Broken pipe: drain reader and return bytes written so far.

--- a/rust/cuprum-rust/src/splice/tests.rs
+++ b/rust/cuprum-rust/src/splice/tests.rs
@@ -241,7 +241,14 @@ proptest! {
             }
             Terminal::Fatal => {
                 prop_assert_eq!(drained, 0);
-                prop_assert!(result.is_err());
+                match result {
+                    Err(PumpError::Io(io_err)) => {
+                        prop_assert_eq!(io_err.kind(), io::ErrorKind::PermissionDenied);
+                    }
+                    other => {
+                        prop_assert!(false, "expected propagated PermissionDenied, got {other:?}");
+                    }
+                }
             }
         }
     }

--- a/rust/cuprum-rust/src/splice/tests.rs
+++ b/rust/cuprum-rust/src/splice/tests.rs
@@ -1,0 +1,248 @@
+//! Behavioural tests for the unified splice loop and the EINTR-correct
+//! drain: full transfer between pipes, fallback signalling for
+//! unsupported descriptor types, and broken-pipe draining.
+
+use std::fs::File;
+use std::io;
+use std::os::fd::{AsRawFd, OwnedFd};
+
+use proptest::prelude::*;
+use rstest::{fixture, rstest};
+use tempfile::NamedTempFile;
+
+use super::{accumulate_splices, drain_reader, splice_once_with, try_splice_pump};
+use crate::errors::PumpError;
+use crate::test_support::{make_pipe, read_all_from, unwrap_ok, write_all_to};
+
+/// A connected `pipe(2)` pair: `(read_end, write_end)`.
+type PipePair = (OwnedFd, OwnedFd);
+
+/// A `pipe(2)` pair as an [`rstest`] fixture wrapping
+/// [`crate::test_support::make_pipe`].
+///
+/// Exposing the shared pipe setup as a fixture keeps its construction in
+/// one place; tests needing several independent pipes request it once per
+/// `#[from(pipe)]` parameter.
+#[fixture]
+fn pipe() -> PipePair {
+    make_pipe()
+}
+
+#[rstest]
+fn splice_transfers_all_bytes_between_pipes(
+    #[from(pipe)] source: PipePair,
+    #[from(pipe)] sink: PipePair,
+) {
+    let (source_read, source_write) = source;
+    let (sink_read, sink_write) = sink;
+    let payload = b"unified splice loop payload";
+
+    write_all_to(&source_write, payload);
+    drop(source_write); // EOF for the splice loop.
+
+    let outcome = try_splice_pump(&source_read, &sink_write, 4096);
+    drop(sink_write); // EOF for the verification read.
+
+    let expected_len = unwrap_ok(u64::try_from(payload.len()));
+    match outcome {
+        Some(Ok(transferred)) => {
+            assert_eq!(transferred, expected_len);
+        }
+        other => panic!("expected Some(Ok(_)) from pipe splice, got {other:?}"),
+    }
+    assert_eq!(read_all_from(&sink_read), payload);
+}
+
+#[rstest]
+fn unsupported_descriptors_signal_fallback() {
+    // Unique temp files avoid name collisions between concurrent test
+    // runs; each `NamedTempFile` removes itself on drop, so a mid-test
+    // panic leaves nothing behind.
+    let reader_file = unwrap_ok(NamedTempFile::new());
+    let writer_file = unwrap_ok(NamedTempFile::new());
+    unwrap_ok(std::fs::write(reader_file.path(), b"file payload"));
+    let reader = OwnedFd::from(unwrap_ok(File::open(reader_file.path())));
+    let writer = OwnedFd::from(unwrap_ok(File::create(writer_file.path())));
+
+    // Two regular files cannot splice; the first call must signal the
+    // read/write fallback rather than erroring.
+    let outcome = try_splice_pump(&reader, &writer, 4096);
+    assert!(
+        outcome.is_none(),
+        "expected fallback signal, got {outcome:?}"
+    );
+}
+
+#[rstest]
+fn broken_pipe_drains_reader_and_reports_transferred_bytes(
+    #[from(pipe)] source: PipePair,
+    #[from(pipe)] sink: PipePair,
+) {
+    let (source_read, source_write) = source;
+    let (sink_read, sink_write) = sink;
+    let payload = b"bytes that can no longer be delivered";
+
+    write_all_to(&source_write, payload);
+    drop(source_write);
+    drop(sink_read); // Break the downstream pipe before pumping.
+
+    let outcome = try_splice_pump(&source_read, &sink_write, 4096);
+    match outcome {
+        Some(Ok(0)) => {}
+        other => panic!("expected Some(Ok(0)) after broken pipe, got {other:?}"),
+    }
+
+    // The drain must have consumed the source to EOF so upstream writers
+    // cannot block on a full pipe buffer.
+    let leftover = read_all_from(&source_read);
+    assert!(
+        leftover.is_empty(),
+        "reader must be drained, got {leftover:?}"
+    );
+}
+
+#[rstest]
+fn drain_reader_consumes_to_eof(pipe: PipePair) {
+    let (read_end, write_end) = pipe;
+    write_all_to(&write_end, b"residual data");
+    drop(write_end);
+
+    unwrap_ok(drain_reader(read_end.as_raw_fd(), 8));
+
+    let leftover = read_all_from(&read_end);
+    assert!(leftover.is_empty(), "drain must consume the pipe to EOF");
+}
+
+#[rstest]
+fn splice_once_retries_after_interruption() {
+    // A signal delivered mid-transfer surfaces as `EINTR`; the syscall
+    // wrapper must re-issue the splice rather than fail. Inject one
+    // interruption, then a successful transfer, and confirm the retry.
+    let mut attempts = 0_u8;
+
+    let transferred = unwrap_ok(splice_once_with(|| {
+        attempts = attempts.saturating_add(1);
+        if attempts == 1 {
+            return Err(io::Error::from(io::ErrorKind::Interrupted));
+        }
+        Ok(7)
+    }));
+
+    assert_eq!(transferred, 7);
+    assert_eq!(attempts, 2);
+}
+
+proptest! {
+    /// Across any number of leading `EINTR`s and either terminal outcome,
+    /// `splice_once_with` issues exactly one syscall per attempt and
+    /// returns the first non-interrupted result. This exercises the retry
+    /// state space the deterministic case above only samples at one point.
+    #[test]
+    fn splice_once_with_retries_through_interruptions(
+        interruptions in 0_u32..64,
+        terminal_ok in any::<bool>(),
+    ) {
+        let mut remaining = interruptions;
+        let mut calls = 0_u32;
+
+        let result = splice_once_with(|| {
+            calls = calls.saturating_add(1);
+            if remaining > 0 {
+                remaining = remaining.saturating_sub(1);
+                return Err(io::Error::from(io::ErrorKind::Interrupted));
+            }
+            if terminal_ok {
+                Ok(7)
+            } else {
+                Err(io::Error::from(io::ErrorKind::BrokenPipe))
+            }
+        });
+
+        prop_assert_eq!(calls, interruptions.saturating_add(1));
+        match result {
+            Ok(transferred) => {
+                prop_assert!(terminal_ok);
+                prop_assert_eq!(transferred, 7);
+            }
+            Err(err) => {
+                prop_assert!(!terminal_ok);
+                prop_assert!(matches!(err, PumpError::Io(_)));
+            }
+        }
+    }
+}
+
+/// How a generated splice sequence ends, for the accumulation property.
+#[derive(Debug, Clone, Copy)]
+enum Terminal {
+    /// `Ok(0)`: end of input.
+    Eof,
+    /// Non-fatal write error: the reader must be drained, bytes so far
+    /// reported.
+    BrokenPipe,
+    /// Fatal error: propagate, no drain.
+    Fatal,
+}
+
+proptest! {
+    /// The unified loop sums every `Ok(n)` before the terminal outcome,
+    /// drains exactly on a broken pipe, and propagates a fatal error
+    /// without draining. Covers the `Ok(0)` / `Ok(n)` / non-fatal / fatal
+    /// transitions the production loop feeds from `splice_once`.
+    #[test]
+    fn accumulate_splices_sums_until_terminal(
+        chunks in prop::collection::vec(1_u16..4096, 0..32),
+        terminal in prop_oneof![
+            Just(Terminal::Eof),
+            Just(Terminal::BrokenPipe),
+            Just(Terminal::Fatal),
+        ],
+    ) {
+        let mut outcomes: Vec<Result<usize, PumpError>> =
+            chunks.iter().map(|&n| Ok(usize::from(n))).collect();
+        outcomes.push(match terminal {
+            Terminal::Eof => Ok(0),
+            Terminal::BrokenPipe => {
+                Err(PumpError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
+            }
+            Terminal::Fatal => {
+                Err(PumpError::from(io::Error::from(io::ErrorKind::PermissionDenied)))
+            }
+        });
+
+        let mut remaining = outcomes.into_iter();
+        let first = remaining.next().unwrap_or(Ok(0));
+        let mut drained = 0_u32;
+
+        let result = accumulate_splices(
+            first,
+            || remaining.next().unwrap_or(Ok(0)),
+            || {
+                drained = drained.saturating_add(1);
+                Ok(())
+            },
+        );
+
+        let expected_total: u64 = chunks.iter().map(|&n| u64::from(n)).sum();
+        match terminal {
+            Terminal::Eof => {
+                prop_assert_eq!(drained, 0);
+                match result {
+                    Ok(total) => prop_assert_eq!(total, expected_total),
+                    Err(err) => prop_assert!(false, "unexpected error: {err:?}"),
+                }
+            }
+            Terminal::BrokenPipe => {
+                prop_assert_eq!(drained, 1);
+                match result {
+                    Ok(total) => prop_assert_eq!(total, expected_total),
+                    Err(err) => prop_assert!(false, "unexpected error: {err:?}"),
+                }
+            }
+            Terminal::Fatal => {
+                prop_assert_eq!(drained, 0);
+                prop_assert!(result.is_err());
+            }
+        }
+    }
+}

--- a/rust/cuprum-rust/src/splice/tests.rs
+++ b/rust/cuprum-rust/src/splice/tests.rs
@@ -166,7 +166,14 @@ proptest! {
             }
             Err(err) => {
                 prop_assert!(!terminal_ok);
-                prop_assert!(matches!(err, PumpError::Io(_)));
+                match err {
+                    PumpError::Io(io_err) => {
+                        prop_assert_eq!(io_err.kind(), io::ErrorKind::BrokenPipe);
+                    }
+                    other => {
+                        prop_assert!(false, "expected BrokenPipe PumpError::Io, got {other:?}");
+                    }
+                }
             }
         }
     }

--- a/rust/cuprum-rust/src/splice/tests.rs
+++ b/rust/cuprum-rust/src/splice/tests.rs
@@ -260,3 +260,21 @@ proptest! {
         }
     }
 }
+
+#[cfg(target_pointer_width = "64")]
+#[rstest]
+fn accumulate_splices_reports_length_overflow() {
+    // Two `usize::MAX` chunks sum past `u64::MAX` on 64-bit targets, so the
+    // second accumulation exercises the `checked_add` overflow branch and must
+    // surface `LengthOverflow` rather than silently capping the total.
+    let outcomes: [Result<usize, PumpError>; 2] = [Ok(usize::MAX), Ok(usize::MAX)];
+    let mut remaining = outcomes.into_iter();
+    let first = remaining.next().unwrap_or(Ok(0));
+
+    let result = accumulate_splices(first, || remaining.next().unwrap_or(Ok(0)), || Ok(()));
+
+    assert!(
+        matches!(result, Err(PumpError::LengthOverflow)),
+        "expected LengthOverflow, got {result:?}"
+    );
+}

--- a/rust/cuprum-rust/src/splice/tests.rs
+++ b/rust/cuprum-rust/src/splice/tests.rs
@@ -2,8 +2,7 @@
 //! drain: full transfer between pipes, fallback signalling for
 //! unsupported descriptor types, and broken-pipe draining.
 
-use std::fs::File;
-use std::io;
+use std::io::{self, Write};
 use std::os::fd::{AsRawFd, OwnedFd};
 
 use proptest::prelude::*;
@@ -58,11 +57,13 @@ fn unsupported_descriptors_signal_fallback() {
     // Unique temp files avoid name collisions between concurrent test
     // runs; each `NamedTempFile` removes itself on drop, so a mid-test
     // panic leaves nothing behind.
-    let reader_file = unwrap_ok(NamedTempFile::new());
+    let mut reader_file = unwrap_ok(NamedTempFile::new());
     let writer_file = unwrap_ok(NamedTempFile::new());
-    unwrap_ok(std::fs::write(reader_file.path(), b"file payload"));
-    let reader = OwnedFd::from(unwrap_ok(File::open(reader_file.path())));
-    let writer = OwnedFd::from(unwrap_ok(File::create(writer_file.path())));
+    unwrap_ok(reader_file.as_file_mut().write_all(b"file payload"));
+    // `reopen()` hands back an independent descriptor to the same inode,
+    // verified against replacement, rather than a racy path lookup.
+    let reader = OwnedFd::from(unwrap_ok(reader_file.reopen()));
+    let writer = OwnedFd::from(unwrap_ok(writer_file.reopen()));
 
     // Two regular files cannot splice; the first call must signal the
     // read/write fallback rather than erroring.


### PR DESCRIPTION
## Summary

`origin/main` already carries the [#123](https://github.com/leynos/cuprum/issues/123) `PumpError` taxonomy and the [#124](https://github.com/leynos/cuprum/issues/124) splice-loop unification and `drain_reader` EINTR fix — both merged and refined since this branch opened. Rebased onto current `main`, this branch now layers the remaining review follow-ups on top:

- Replace the splice behavioural tests' ad-hoc helpers and fixed temp paths with an rstest `pipe` fixture (wrapping `test_support::make_pipe`) and `tempfile::NamedTempFile`.
- Add a deterministic regression test for `splice_once`'s syscall-level `EINTR` retry, via a `splice_once_with` closure split that mirrors `io_utils::read_raw_fd_with`.
- Document the `splice_once` `EINTR` retry and the rstest `pipe` fixture in the developers' guide's splice-loop and drain contract.

Closes [#124](https://github.com/leynos/cuprum/issues/124).

## Changes over `main`

- `rust/cuprum-rust/src/splice.rs` — rstest `pipe` fixture and `NamedTempFile`; `splice_once` split into `splice_once` + `splice_once_with`, with a `splice_once_retries_after_interruption` regression test.
- `rust/cuprum-rust/Cargo.toml`, `rust/Cargo.lock` — add the `tempfile` dev-dependency.
- `docs/developers-guide.md` — document the syscall-level `EINTR` retry and the rstest fixture.

## Validation

- `make check-fmt`, `make lint`, `make typecheck`, `make markdownlint`, `make nixie`: pass.
- `make test`: Rust suite 30/30 under the CI-pinned toolchain (rustc 1.92.0), including the new `splice_once_retries_after_interruption`; Python suite green. Under a newer local rustc only the unrelated `const_availability_export` trybuild snapshot drifts, which matches CI at 1.92.0.

## Notes

The Kani harnesses for the drain policy and loop accumulation remain tracked in [#88](https://github.com/leynos/cuprum/issues/88) and [#87](https://github.com/leynos/cuprum/issues/87).

## References

- Lody session: https://lody.ai/leynos/sessions/55f55bb4-30b4-439b-937a-7275ebdd5380
