### PR TITLE
Add PR token experiment marker

### DIFF
--- a/cuprum/unittests/test_tee_profile_worker_concurrency.py
+++ b/cuprum/unittests/test_tee_profile_worker_concurrency.py
@@ -47,9 +47,13 @@ _THREAD_JOIN_TIMEOUT_SECONDS = 15
 class _RLockLike(typ.Protocol):
     """Structural type for the ``RLock`` operations this test instruments."""
 
-    def acquire(self, *, blocking: bool = True, timeout: float = -1) -> bool: ...
+    def acquire(self, *, blocking: bool = True, timeout: float = -1) -> bool:
+        """Acquire the lock using the subset of ``RLock`` arguments under test."""
+        ...
 
-    def release(self) -> None: ...
+    def release(self) -> None:
+        """Release a lock previously acquired by the current thread."""
+        ...
 
 
 class _SignallingRLock:
@@ -98,9 +102,11 @@ class _SignallingRLock:
         return self._delegate.acquire(blocking=blocking, timeout=timeout)
 
     def release(self) -> None:
+        """Release the wrapped lock."""
         self._delegate.release()
 
     def __enter__(self) -> _SignallingRLock:
+        """Acquire the wrapped lock for context manager use."""
         self.acquire()
         return self
 
@@ -110,6 +116,7 @@ class _SignallingRLock:
         exc_value: BaseException | None,
         traceback: types.TracebackType | None,
     ) -> None:
+        """Release the wrapped lock when leaving a context manager block."""
         self.release()
 
 

--- a/experiments/pandalump-token-pr.txt
+++ b/experiments/pandalump-token-pr.txt
@@ -1,0 +1,1 @@
+This file records a pull request creation experiment using the pandalump token.


### PR DESCRIPTION
## Summary

This branch restores the repository's 100% interrogate documentation gate for
lock-related concurrency test helpers, then adds an experiment marker file for
the pandalump-token pull request flow.

## Review walkthrough

- Start with [cuprum/unittests/test_tee_profile_worker_concurrency.py](https://github.com/leynos/cuprum/blob/feat/file-pr-with-pat/cuprum/unittests/test_tee_profile_worker_concurrency.py) to review the helper docstrings that keep the lint gate passing.
- Then review [experiments/pandalump-token-pr.txt](https://github.com/leynos/cuprum/blob/feat/file-pr-with-pat/experiments/pandalump-token-pr.txt) for the requested experiment file.

## Validation

- `make all`: passed.

## Summary by Sourcery

Restore full documentation coverage for concurrency test helpers and add an experiment marker file for the pandalump token PR flow.

Enhancements:
- Document lock-like protocol and signalling lock helper methods used in concurrency tests.

Chores:
- Add an experiment marker file for the pandalump-token pull request workflow.