### PR TITLE
Enforce caret dependency baselines and fallible casts (#126)

### DIFF
--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -258,8 +258,8 @@ namespace exposes functions that construct `DynamicCmd` for the rare cases
 where arbitrary composition is required.
 
 High‑level facilities (pipelines, context‑scoped allowlists, etc.) are
-optimized for `SafeCmd`. `DynamicCmd` can be adapted into these facilities,
-but doing so is visually explicit and reviewable.
+optimized for `SafeCmd`. `DynamicCmd` can be adapted into these facilities, but
+doing so is visually explicit and reviewable.
 
 ### 5.3 Execution Context
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -720,6 +720,27 @@ and tool-discovery recipes only. This supports non-interactive Continuous
 Integration/Continuous Delivery (CI/CD) hook environments without globally
 shadowing system tools for unrelated Makefile workflows.
 
+
+## Rust error taxonomy (`PumpError`)
+
+The `cuprum-rust` crate reports stream pump and consume failures through one
+semantic error enum, `PumpError` (`rust/cuprum-rust/src/errors.rs`), derived
+with `thiserror`:
+
+- `LengthOverflow` — an integer length conversion overflowed its target
+  type ("impossible" on supported platforms, kept observable rather than
+  silently truncating).
+- `BufferRangeExceeded` — a computed range exceeded the backing buffer.
+- `Io(io::Error)` — an operating-system I/O failure (transparent wrapper).
+
+Conversion to a Python exception happens in exactly one place
+(`From<PumpError> for PyErr`): `Io` maps through `pyo3`'s standard `io::Error`
+translation, and the overflow variants surface as `OSError`. The non-fatal
+write classification (broken pipe / connection reset) lives on the enum as
+`PumpError::is_nonfatal_write`, replacing the free function the splice and
+read/write paths previously shared. New failure conditions get a variant here
+rather than a stringly-typed `io::Error::other(...)`.
+
 ## Rust property testing and verification
 
 Rust-level tests for `cuprum-rust` live with the crate under

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1151,17 +1151,27 @@ on the overlapping cases.
 
 ## Output behaviour carrier
 
-`RunOutputOptions` (`capture`, `echo`) is the canonical carrier for `SafeCmd`
-and `Pipeline` output-stream behaviour. `SafeCmd.run` / `run_sync` accept it
-via the `output` parameter and pass it straight through to
-`_prepare_execution_observation`, which reads `output.capture` / `output.echo`
-for the observation tags. `Pipeline.run` / `run_sync` use the same `output`
-parameter and resolve it before building the pipeline execution config. There
-is no parallel internal `(capture, echo)` value object: the former
-`_IOBehaviour` was redundant with `RunOutputOptions` and has been removed.
-`IOOptions` remains only as a deprecated subclass alias that emits a
-`DeprecationWarning`. New code — internal or public — should carry output
-behaviour as a `RunOutputOptions`, not as loose `capture` / `echo` flags.
+`RunOutputOptions` (`capture`, `echo`) is the canonical carrier for command
+output behaviour. Public command execution should accept or construct this
+object rather than threading separate `capture` and `echo` keyword arguments
+through new APIs. Keep that pairing intact so stdout/stderr handling stays
+explicit, testable, and compatible with the `IOOptions` deprecation path.
+
+`SafeCmd.run` / `run_sync` accept `RunOutputOptions` via the `output` parameter
+and pass it straight through to `_prepare_execution_observation`, which reads
+`output.capture` / `output.echo` for the observation tags. `Pipeline.run` /
+`run_sync` use the same `output` parameter and resolve it before building the
+pipeline execution config. There is no parallel internal `(capture, echo)` value
+object: the former `_IOBehaviour` was redundant with `RunOutputOptions` and has
+been removed. `IOOptions` remains only as a deprecated subclass alias that
+emits a `DeprecationWarning`.
+
+Internal adapters may translate legacy or aggregate configuration into
+`RunOutputOptions` at the boundary. For example, the concurrent runner converts
+its `_ConcurrentRunConfig` flags into `RunOutputOptions` once before calling
+`SafeCmd.run`. Avoid reintroducing parallel output-option structures unless a
+new boundary genuinely has different semantics; in that case, document the
+translation rule here and cover it with behavioural tests.
 
 `Pipeline.run` and `Pipeline.run_sync` retain `capture` and `echo` keyword
 arguments only for compatibility. Those flags emit `DeprecationWarning` and

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -720,7 +720,6 @@ and tool-discovery recipes only. This supports non-interactive Continuous
 Integration/Continuous Delivery (CI/CD) hook environments without globally
 shadowing system tools for unrelated Makefile workflows.
 
-
 ## Rust error taxonomy (`PumpError`)
 
 The `cuprum-rust` crate reports stream pump and consume failures through one

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -10,7 +10,6 @@ of truth for day-to-day contributor expectations. For the system design, see the
 - [ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md)
 - [ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md)
 
-
 ## Rust dependency management
 
 When editing `Cargo.toml`, dependencies must use explicit semver-compatible
@@ -40,9 +39,9 @@ emission order: `archive`, `delete`, `dry_run`, `verbose`, then `compress`.
 This is a documented contract covered by the property tests in
 `cuprum/unittests/test_builder_property_based.py`.
 
-Both `TarCreateOptions` and `RsyncOptions` provide `allow_relative`. It defaults
-to `False`, so `safe_path` rejects relative paths unless a caller explicitly
-opts in.
+Both `TarCreateOptions` and `RsyncOptions` provide `allow_relative`. It
+defaults to `False`, so `safe_path` rejects relative paths unless a caller
+explicitly opts in.
 
 ## Command argument construction
 
@@ -767,7 +766,14 @@ and anything else propagates.
 read/write fallback: interrupted reads (`EINTR`) retry instead of silently
 ending the drain, end of file terminates it, and other errors propagate.
 Behavioural tests in the module cover full pipe-to-pipe transfer, the fallback
-signal for regular files, broken-pipe draining, and the drain's EOF termination.
+signal for regular files, broken-pipe draining, and the drain's EOF
+termination. These outcomes and `PumpError` values are intentionally returned
+to the Python boundary, where command observation owns telemetry, so this
+internal Rust path does not add a second logging or metrics surface.
+
+Unix Rust tests share pipe creation, duplicated-file wrapping, result helpers,
+and descriptor-state checks through `test_support`. Re-use that module for
+descriptor-backed test setup; keep production code independent of test helpers.
 
 ## Rust property testing and verification
 
@@ -1044,15 +1050,15 @@ uv run pytest cuprum/unittests/test_maturin_build.py \
 
 ## Workflow pins and Dependabot
 
-Dependabot owns the upgrade of GitHub Actions and reusable workflows,
-including calls into `leynos/shared-actions`. Contract tests that assert a
-caller's exact commit SHA create a lockstep dependency: every time Dependabot
-opens a bump PR, the test fails until a human edits the pinned constant to
-match. That defeats the purpose of automated dependency updates and turns a
-routine bump into a manual chore.
+Dependabot owns the upgrade of GitHub Actions and reusable workflows, including
+calls into `leynos/shared-actions`. Contract tests that assert a caller's exact
+commit SHA create a lockstep dependency: every time Dependabot opens a bump PR,
+the test fails until a human edits the pinned constant to match. That defeats
+the purpose of automated dependency updates and turns a routine bump into a
+manual chore.
 
-Contract tests may still verify the *shape* of a reusable-workflow caller.
-They must not verify the specific SHA value.
+Contract tests may still verify the *shape* of a reusable-workflow caller. They
+must not verify the specific SHA value.
 
 - Do assert the workflow references the correct reusable workflow path.
 - Do assert the ref is pinned to a full 40-character commit SHA, not a
@@ -1172,10 +1178,10 @@ explicit, testable, and compatible with the `IOOptions` deprecation path.
 and pass it straight through to `_prepare_execution_observation`, which reads
 `output.capture` / `output.echo` for the observation tags. `Pipeline.run` /
 `run_sync` use the same `output` parameter and resolve it before building the
-pipeline execution config. There is no parallel internal `(capture, echo)` value
-object: the former `_IOBehaviour` was redundant with `RunOutputOptions` and has
-been removed. `IOOptions` remains only as a deprecated subclass alias that
-emits a `DeprecationWarning`.
+pipeline execution config. There is no parallel internal `(capture, echo)`
+value object: the former `_IOBehaviour` was redundant with `RunOutputOptions`
+and has been removed. `IOOptions` remains only as a deprecated subclass alias
+that emits a `DeprecationWarning`.
 
 Internal adapters may translate legacy or aggregate configuration into
 `RunOutputOptions` at the boundary. For example, the concurrent runner converts

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -740,7 +740,6 @@ write classification (broken pipe / connection reset) lives on the enum as
 read/write paths previously shared. New failure conditions get a variant here
 rather than a stringly-typed `io::Error::other(...)`.
 
-
 ## Rust splice-loop and drain contract
 
 The Linux zero-copy path in `rust/cuprum-rust/src/splice.rs` follows one

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -10,6 +10,17 @@ of truth for day-to-day contributor expectations. For the system design, see the
 - [ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md)
 - [ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md)
 
+
+## Rust dependency management
+
+When editing `Cargo.toml`, dependencies must use explicit semver-compatible
+caret requirements only (for example `"1.2.3"`). Do not use wildcards such as
+`*` or open-ended ranges such as `>=` or `~`.
+
+When updating Rust dependencies, keep the requested version aligned to the
+patch baseline already present in `Cargo.lock`. This keeps lockfile updates
+focused, small, and easy to review.
+
 ## Tar and rsync builder helpers
 
 `TarCreateOptions.compression` in `cuprum/builders/tar.py` selects one member

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -740,6 +740,25 @@ write classification (broken pipe / connection reset) lives on the enum as
 read/write paths previously shared. New failure conditions get a variant here
 rather than a stringly-typed `io::Error::other(...)`.
 
+
+## Rust splice-loop and drain contract
+
+The Linux zero-copy path in `rust/cuprum-rust/src/splice.rs` follows one
+canonical loop. `try_splice_pump` performs the first `splice_once` solely to
+detect support: `EINVAL` on that first call signals unsupported descriptor
+types and the read/write fallback. Every outcome thereafter — including the
+first call's, which is fed into the loop — is handled by the same arms: `Ok(0)`
+ends the transfer, `Ok(n)` accumulates, a non-fatal write error (broken pipe /
+connection reset) drains the reader and reports the bytes transferred so far,
+and anything else propagates.
+
+`drain_reader` routes through the canonical raw-fd read helper
+(`io_utils::read_raw_fd`), so it shares the Unix read policy with the
+read/write fallback: interrupted reads (`EINTR`) retry instead of silently
+ending the drain, end of file terminates it, and other errors propagate.
+Behavioural tests in the module cover full pipe-to-pipe transfer, the fallback
+signal for regular files, broken-pipe draining, and the drain's EOF termination.
+
 ## Rust property testing and verification
 
 Rust-level tests for `cuprum-rust` live with the crate under

--- a/docs/execplans/3-1-1-core-builder-set-for-common-tools.md
+++ b/docs/execplans/3-1-1-core-builder-set-for-common-tools.md
@@ -316,8 +316,8 @@ cuprum/builders/tar.py
   ) -> SafeCmd
 ```
 
-`Compression` selects one mutually exclusive member: `NONE`, `GZIP`, `BZIP2`,
-or `XZ`.
+`Compression` selects one mutually exclusive member: `NONE`, `GZIP`, `BZIP2`, or
+`XZ`.
 
 Exports and catalogue updates:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -267,7 +267,6 @@ and echo semantics and returns a structured `CommandResult`:
 - `exit_code`, `pid`, and `ok` on the `CommandResult` make it easy to branch on
   success.
 
-
 ### Output options
 
 `RunOutputOptions` is the public contract for command output handling on
@@ -318,8 +317,8 @@ result = pipeline.run_sync(output=RunOutputOptions(capture=False, echo=True))
 ```
 
 If existing code constructs `IOOptions`, replace it with `RunOutputOptions`.
-`IOOptions` remains a deprecated alias for the same `capture` and `echo`
-values and emits a `DeprecationWarning` on construction. Migrate by replacing
+`IOOptions` remains a deprecated alias for the same `capture` and `echo` values
+and emits a `DeprecationWarning` on construction. Migrate by replacing
 `IOOptions(capture=..., echo=...)` usage with
 `RunOutputOptions(capture=..., echo=...)` passed as `output=...`.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -267,6 +267,23 @@ and echo semantics and returns a structured `CommandResult`:
 - `exit_code`, `pid`, and `ok` on the `CommandResult` make it easy to branch on
   success.
 
+
+### Output options
+
+`RunOutputOptions` is the public contract for command output handling on
+`SafeCmd.run()` and `SafeCmd.run_sync()`. Pass it with the `output` parameter
+when a call needs output behaviour that differs from the default.
+
+- `capture=True` stores stdout and stderr on the returned `CommandResult`.
+  Set it to `False` when the caller does not need captured output; `stdout` and
+  `stderr` will then be `None`.
+- `echo=False` keeps output out of the parent process streams. Set it to `True`
+  to tee stdout and stderr while the command runs. When `capture=True`, echoed
+  output is still captured.
+
+`RunOutputOptions(capture=True, echo=False)` is the default; you only need to
+supply it explicitly when overriding either flag.
+
 ```python
 from cuprum import ECHO, ExecutionContext, RunOutputOptions, sh
 
@@ -295,11 +312,14 @@ result = pipeline.run_sync(capture=False, echo=True)
 # After
 from cuprum import RunOutputOptions
 
+result = await cmd.run(output=RunOutputOptions(capture=True, echo=False))
+result = cmd.run_sync(output=RunOutputOptions(capture=False))
 result = pipeline.run_sync(output=RunOutputOptions(capture=False, echo=True))
 ```
 
-`IOOptions` remains available only as a compatibility alias and emits a
-`DeprecationWarning` on construction; migrate by replacing any
+If existing code constructs `IOOptions`, replace it with `RunOutputOptions`.
+`IOOptions` remains a deprecated alias for the same `capture` and `echo`
+values and emits a `DeprecationWarning` on construction. Migrate by replacing
 `IOOptions(capture=..., echo=...)` usage with
 `RunOutputOptions(capture=..., echo=...)` passed as `output=...`.
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,12 +91,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,15 +146,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -174,15 +160,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -197,21 +174,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -219,12 +188,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -239,16 +202,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "log"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
-
-[[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-traits"
@@ -284,16 +241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -398,9 +345,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -419,9 +366,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -457,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -469,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -618,9 +565,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -646,7 +593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -734,9 +681,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "trybuild"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
 dependencies = [
  "dissimilar",
  "glob",
@@ -761,12 +708,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,54 +718,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -853,20 +751,11 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -876,98 +765,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -976,6 +786,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "libc",
  "proptest",
  "pyo3",
+ "thiserror",
  "trybuild",
 ]
 
@@ -518,6 +519,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +57,7 @@ dependencies = [
  "libc",
  "proptest",
  "pyo3",
+ "rstest",
  "thiserror",
  "trybuild",
 ]
@@ -91,6 +101,48 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -214,6 +266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +294,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -389,10 +456,77 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.8.10"
+name = "regex"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -475,6 +609,12 @@ checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
@@ -563,6 +703,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -704,6 +856,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/rust/cuprum-rust/Cargo.toml
+++ b/rust/cuprum-rust/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["extension-module"] }
+thiserror = "2.0.17"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/rust/cuprum-rust/Cargo.toml
+++ b/rust/cuprum-rust/Cargo.toml
@@ -19,6 +19,7 @@ libc = "0.2.186"
 
 [dev-dependencies]
 proptest = "1.11.0"
+rstest = "0.26.1"
 trybuild = { version = "1.0.116", features = ["diff"] }
 
 [lints]

--- a/rust/cuprum-rust/Cargo.toml
+++ b/rust/cuprum-rust/Cargo.toml
@@ -12,14 +12,14 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["extension-module"] }
-thiserror = "2.0.17"
+thiserror = "2.0.18"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = "0.2.186"
 
 [dev-dependencies]
-proptest = "1"
-trybuild = { version = "1", features = ["diff"] }
+proptest = "1.11.0"
+trybuild = { version = "1.0.116", features = ["diff"] }
 
 [lints]
 workspace = true

--- a/rust/cuprum-rust/src/errors.rs
+++ b/rust/cuprum-rust/src/errors.rs
@@ -46,6 +46,15 @@ impl PumpError {
             )
         )
     }
+
+    /// Return the Python `OSError` message for semantic non-I/O variants.
+    pub(crate) const fn py_os_error_message(&self) -> Option<&'static str> {
+        match self {
+            Self::LengthOverflow => Some("integer length conversion overflowed"),
+            Self::BufferRangeExceeded => Some("computed range exceeded the buffer bounds"),
+            Self::Io(_) => None,
+        }
+    }
 }
 
 impl From<PumpError> for PyErr {
@@ -53,7 +62,7 @@ impl From<PumpError> for PyErr {
         match err {
             PumpError::Io(io_err) => io_err.into(),
             other @ (PumpError::LengthOverflow | PumpError::BufferRangeExceeded) => {
-                PyOSError::new_err(other.to_string())
+                PyOSError::new_err(other.py_os_error_message().unwrap_or("stream pump failed"))
             }
         }
     }
@@ -108,6 +117,22 @@ mod tests {
         assert_eq!(
             PumpError::BufferRangeExceeded.to_string(),
             "computed range exceeded the buffer bounds",
+        );
+    }
+
+    #[test]
+    fn semantic_overflow_errors_define_py_os_error_messages() {
+        assert_eq!(
+            PumpError::LengthOverflow.py_os_error_message(),
+            Some("integer length conversion overflowed"),
+        );
+        assert_eq!(
+            PumpError::BufferRangeExceeded.py_os_error_message(),
+            Some("computed range exceeded the buffer bounds"),
+        );
+        assert_eq!(
+            PumpError::from(io::Error::other("boom")).py_os_error_message(),
+            None,
         );
     }
 }

--- a/rust/cuprum-rust/src/errors.rs
+++ b/rust/cuprum-rust/src/errors.rs
@@ -1,0 +1,113 @@
+//! Canonical semantic error type for the stream pump and consume paths.
+//!
+//! `PumpError` is the single error taxonomy for the crate's internal stream
+//! operations. The previously scattered `io::Error::other("...")`
+//! constructions for "impossible" overflow and slice conditions are replaced
+//! by machine-distinguishable variants; conversion to a Python exception
+//! happens in exactly one place (`From<PumpError> for PyErr`).
+
+use std::io;
+
+use pyo3::PyErr;
+use pyo3::exceptions::PyOSError;
+use thiserror::Error;
+
+/// Semantic error for stream pump and consume operations.
+#[derive(Debug, Error)]
+pub(crate) enum PumpError {
+    /// An integer length conversion overflowed its target type.
+    ///
+    /// This is an "impossible" condition on supported platforms (for
+    /// example, a non-negative `ssize_t` always fits a `usize` on Linux);
+    /// the variant exists so the condition stays observable rather than
+    /// silently truncating.
+    #[error("integer length conversion overflowed")]
+    LengthOverflow,
+    /// A computed range exceeded the backing buffer's bounds.
+    #[error("computed range exceeded the buffer bounds")]
+    BufferRangeExceeded,
+    /// An operating-system I/O failure.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+impl PumpError {
+    /// Report whether this is a non-fatal write condition (broken pipe).
+    ///
+    /// These errors indicate the write end closed, which is expected when
+    /// downstream processes exit early. The caller should drain the reader
+    /// and return successfully rather than propagating the error.
+    pub(crate) fn is_nonfatal_write(&self) -> bool {
+        matches!(
+            self,
+            Self::Io(err) if matches!(
+                err.kind(),
+                io::ErrorKind::BrokenPipe | io::ErrorKind::ConnectionReset
+            )
+        )
+    }
+}
+
+impl From<PumpError> for PyErr {
+    fn from(err: PumpError) -> Self {
+        match err {
+            PumpError::Io(io_err) => io_err.into(),
+            other @ (PumpError::LengthOverflow | PumpError::BufferRangeExceeded) => {
+                PyOSError::new_err(other.to_string())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the canonical `PumpError` taxonomy: variant mapping,
+    //! the non-fatal write predicate, and stable display messages.
+    use super::PumpError;
+    use std::io;
+
+    #[test]
+    fn io_errors_round_trip_their_kind() {
+        let source = io::Error::new(io::ErrorKind::BrokenPipe, "downstream closed");
+        let err = PumpError::from(source);
+        match &err {
+            PumpError::Io(inner) => assert_eq!(inner.kind(), io::ErrorKind::BrokenPipe),
+            other => panic!("expected Io variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn only_broken_pipe_and_connection_reset_are_nonfatal() {
+        let nonfatal_kinds = [io::ErrorKind::BrokenPipe, io::ErrorKind::ConnectionReset];
+        for kind in nonfatal_kinds {
+            let err = PumpError::from(io::Error::new(kind, "closed"));
+            assert!(err.is_nonfatal_write(), "{kind:?} must be non-fatal");
+        }
+
+        let fatal_kinds = [
+            io::ErrorKind::NotFound,
+            io::ErrorKind::PermissionDenied,
+            io::ErrorKind::WriteZero,
+            io::ErrorKind::Interrupted,
+            io::ErrorKind::Other,
+        ];
+        for kind in fatal_kinds {
+            let err = PumpError::from(io::Error::new(kind, "boom"));
+            assert!(!err.is_nonfatal_write(), "{kind:?} must be fatal");
+        }
+        assert!(!PumpError::LengthOverflow.is_nonfatal_write());
+        assert!(!PumpError::BufferRangeExceeded.is_nonfatal_write());
+    }
+
+    #[test]
+    fn overflow_variants_have_stable_messages() {
+        assert_eq!(
+            PumpError::LengthOverflow.to_string(),
+            "integer length conversion overflowed",
+        );
+        assert_eq!(
+            PumpError::BufferRangeExceeded.to_string(),
+            "computed range exceeded the buffer bounds",
+        );
+    }
+}

--- a/rust/cuprum-rust/src/fd_tests.rs
+++ b/rust/cuprum-rust/src/fd_tests.rs
@@ -1,0 +1,120 @@
+//! Unit and property tests for platform file descriptor conversion.
+
+#[cfg(unix)]
+mod unix {
+    //! Tests for Unix file descriptor conversion boundaries.
+
+    use proptest::prelude::*;
+
+    use crate::convert_platform_fd;
+
+    #[test]
+    fn convert_fd_accepts_valid_descriptors() {
+        match convert_platform_fd(0) {
+            Ok(fd) => assert_eq!(fd, 0),
+            Err(err) => panic!("zero descriptor should be accepted: {err}"),
+        }
+        match convert_platform_fd(i64::from(i32::MAX)) {
+            Ok(fd) => assert_eq!(fd, i32::MAX),
+            Err(err) => panic!("i32::MAX descriptor should be accepted: {err}"),
+        }
+    }
+
+    #[test]
+    fn convert_fd_rejects_negative_descriptors() {
+        assert_eq!(
+            convert_platform_fd(-1),
+            Err("file descriptor must be non-negative"),
+        );
+    }
+
+    #[test]
+    fn convert_fd_rejects_i64_min_descriptors_as_out_of_range() {
+        assert_eq!(
+            convert_platform_fd(i64::MIN),
+            Err("file descriptor out of range"),
+        );
+    }
+
+    #[test]
+    fn convert_fd_rejects_out_of_range_descriptors() {
+        assert_eq!(
+            convert_platform_fd(i64::from(i32::MAX) + 1),
+            Err("file descriptor out of range"),
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn convert_fd_matches_descriptor_bounds(value in any::<i64>()) {
+            let result = convert_platform_fd(value);
+
+            if let Ok(expected) = i32::try_from(value) {
+                if expected >= 0 {
+                    match result {
+                        Ok(fd) => prop_assert_eq!(fd, expected),
+                        Err(err) => prop_assert!(false, "{value} should be accepted: {err}"),
+                    }
+                } else {
+                    prop_assert!(result.is_err());
+                }
+            } else {
+                prop_assert!(result.is_err());
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    //! Tests for Windows handle conversion boundaries.
+
+    use proptest::prelude::*;
+
+    use crate::convert_platform_fd;
+
+    #[test]
+    fn convert_fd_accepts_valid_handles() {
+        match convert_platform_fd(0) {
+            Ok(handle) => assert_eq!(handle, 0_usize),
+            Err(err) => panic!("zero handle should be accepted: {err}"),
+        }
+        match convert_platform_fd(i64::from(u16::MAX)) {
+            Ok(handle) => assert_eq!(handle, usize::from(u16::MAX)),
+            Err(err) => panic!("u16::MAX handle should be accepted: {err}"),
+        }
+    }
+
+    #[test]
+    fn convert_fd_rejects_negative_handles() {
+        assert_eq!(
+            convert_platform_fd(-1),
+            Err("file handle must be non-negative"),
+        );
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn convert_fd_rejects_out_of_range_handles() {
+        assert_eq!(
+            convert_platform_fd(i64::from(u32::MAX) + 1),
+            Err("file handle out of range"),
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn convert_fd_matches_handle_bounds(value in any::<i64>()) {
+            let result = convert_platform_fd(value);
+
+            if let Ok(expected) = usize::try_from(value) {
+                match result {
+                    Ok(handle) => prop_assert_eq!(handle, expected),
+                    Err(err) => prop_assert!(false, "{value} should be accepted: {err}"),
+                }
+            } else {
+                prop_assert!(result.is_err());
+            }
+        }
+    }
+}

--- a/rust/cuprum-rust/src/fd_tests.rs
+++ b/rust/cuprum-rust/src/fd_tests.rs
@@ -8,16 +8,17 @@ mod unix {
 
     use crate::convert_platform_fd;
 
+    fn check_accepted(input: i64, expected: i32) {
+        match convert_platform_fd(input) {
+            Ok(fd) => assert_eq!(fd, expected),
+            Err(err) => panic!("{input} should be accepted: {err}"),
+        }
+    }
+
     #[test]
     fn convert_fd_accepts_valid_descriptors() {
-        match convert_platform_fd(0) {
-            Ok(fd) => assert_eq!(fd, 0),
-            Err(err) => panic!("zero descriptor should be accepted: {err}"),
-        }
-        match convert_platform_fd(i64::from(i32::MAX)) {
-            Ok(fd) => assert_eq!(fd, i32::MAX),
-            Err(err) => panic!("i32::MAX descriptor should be accepted: {err}"),
-        }
+        check_accepted(0, 0);
+        check_accepted(i64::from(i32::MAX), i32::MAX);
     }
 
     #[test]
@@ -73,16 +74,17 @@ mod windows {
 
     use crate::convert_platform_fd;
 
+    fn check_accepted(input: i64, expected: usize) {
+        match convert_platform_fd(input) {
+            Ok(handle) => assert_eq!(handle, expected),
+            Err(err) => panic!("{input} should be accepted: {err}"),
+        }
+    }
+
     #[test]
     fn convert_fd_accepts_valid_handles() {
-        match convert_platform_fd(0) {
-            Ok(handle) => assert_eq!(handle, 0_usize),
-            Err(err) => panic!("zero handle should be accepted: {err}"),
-        }
-        match convert_platform_fd(i64::from(u16::MAX)) {
-            Ok(handle) => assert_eq!(handle, usize::from(u16::MAX)),
-            Err(err) => panic!("u16::MAX handle should be accepted: {err}"),
-        }
+        check_accepted(0, 0_usize);
+        check_accepted(i64::from(u16::MAX), usize::from(u16::MAX));
     }
 
     #[test]

--- a/rust/cuprum-rust/src/io_utils.rs
+++ b/rust/cuprum-rust/src/io_utils.rs
@@ -344,18 +344,25 @@ mod tests {
         assert!(matches!(err, PumpError::Io(_)));
     }
 
+    /// Call [`handle_write_result`] with `b"chunk"` starting from
+    /// `initial_total` and return both the call's result and the
+    /// (possibly updated) total.
+    fn run_handle_write_result(
+        writer: &mut OwnedFd,
+        initial_total: u64,
+    ) -> (Result<bool, PumpError>, u64) {
+        let mut total_written = initial_total;
+        let result = handle_write_result(writer, b"chunk", &mut total_written);
+        (result, total_written)
+    }
+
     #[test]
     fn handle_write_result_updates_total_on_success() {
         let (read_end, mut write_end) = pipe_pair();
-        let mut total_written = 7_u64;
 
-        let should_continue = unwrap_ok(handle_write_result(
-            &mut write_end,
-            b"chunk",
-            &mut total_written,
-        ));
+        let (result, total_written) = run_handle_write_result(&mut write_end, 7);
 
-        assert!(should_continue);
+        assert!(unwrap_ok(result));
         assert_eq!(total_written, 12);
         drop(read_end);
     }
@@ -363,15 +370,10 @@ mod tests {
     #[test]
     fn handle_write_result_preserves_total_on_fatal_error() {
         let (mut read_end, _write_end) = pipe_pair();
-        let mut total_written = 7_u64;
 
-        let err = unwrap_err(handle_write_result(
-            &mut read_end,
-            b"chunk",
-            &mut total_written,
-        ));
+        let (result, total_written) = run_handle_write_result(&mut read_end, 7);
 
-        assert!(matches!(err, PumpError::Io(_)));
+        assert!(matches!(unwrap_err(result), PumpError::Io(_)));
         assert_eq!(total_written, 7);
     }
 

--- a/rust/cuprum-rust/src/io_utils.rs
+++ b/rust/cuprum-rust/src/io_utils.rs
@@ -2,9 +2,12 @@
 //!
 //! This module provides helpers for reading and writing descriptor-backed
 //! streams with proper error handling, including detection of non-fatal write
-//! errors like broken pipes.
+//! errors like broken pipes. Failures are reported through the crate's
+//! canonical [`PumpError`] taxonomy.
 
 use std::io;
+
+use crate::errors::PumpError;
 
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, OwnedFd};
@@ -25,7 +28,7 @@ pub(crate) type StreamHandle = File;
 pub(crate) fn read_stream(
     reader: &mut StreamHandle,
     buffer: &mut [u8],
-) -> Result<usize, io::Error> {
+) -> Result<usize, PumpError> {
     #[cfg(unix)]
     {
         read_stream_unix(reader, buffer)
@@ -33,31 +36,19 @@ pub(crate) fn read_stream(
 
     #[cfg(windows)]
     {
-        reader.read(buffer)
+        reader.read(buffer).map_err(PumpError::from)
     }
 }
 
 /// Write all bytes from a chunk to the writer, returning bytes written.
-pub(crate) fn handle_write(writer: &mut StreamHandle, chunk: &[u8]) -> Result<u64, io::Error> {
+pub(crate) fn handle_write(writer: &mut StreamHandle, chunk: &[u8]) -> Result<u64, PumpError> {
     #[cfg(unix)]
     write_all_unix(writer, chunk)?;
 
     #[cfg(windows)]
-    writer.write_all(chunk)?;
+    writer.write_all(chunk).map_err(PumpError::from)?;
 
-    u64::try_from(chunk.len()).map_err(|_| io::Error::other("write length overflow"))
-}
-
-/// Check if an error is a non-fatal write condition (broken pipe).
-///
-/// These errors indicate the write end closed, which is expected when
-/// downstream processes exit early. The caller should drain the reader
-/// and return successfully rather than propagating the error.
-pub(crate) fn is_nonfatal_write_error(err: &io::Error) -> bool {
-    matches!(
-        err.kind(),
-        io::ErrorKind::BrokenPipe | io::ErrorKind::ConnectionReset
-    )
+    u64::try_from(chunk.len()).map_err(|_| PumpError::LengthOverflow)
 }
 
 /// Attempt to write a chunk and update the total written count.
@@ -69,14 +60,14 @@ pub(crate) fn handle_write_result(
     writer: &mut StreamHandle,
     chunk: &[u8],
     total_written: &mut u64,
-) -> Result<bool, io::Error> {
+) -> Result<bool, PumpError> {
     match handle_write(writer, chunk) {
         Ok(bytes) => {
             *total_written = total_written.saturating_add(bytes);
             Ok(true)
         }
         Err(err) => {
-            if is_nonfatal_write_error(&err) {
+            if err.is_nonfatal_write() {
                 Ok(false)
             } else {
                 Err(err)
@@ -86,7 +77,7 @@ pub(crate) fn handle_write_result(
 }
 
 #[cfg(unix)]
-fn read_stream_unix(reader: &StreamHandle, buffer: &mut [u8]) -> Result<usize, io::Error> {
+fn read_stream_unix(reader: &StreamHandle, buffer: &mut [u8]) -> Result<usize, PumpError> {
     loop {
         // SAFETY: `buffer` is valid for writes of `buffer.len()` bytes, and
         // `reader` owns a valid descriptor for the duration of this call.
@@ -99,18 +90,18 @@ fn read_stream_unix(reader: &StreamHandle, buffer: &mut [u8]) -> Result<usize, i
         };
 
         if read_len >= 0 {
-            return usize::try_from(read_len).map_err(|_| io::Error::other("read length overflow"));
+            return usize::try_from(read_len).map_err(|_| PumpError::LengthOverflow);
         }
 
         let err = io::Error::last_os_error();
         if err.kind() != io::ErrorKind::Interrupted {
-            return Err(err);
+            return Err(PumpError::from(err));
         }
     }
 }
 
 #[cfg(unix)]
-fn write_all_unix(writer: &StreamHandle, mut chunk: &[u8]) -> Result<(), io::Error> {
+fn write_all_unix(writer: &StreamHandle, mut chunk: &[u8]) -> Result<(), PumpError> {
     while !chunk.is_empty() {
         // SAFETY: `chunk` is valid for reads of `chunk.len()` bytes, and
         // `writer` owns a valid descriptor for the duration of this call.
@@ -123,24 +114,23 @@ fn write_all_unix(writer: &StreamHandle, mut chunk: &[u8]) -> Result<(), io::Err
         };
 
         if written > 0 {
-            let written_len =
-                usize::try_from(written).map_err(|_| io::Error::other("write length overflow"))?;
+            let written_len = usize::try_from(written).map_err(|_| PumpError::LengthOverflow)?;
             chunk = chunk
                 .get(written_len..)
-                .ok_or_else(|| io::Error::other("write length exceeded buffer"))?;
+                .ok_or(PumpError::BufferRangeExceeded)?;
             continue;
         }
 
         if written == 0 {
-            return Err(io::Error::new(
+            return Err(PumpError::from(io::Error::new(
                 io::ErrorKind::WriteZero,
                 "failed to write whole buffer",
-            ));
+            )));
         }
 
         let err = io::Error::last_os_error();
         if err.kind() != io::ErrorKind::Interrupted {
-            return Err(err);
+            return Err(PumpError::from(err));
         }
     }
 

--- a/rust/cuprum-rust/src/io_utils.rs
+++ b/rust/cuprum-rust/src/io_utils.rs
@@ -222,62 +222,22 @@ fn map_short_write_error(err: io::Error, total_written: u64) -> Result<WriteOutc
     Err(pump_error)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     //! Direct tests for descriptor-backed I/O helper contracts.
 
-    use std::fmt::Debug;
-    use std::io::{self, Write};
-    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::io;
+    use std::os::fd::{AsRawFd, OwnedFd};
 
     use super::{
         PumpError, WriteOutcome, handle_write, handle_write_result, map_short_write_error,
         read_raw_fd, read_raw_fd_with, read_stream,
     };
-
-    fn pipe_pair() -> (OwnedFd, OwnedFd) {
-        let mut fds = [0_i32; 2];
-        // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
-        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
-        assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
-
-        // SAFETY: on success `pipe(2)` returned two freshly opened FDs that
-        // this process exclusively owns.
-        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
-    }
-
-    fn write_all_to(fd: &OwnedFd, payload: &[u8]) {
-        // SAFETY: duplicating an owned descriptor for a scoped File wrapper.
-        let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
-        assert_ne!(
-            duplicated_fd,
-            -1,
-            "dup(2) failed: {}",
-            io::Error::last_os_error(),
-        );
-        // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and
-        // is now owned by this scoped `File`.
-        let mut file = unsafe { std::fs::File::from_raw_fd(duplicated_fd) };
-        unwrap_ok(file.write_all(payload));
-    }
-
-    fn unwrap_ok<T, E: Debug>(result: Result<T, E>) -> T {
-        match result {
-            Ok(value) => value,
-            Err(err) => panic!("expected Ok(..), got Err({err:?})"),
-        }
-    }
-
-    fn unwrap_err<T: Debug, E>(result: Result<T, E>) -> E {
-        match result {
-            Ok(value) => panic!("expected Err(..), got Ok({value:?})"),
-            Err(err) => err,
-        }
-    }
+    use crate::test_support::{make_pipe, unwrap_err, unwrap_ok, write_all_to};
 
     #[test]
     fn read_stream_reads_pipe_bytes() {
-        let (mut read_end, write_end) = pipe_pair();
+        let (mut read_end, write_end) = make_pipe();
         write_all_to(&write_end, b"chunk");
         drop(write_end);
         let mut buffer = [0_u8; 8];
@@ -290,7 +250,7 @@ mod tests {
 
     #[test]
     fn read_stream_reports_unreadable_descriptor() {
-        let (_read_end, mut write_end) = pipe_pair();
+        let (_read_end, mut write_end) = make_pipe();
         let mut buffer = [0_u8; 8];
 
         let err = unwrap_err(read_stream(&mut write_end, &mut buffer));
@@ -300,7 +260,7 @@ mod tests {
 
     #[test]
     fn read_raw_fd_reports_eof() {
-        let (read_end, write_end) = pipe_pair();
+        let (read_end, write_end) = make_pipe();
         drop(write_end);
         let mut buffer = [0_u8; 8];
 
@@ -327,7 +287,7 @@ mod tests {
 
     #[test]
     fn handle_write_returns_complete_outcome() {
-        let (read_end, mut write_end) = pipe_pair();
+        let (read_end, mut write_end) = make_pipe();
 
         let outcome = unwrap_ok(handle_write(&mut write_end, b"chunk"));
 
@@ -337,7 +297,7 @@ mod tests {
 
     #[test]
     fn handle_write_reports_unwritable_descriptor() {
-        let (mut read_end, _write_end) = pipe_pair();
+        let (mut read_end, _write_end) = make_pipe();
 
         let err = unwrap_err(handle_write(&mut read_end, b"chunk"));
 
@@ -358,7 +318,7 @@ mod tests {
 
     #[test]
     fn handle_write_result_updates_total_on_success() {
-        let (read_end, mut write_end) = pipe_pair();
+        let (read_end, mut write_end) = make_pipe();
 
         let (result, total_written) = run_handle_write_result(&mut write_end, 7);
 
@@ -369,7 +329,7 @@ mod tests {
 
     #[test]
     fn handle_write_result_preserves_total_on_fatal_error() {
-        let (mut read_end, _write_end) = pipe_pair();
+        let (mut read_end, _write_end) = make_pipe();
 
         let (result, total_written) = run_handle_write_result(&mut read_end, 7);
 

--- a/rust/cuprum-rust/src/io_utils.rs
+++ b/rust/cuprum-rust/src/io_utils.rs
@@ -24,8 +24,13 @@ pub(crate) type StreamHandle = OwnedFd;
 #[cfg(windows)]
 pub(crate) type StreamHandle = File;
 
+/// Result of a single write attempt on the stream.
 pub(crate) enum WriteOutcome {
+    /// The full chunk was written successfully; contains the byte count.
     Complete(u64),
+    /// A non-fatal pipe closure occurred after this many bytes were written.
+    ///
+    /// This covers broken pipes and connection resets after partial progress.
     NonFatalShortWrite(u64),
 }
 

--- a/rust/cuprum-rust/src/io_utils.rs
+++ b/rust/cuprum-rust/src/io_utils.rs
@@ -25,12 +25,13 @@ pub(crate) type StreamHandle = OwnedFd;
 pub(crate) type StreamHandle = File;
 
 /// Result of a single write attempt on the stream.
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum WriteOutcome {
     /// The full chunk was written successfully; contains the byte count.
     Complete(u64),
-    /// A non-fatal pipe closure occurred after this many bytes were written.
-    ///
-    /// This covers broken pipes and connection resets after partial progress.
+    /// The write stopped due to a non-fatal broken-pipe/connection-reset error.
+    /// The value is the number of bytes accepted before that error occurred,
+    /// and it may be zero.
     NonFatalShortWrite(u64),
 }
 
@@ -105,7 +106,7 @@ fn read_stream_unix(reader: &StreamHandle, buffer: &mut [u8]) -> Result<usize, P
 /// every other error propagates.
 #[cfg(unix)]
 pub(crate) fn read_raw_fd(fd: libc::c_int, buffer: &mut [u8]) -> Result<usize, PumpError> {
-    loop {
+    read_raw_fd_with(|| {
         // SAFETY: `buffer` is valid for writes of `buffer.len()` bytes, and
         // the caller guarantees `fd` stays valid for the duration of this
         // call.
@@ -113,12 +114,24 @@ pub(crate) fn read_raw_fd(fd: libc::c_int, buffer: &mut [u8]) -> Result<usize, P
             unsafe { libc::read(fd, buffer.as_mut_ptr().cast::<libc::c_void>(), buffer.len()) };
 
         if read_len >= 0 {
-            return usize::try_from(read_len).map_err(|_| PumpError::LengthOverflow);
+            Ok(read_len)
+        } else {
+            Err(io::Error::last_os_error())
         }
+    })
+}
 
-        let err = io::Error::last_os_error();
-        if err.kind() != io::ErrorKind::Interrupted {
-            return Err(PumpError::from(err));
+#[cfg(unix)]
+fn read_raw_fd_with(
+    mut read_once: impl FnMut() -> Result<libc::ssize_t, io::Error>,
+) -> Result<usize, PumpError> {
+    loop {
+        match read_once() {
+            Ok(read_len) => {
+                return usize::try_from(read_len).map_err(|_| PumpError::LengthOverflow);
+            }
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+            Err(err) => return Err(PumpError::from(err)),
         }
     }
 }
@@ -207,4 +220,178 @@ fn map_short_write_error(err: io::Error, total_written: u64) -> Result<WriteOutc
         return Ok(WriteOutcome::NonFatalShortWrite(total_written));
     }
     Err(pump_error)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Direct tests for descriptor-backed I/O helper contracts.
+
+    use std::fmt::Debug;
+    use std::io::{self, Write};
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+    use super::{
+        PumpError, WriteOutcome, handle_write, handle_write_result, map_short_write_error,
+        read_raw_fd, read_raw_fd_with, read_stream,
+    };
+
+    fn pipe_pair() -> (OwnedFd, OwnedFd) {
+        let mut fds = [0_i32; 2];
+        // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
+        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
+
+        // SAFETY: on success `pipe(2)` returned two freshly opened FDs that
+        // this process exclusively owns.
+        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+    }
+
+    fn write_all_to(fd: &OwnedFd, payload: &[u8]) {
+        // SAFETY: duplicating an owned descriptor for a scoped File wrapper.
+        let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
+        assert_ne!(
+            duplicated_fd,
+            -1,
+            "dup(2) failed: {}",
+            io::Error::last_os_error(),
+        );
+        // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and
+        // is now owned by this scoped `File`.
+        let mut file = unsafe { std::fs::File::from_raw_fd(duplicated_fd) };
+        unwrap_ok(file.write_all(payload));
+    }
+
+    fn unwrap_ok<T, E: Debug>(result: Result<T, E>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(err) => panic!("expected Ok(..), got Err({err:?})"),
+        }
+    }
+
+    fn unwrap_err<T: Debug, E>(result: Result<T, E>) -> E {
+        match result {
+            Ok(value) => panic!("expected Err(..), got Ok({value:?})"),
+            Err(err) => err,
+        }
+    }
+
+    #[test]
+    fn read_stream_reads_pipe_bytes() {
+        let (mut read_end, write_end) = pipe_pair();
+        write_all_to(&write_end, b"chunk");
+        drop(write_end);
+        let mut buffer = [0_u8; 8];
+
+        let read_len = unwrap_ok(read_stream(&mut read_end, &mut buffer));
+
+        assert_eq!(read_len, 5);
+        assert_eq!(buffer.get(..read_len), Some(&b"chunk"[..]));
+    }
+
+    #[test]
+    fn read_stream_reports_unreadable_descriptor() {
+        let (_read_end, mut write_end) = pipe_pair();
+        let mut buffer = [0_u8; 8];
+
+        let err = unwrap_err(read_stream(&mut write_end, &mut buffer));
+
+        assert!(matches!(err, PumpError::Io(_)));
+    }
+
+    #[test]
+    fn read_raw_fd_reports_eof() {
+        let (read_end, write_end) = pipe_pair();
+        drop(write_end);
+        let mut buffer = [0_u8; 8];
+
+        let read_len = unwrap_ok(read_raw_fd(read_end.as_raw_fd(), &mut buffer));
+
+        assert_eq!(read_len, 0);
+    }
+
+    #[test]
+    fn read_raw_fd_retries_after_interruption() {
+        let mut attempts = 0_u8;
+
+        let read_len = unwrap_ok(read_raw_fd_with(|| {
+            attempts = attempts.saturating_add(1);
+            if attempts == 1 {
+                return Err(io::Error::from(io::ErrorKind::Interrupted));
+            }
+            Ok(0)
+        }));
+
+        assert_eq!(read_len, 0);
+        assert_eq!(attempts, 2);
+    }
+
+    #[test]
+    fn handle_write_returns_complete_outcome() {
+        let (read_end, mut write_end) = pipe_pair();
+
+        let outcome = unwrap_ok(handle_write(&mut write_end, b"chunk"));
+
+        assert_eq!(outcome, WriteOutcome::Complete(5));
+        drop(read_end);
+    }
+
+    #[test]
+    fn handle_write_reports_unwritable_descriptor() {
+        let (mut read_end, _write_end) = pipe_pair();
+
+        let err = unwrap_err(handle_write(&mut read_end, b"chunk"));
+
+        assert!(matches!(err, PumpError::Io(_)));
+    }
+
+    #[test]
+    fn handle_write_result_updates_total_on_success() {
+        let (read_end, mut write_end) = pipe_pair();
+        let mut total_written = 7_u64;
+
+        let should_continue = unwrap_ok(handle_write_result(
+            &mut write_end,
+            b"chunk",
+            &mut total_written,
+        ));
+
+        assert!(should_continue);
+        assert_eq!(total_written, 12);
+        drop(read_end);
+    }
+
+    #[test]
+    fn handle_write_result_preserves_total_on_fatal_error() {
+        let (mut read_end, _write_end) = pipe_pair();
+        let mut total_written = 7_u64;
+
+        let err = unwrap_err(handle_write_result(
+            &mut read_end,
+            b"chunk",
+            &mut total_written,
+        ));
+
+        assert!(matches!(err, PumpError::Io(_)));
+        assert_eq!(total_written, 7);
+    }
+
+    #[test]
+    fn nonfatal_short_write_records_accepted_bytes() {
+        let outcome = unwrap_ok(map_short_write_error(
+            io::Error::from(io::ErrorKind::BrokenPipe),
+            3,
+        ));
+
+        assert_eq!(outcome, WriteOutcome::NonFatalShortWrite(3));
+    }
+
+    #[test]
+    fn fatal_short_write_errors_propagate() {
+        let err = unwrap_err(map_short_write_error(
+            io::Error::from(io::ErrorKind::PermissionDenied),
+            3,
+        ));
+
+        assert!(matches!(err, PumpError::Io(_)));
+    }
 }

--- a/rust/cuprum-rust/src/io_utils.rs
+++ b/rust/cuprum-rust/src/io_utils.rs
@@ -24,6 +24,11 @@ pub(crate) type StreamHandle = OwnedFd;
 #[cfg(windows)]
 pub(crate) type StreamHandle = File;
 
+pub(crate) enum WriteOutcome {
+    Complete(u64),
+    NonFatalShortWrite(u64),
+}
+
 /// Read bytes from the stream into the buffer.
 pub(crate) fn read_stream(
     reader: &mut StreamHandle,
@@ -40,15 +45,18 @@ pub(crate) fn read_stream(
     }
 }
 
-/// Write all bytes from a chunk to the writer, returning bytes written.
-pub(crate) fn handle_write(writer: &mut StreamHandle, chunk: &[u8]) -> Result<u64, PumpError> {
+/// Write all bytes from a chunk to the writer, returning the write outcome.
+pub(crate) fn handle_write(
+    writer: &mut StreamHandle,
+    chunk: &[u8],
+) -> Result<WriteOutcome, PumpError> {
     #[cfg(unix)]
-    write_all_unix(writer, chunk)?;
+    let outcome = write_all_unix(writer, chunk)?;
 
     #[cfg(windows)]
-    writer.write_all(chunk).map_err(PumpError::from)?;
+    let outcome = write_all_windows(writer, chunk)?;
 
-    u64::try_from(chunk.len()).map_err(|_| PumpError::LengthOverflow)
+    Ok(outcome)
 }
 
 /// Attempt to write a chunk and update the total written count.
@@ -62,9 +70,13 @@ pub(crate) fn handle_write_result(
     total_written: &mut u64,
 ) -> Result<bool, PumpError> {
     match handle_write(writer, chunk) {
-        Ok(bytes) => {
+        Ok(WriteOutcome::Complete(bytes)) => {
             *total_written = total_written.saturating_add(bytes);
             Ok(true)
+        }
+        Ok(WriteOutcome::NonFatalShortWrite(bytes)) => {
+            *total_written = total_written.saturating_add(bytes);
+            Ok(false)
         }
         Err(err) => {
             if err.is_nonfatal_write() {
@@ -107,7 +119,9 @@ pub(crate) fn read_raw_fd(fd: libc::c_int, buffer: &mut [u8]) -> Result<usize, P
 }
 
 #[cfg(unix)]
-fn write_all_unix(writer: &StreamHandle, mut chunk: &[u8]) -> Result<(), PumpError> {
+fn write_all_unix(writer: &StreamHandle, mut chunk: &[u8]) -> Result<WriteOutcome, PumpError> {
+    let mut total_written = 0_u64;
+
     while !chunk.is_empty() {
         // SAFETY: `chunk` is valid for reads of `chunk.len()` bytes, and
         // `writer` owns a valid descriptor for the duration of this call.
@@ -121,9 +135,7 @@ fn write_all_unix(writer: &StreamHandle, mut chunk: &[u8]) -> Result<(), PumpErr
 
         if written > 0 {
             let written_len = usize::try_from(written).map_err(|_| PumpError::LengthOverflow)?;
-            chunk = chunk
-                .get(written_len..)
-                .ok_or(PumpError::BufferRangeExceeded)?;
+            record_write_progress(&mut chunk, written_len, &mut total_written)?;
             continue;
         }
 
@@ -136,9 +148,58 @@ fn write_all_unix(writer: &StreamHandle, mut chunk: &[u8]) -> Result<(), PumpErr
 
         let err = io::Error::last_os_error();
         if err.kind() != io::ErrorKind::Interrupted {
-            return Err(PumpError::from(err));
+            return map_short_write_error(err, total_written);
         }
     }
 
+    Ok(WriteOutcome::Complete(total_written))
+}
+
+#[cfg(windows)]
+fn write_all_windows(
+    writer: &mut StreamHandle,
+    mut chunk: &[u8],
+) -> Result<WriteOutcome, PumpError> {
+    let mut total_written = 0_u64;
+
+    while !chunk.is_empty() {
+        match writer.write(chunk) {
+            Ok(0) => {
+                return Err(PumpError::from(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write whole buffer",
+                )));
+            }
+            Ok(written_len) => {
+                record_write_progress(&mut chunk, written_len, &mut total_written)?;
+            }
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+            Err(err) => {
+                return map_short_write_error(err, total_written);
+            }
+        }
+    }
+
+    Ok(WriteOutcome::Complete(total_written))
+}
+
+fn record_write_progress(
+    chunk: &mut &[u8],
+    written_len: usize,
+    total_written: &mut u64,
+) -> Result<(), PumpError> {
+    let written_len_u64 = u64::try_from(written_len).map_err(|_| PumpError::LengthOverflow)?;
+    *total_written = total_written.saturating_add(written_len_u64);
+    *chunk = chunk
+        .get(written_len..)
+        .ok_or(PumpError::BufferRangeExceeded)?;
     Ok(())
+}
+
+fn map_short_write_error(err: io::Error, total_written: u64) -> Result<WriteOutcome, PumpError> {
+    let pump_error = PumpError::from(err);
+    if pump_error.is_nonfatal_write() {
+        return Ok(WriteOutcome::NonFatalShortWrite(total_written));
+    }
+    Err(pump_error)
 }

--- a/rust/cuprum-rust/src/io_utils.rs
+++ b/rust/cuprum-rust/src/io_utils.rs
@@ -78,16 +78,22 @@ pub(crate) fn handle_write_result(
 
 #[cfg(unix)]
 fn read_stream_unix(reader: &StreamHandle, buffer: &mut [u8]) -> Result<usize, PumpError> {
+    read_raw_fd(reader.as_raw_fd(), buffer)
+}
+
+/// Read from a raw descriptor, retrying on `EINTR`.
+///
+/// This is the canonical Unix read policy shared by the stream read path and
+/// the splice drain: interrupted reads retry, end of file returns zero, and
+/// every other error propagates.
+#[cfg(unix)]
+pub(crate) fn read_raw_fd(fd: libc::c_int, buffer: &mut [u8]) -> Result<usize, PumpError> {
     loop {
         // SAFETY: `buffer` is valid for writes of `buffer.len()` bytes, and
-        // `reader` owns a valid descriptor for the duration of this call.
-        let read_len = unsafe {
-            libc::read(
-                reader.as_raw_fd(),
-                buffer.as_mut_ptr().cast::<libc::c_void>(),
-                buffer.len(),
-            )
-        };
+        // the caller guarantees `fd` stays valid for the duration of this
+        // call.
+        let read_len =
+            unsafe { libc::read(fd, buffer.as_mut_ptr().cast::<libc::c_void>(), buffer.len()) };
 
         if read_len >= 0 {
             return usize::try_from(read_len).map_err(|_| PumpError::LengthOverflow);

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -25,6 +25,8 @@ mod io_utils;
 mod lib_tests;
 #[cfg(target_os = "linux")]
 mod splice;
+#[cfg(all(test, unix))]
+mod test_support;
 mod utf8;
 
 use errors::PumpError;

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -93,14 +93,13 @@ fn rust_consume_stream(py: Python<'_>, reader_fd: i64, buffer_size: i64) -> PyRe
 
 #[cfg(unix)]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {
-    let fd =
-        i32::try_from(value).map_err(|_| PyValueError::new_err("file descriptor out of range"))?;
-    if fd < 0 {
-        return Err(PyValueError::new_err(
-            "file descriptor must be non-negative",
-        ));
+    // Reject negative handles for symmetry with the Unix arm: Python hands
+    // over non-negative handle values, and reinterpreting a negative i64 as
+    // a pointer-sized handle would silently address nonsense.
+    if value < 0 {
+        return Err(PyValueError::new_err("file handle must be non-negative"));
     }
-    Ok(fd)
+    usize::try_from(value).map_err(|_| PyValueError::new_err("file handle out of range"))
 }
 
 #[cfg(windows)]
@@ -130,9 +129,12 @@ fn validate_buffer_size(buffer_size: i64) -> PyResult<BufferSize> {
 }
 
 #[cfg(unix)]
-fn stream_from_raw(fd: PlatformFd) -> StreamHandle {
-    // SAFETY: The caller ensures the fd is valid and owned by the caller.
-    unsafe { OwnedFd::from_raw_fd(fd) }
+fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
+    // The usize-to-pointer cast is a deliberate, documented reinterpretation:
+    // Windows handles are pointer-sized opaque values, so this widens or
+    // narrows nothing.
+    // SAFETY: The caller ensures the handle is valid and owned by the caller.
+    unsafe { File::from_raw_handle(handle as RawHandle) }
 }
 
 /// Run `operation` against a `StreamHandle` borrowed from a caller-owned FD.
@@ -190,7 +192,7 @@ fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String
 }
 
 #[cfg(unix)]
-type PlatformFd = i32;
+type PlatformFd = usize;
 
 #[cfg(windows)]
 type PlatformFd = usize;
@@ -352,8 +354,16 @@ mod tests {
 
         {
             // SAFETY: duplicating an owned descriptor for a scoped writer.
-            let mut writer =
-                unsafe { std::fs::File::from_raw_fd(libc::dup(write_end.as_raw_fd())) };
+            let duplicated_fd = unsafe { libc::dup(write_end.as_raw_fd()) };
+            assert_ne!(
+                duplicated_fd,
+                -1,
+                "dup(2) failed: {}",
+                io::Error::last_os_error(),
+            );
+            // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above
+            // and is now owned by this scoped `File`.
+            let mut writer = unsafe { std::fs::File::from_raw_fd(duplicated_fd) };
             match writer.write_all(b"ping") {
                 Ok(()) => {}
                 Err(err) => panic!("pipe write failed: {err}"),

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -17,7 +17,12 @@ use std::fs::File;
 #[cfg(windows)]
 use std::os::windows::io::{FromRawHandle, RawHandle};
 
+mod errors;
+#[cfg(test)]
+mod fd_tests;
 mod io_utils;
+#[cfg(all(test, unix))]
+mod lib_tests;
 #[cfg(target_os = "linux")]
 mod splice;
 mod utf8;
@@ -93,26 +98,33 @@ fn rust_consume_stream(py: Python<'_>, reader_fd: i64, buffer_size: i64) -> PyRe
 
 #[cfg(unix)]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {
+    convert_platform_fd(value).map_err(PyValueError::new_err)
+}
+
+#[cfg(unix)]
+fn convert_platform_fd(value: i64) -> Result<PlatformFd, &'static str> {
+    let fd = i32::try_from(value).map_err(|_| "file descriptor out of range")?;
+    if fd < 0 {
+        return Err("file descriptor must be non-negative");
+    }
+    Ok(fd)
+}
+
+#[cfg(windows)]
+fn convert_platform_fd(value: i64) -> Result<PlatformFd, &'static str> {
     // Reject negative handles for symmetry with the Unix arm: Python hands
     // over non-negative handle values, and reinterpreting a negative i64 as
     // a pointer-sized handle would silently address nonsense.
     if value < 0 {
-        return Err(PyValueError::new_err("file handle must be non-negative"));
+        return Err("file handle must be non-negative");
     }
-    usize::try_from(value).map_err(|_| PyValueError::new_err("file handle out of range"))
+    usize::try_from(value).map_err(|_| "file handle out of range")
 }
 
 #[cfg(windows)]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {
-    // Reject negative handles for symmetry with the Unix arm: Python hands
-    // over non-negative handle values, and reinterpreting a negative i64 as
-    // a pointer-sized handle would silently address nonsense.
-    if value < 0 {
-        return Err(PyValueError::new_err("file handle must be non-negative"));
-    }
-    usize::try_from(value).map_err(|_| PyValueError::new_err("file handle out of range"))
+    convert_platform_fd(value).map_err(PyValueError::new_err)
 }
-
 /// Validate that `buffer_size` is positive and fits into a usize.
 ///
 /// # Errors
@@ -129,12 +141,9 @@ fn validate_buffer_size(buffer_size: i64) -> PyResult<BufferSize> {
 }
 
 #[cfg(unix)]
-fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
-    // The usize-to-pointer cast is a deliberate, documented reinterpretation:
-    // Windows handles are pointer-sized opaque values, so this widens or
-    // narrows nothing.
-    // SAFETY: The caller ensures the handle is valid and owned by the caller.
-    unsafe { File::from_raw_handle(handle as RawHandle) }
+fn stream_from_raw(fd: PlatformFd) -> StreamHandle {
+    // SAFETY: The caller ensures the fd is valid and owned by the caller.
+    unsafe { OwnedFd::from_raw_fd(fd) }
 }
 
 /// Run `operation` against a `StreamHandle` borrowed from a caller-owned FD.
@@ -192,7 +201,7 @@ fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String
 }
 
 #[cfg(unix)]
-type PlatformFd = usize;
+type PlatformFd = i32;
 
 #[cfg(windows)]
 type PlatformFd = usize;
@@ -298,95 +307,3 @@ fn _rust_backend_native(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResul
     module.add("__loader__", py.None())?;
     Ok(())
 }
-
-mod tests {
-    //! Unit tests for the borrowed-FD ownership contract: the caller-owned
-    //! reader descriptor stays open after normal completion and — critically
-    //! — after a panicking inner operation (no close-on-unwind).
-
-    use std::io::{self, Read, Write};
-    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
-    use std::panic::{AssertUnwindSafe, catch_unwind};
-
-    use super::with_borrowed_reader;
-
-    fn make_pipe() -> (OwnedFd, OwnedFd) {
-        let mut fds = [0_i32; 2];
-        // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
-        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
-        assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
-        // SAFETY: on success `pipe(2)` returned two freshly opened FDs that
-        // this process exclusively owns.
-        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
-    }
-
-    fn fd_is_open(fd: i32) -> bool {
-        // SAFETY: F_GETFD on an arbitrary integer is safe; it reports EBADF
-        // for descriptors that are not open.
-        unsafe { libc::fcntl(fd, libc::F_GETFD) != -1 }
-    }
-
-    #[test]
-    fn borrowed_reader_stays_open_after_panicking_operation() {
-        let (read_end, _write_end) = make_pipe();
-        let raw_fd = read_end.as_raw_fd();
-
-        let outcome = catch_unwind(AssertUnwindSafe(|| {
-            with_borrowed_reader(raw_fd, |_reader| -> () {
-                panic!("simulated failure inside the borrowed scope");
-            });
-        }));
-
-        assert!(outcome.is_err(), "the panic must propagate to the caller");
-        assert!(
-            fd_is_open(raw_fd),
-            "a panicking operation must not close the caller-owned FD",
-        );
-        // `read_end` now drops and closes the FD exactly once, proving the
-        // guard did not already close it (a double close would surface as
-        // EBADF under stricter runtimes).
-    }
-
-    #[test]
-    fn borrowed_reader_stays_open_and_usable_after_success() {
-        let (read_end, write_end) = make_pipe();
-        let raw_fd = read_end.as_raw_fd();
-
-        {
-            // SAFETY: duplicating an owned descriptor for a scoped writer.
-            let duplicated_fd = unsafe { libc::dup(write_end.as_raw_fd()) };
-            assert_ne!(
-                duplicated_fd,
-                -1,
-                "dup(2) failed: {}",
-                io::Error::last_os_error(),
-            );
-            // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above
-            // and is now owned by this scoped `File`.
-            let mut writer = unsafe { std::fs::File::from_raw_fd(duplicated_fd) };
-            match writer.write_all(b"ping") {
-                Ok(()) => {}
-                Err(err) => panic!("pipe write failed: {err}"),
-            }
-        }
-        drop(write_end);
-
-        let collected = with_borrowed_reader(raw_fd, |reader| {
-            // SAFETY: reading through the borrowed handle's raw descriptor.
-            let mut file = unsafe {
-                std::mem::ManuallyDrop::new(std::fs::File::from_raw_fd(reader.as_raw_fd()))
-            };
-            let mut data = Vec::new();
-            match file.read_to_end(&mut data) {
-                Ok(_) => {}
-                Err(err) => panic!("pipe read failed: {err}"),
-            }
-            data
-        });
-
-        assert_eq!(collected, b"ping");
-        assert!(fd_is_open(raw_fd), "the borrowed FD must remain open");
-    }
-}
-
-mod errors;

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -93,24 +93,25 @@ fn rust_consume_stream(py: Python<'_>, reader_fd: i64, buffer_size: i64) -> PyRe
 
 #[cfg(unix)]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {
-    let handle_value = value as u64;
-    if usize::BITS >= 64 {
-        return Ok(handle_value as usize);
+    let fd =
+        i32::try_from(value).map_err(|_| PyValueError::new_err("file descriptor out of range"))?;
+    if fd < 0 {
+        return Err(PyValueError::new_err(
+            "file descriptor must be non-negative",
+        ));
     }
-    let truncated = u32::try_from(handle_value)
-        .map_err(|_| PyValueError::new_err("file handle out of range"))?;
-    Ok(truncated as usize)
+    Ok(fd)
 }
 
 #[cfg(windows)]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {
-    let handle_value = value as u64;
-    if usize::BITS >= 64 {
-        return Ok(handle_value as usize);
+    // Reject negative handles for symmetry with the Unix arm: Python hands
+    // over non-negative handle values, and reinterpreting a negative i64 as
+    // a pointer-sized handle would silently address nonsense.
+    if value < 0 {
+        return Err(PyValueError::new_err("file handle must be non-negative"));
     }
-    let truncated = u32::try_from(handle_value)
-        .map_err(|_| PyValueError::new_err("file handle out of range"))?;
-    Ok(truncated as usize)
+    usize::try_from(value).map_err(|_| PyValueError::new_err("file handle out of range"))
 }
 
 /// Validate that `buffer_size` is positive and fits into a usize.
@@ -129,9 +130,9 @@ fn validate_buffer_size(buffer_size: i64) -> PyResult<BufferSize> {
 }
 
 #[cfg(unix)]
-fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
-    // SAFETY: The caller ensures the handle is valid and owned by the caller.
-    unsafe { File::from_raw_handle(handle as RawHandle) }
+fn stream_from_raw(fd: PlatformFd) -> StreamHandle {
+    // SAFETY: The caller ensures the fd is valid and owned by the caller.
+    unsafe { OwnedFd::from_raw_fd(fd) }
 }
 
 /// Run `operation` against a `StreamHandle` borrowed from a caller-owned FD.
@@ -159,6 +160,9 @@ fn with_borrowed_reader<T>(fd: PlatformFd, operation: impl FnOnce(&mut StreamHan
 
 #[cfg(windows)]
 fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
+    // The usize-to-pointer cast is a deliberate, documented reinterpretation:
+    // Windows handles are pointer-sized opaque values, so this widens or
+    // narrows nothing.
     // SAFETY: The caller ensures the handle is valid and owned by the caller.
     unsafe { File::from_raw_handle(handle as RawHandle) }
 }
@@ -186,7 +190,7 @@ fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String
 }
 
 #[cfg(unix)]
-type PlatformFd = usize;
+type PlatformFd = i32;
 
 #[cfg(windows)]
 type PlatformFd = usize;

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -6,6 +6,8 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
+use std::mem::ManuallyDrop;
+
 #[cfg(unix)]
 use std::os::fd::{FromRawFd, OwnedFd};
 
@@ -91,14 +93,13 @@ fn rust_consume_stream(py: Python<'_>, reader_fd: i64, buffer_size: i64) -> PyRe
 
 #[cfg(unix)]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {
-    let fd =
-        i32::try_from(value).map_err(|_| PyValueError::new_err("file descriptor out of range"))?;
-    if fd < 0 {
-        return Err(PyValueError::new_err(
-            "file descriptor must be non-negative",
-        ));
+    let handle_value = value as u64;
+    if usize::BITS >= 64 {
+        return Ok(handle_value as usize);
     }
-    Ok(fd)
+    let truncated = u32::try_from(handle_value)
+        .map_err(|_| PyValueError::new_err("file handle out of range"))?;
+    Ok(truncated as usize)
 }
 
 #[cfg(windows)]
@@ -128,9 +129,32 @@ fn validate_buffer_size(buffer_size: i64) -> PyResult<BufferSize> {
 }
 
 #[cfg(unix)]
-fn stream_from_raw(fd: PlatformFd) -> StreamHandle {
-    // SAFETY: The caller ensures the fd is valid and owned by the caller.
-    unsafe { OwnedFd::from_raw_fd(fd) }
+fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
+    // SAFETY: The caller ensures the handle is valid and owned by the caller.
+    unsafe { File::from_raw_handle(handle as RawHandle) }
+}
+
+/// Run `operation` against a `StreamHandle` borrowed from a caller-owned FD.
+///
+/// This is the canonical "borrow this FD without owning it" helper: the
+/// handle is wrapped in [`ManuallyDrop`], so it is **never** closed when the
+/// scope ends — including during unwinding from a panicking `operation`.
+/// The previous pattern (a trailing `std::mem::forget` after the inner call)
+/// was skipped on unwind, closing the caller-owned descriptor and exposing
+/// the Python side to a double close.
+///
+/// There is deliberately no writer variant: the writer FD handed to
+/// [`pump_stream`] is *consumed* — it must close (on drop, including during
+/// unwinding) to signal EOF downstream.
+///
+/// SAFETY: the caller must guarantee that `fd` is a valid open descriptor
+/// (or handle on Windows) for the duration of the call, and that ownership
+/// remains with the caller; the helper guarantees it never closes `fd`.
+fn with_borrowed_reader<T>(fd: PlatformFd, operation: impl FnOnce(&mut StreamHandle) -> T) -> T {
+    let mut handle = ManuallyDrop::new(stream_from_raw(fd));
+    // `ManuallyDrop` suppresses the close in every exit path, so no
+    // drop-guard or forget call is required even if `operation` panics.
+    operation(&mut handle)
 }
 
 #[cfg(windows)]
@@ -138,36 +162,31 @@ fn stream_from_raw(handle: PlatformFd) -> StreamHandle {
     // SAFETY: The caller ensures the handle is valid and owned by the caller.
     unsafe { File::from_raw_handle(handle as RawHandle) }
 }
-
 /// Pump bytes between file descriptors with explicit ownership semantics.
 ///
 /// The reader FD is borrowed and left open. The writer FD is treated as
-/// consumed and closes on drop to signal EOF downstream.
+/// consumed and closes on drop to signal EOF downstream — including when
+/// the pump unwinds.
 fn pump_stream(
     reader_fd: ReaderFd,
     writer_fd: WriterFd,
     buffer_size: BufferSize,
 ) -> Result<u64, PumpError> {
-    let mut reader = stream_from_raw(reader_fd.0);
     let mut writer = stream_from_raw(writer_fd.0);
-    let result = pump_stream_files(&mut reader, &mut writer, buffer_size);
-    // The caller owns the reader FD; avoid closing it here.
-    // The writer FD is treated as consumed and closes on drop to signal EOF.
-    std::mem::forget(reader);
-    result
+    with_borrowed_reader(reader_fd.0, |reader| {
+        pump_stream_files(reader, &mut writer, buffer_size)
+    })
 }
 
 /// Consume bytes from a file descriptor and decode UTF-8 with replacement.
 fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String, PumpError> {
-    let mut reader = stream_from_raw(reader_fd.0);
-    let result = consume_stream_files(&mut reader, buffer_size);
-    // The caller owns the reader FD; avoid closing it here.
-    std::mem::forget(reader);
-    result
+    with_borrowed_reader(reader_fd.0, |reader| {
+        consume_stream_files(reader, buffer_size)
+    })
 }
 
 #[cfg(unix)]
-type PlatformFd = i32;
+type PlatformFd = usize;
 
 #[cfg(windows)]
 type PlatformFd = usize;
@@ -272,6 +291,88 @@ fn _rust_backend_native(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResul
     module.add("__package__", "cuprum")?;
     module.add("__loader__", py.None())?;
     Ok(())
+}
+
+mod tests {
+    //! Unit tests for the borrowed-FD ownership contract: the caller-owned
+    //! reader descriptor stays open after normal completion and — critically
+    //! — after a panicking inner operation (no close-on-unwind).
+
+    use std::io::{self, Read, Write};
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use super::with_borrowed_reader;
+
+    fn make_pipe() -> (OwnedFd, OwnedFd) {
+        let mut fds = [0_i32; 2];
+        // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
+        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
+        // SAFETY: on success `pipe(2)` returned two freshly opened FDs that
+        // this process exclusively owns.
+        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+    }
+
+    fn fd_is_open(fd: i32) -> bool {
+        // SAFETY: F_GETFD on an arbitrary integer is safe; it reports EBADF
+        // for descriptors that are not open.
+        unsafe { libc::fcntl(fd, libc::F_GETFD) != -1 }
+    }
+
+    #[test]
+    fn borrowed_reader_stays_open_after_panicking_operation() {
+        let (read_end, _write_end) = make_pipe();
+        let raw_fd = read_end.as_raw_fd();
+
+        let outcome = catch_unwind(AssertUnwindSafe(|| {
+            with_borrowed_reader(raw_fd, |_reader| -> () {
+                panic!("simulated failure inside the borrowed scope");
+            });
+        }));
+
+        assert!(outcome.is_err(), "the panic must propagate to the caller");
+        assert!(
+            fd_is_open(raw_fd),
+            "a panicking operation must not close the caller-owned FD",
+        );
+        // `read_end` now drops and closes the FD exactly once, proving the
+        // guard did not already close it (a double close would surface as
+        // EBADF under stricter runtimes).
+    }
+
+    #[test]
+    fn borrowed_reader_stays_open_and_usable_after_success() {
+        let (read_end, write_end) = make_pipe();
+        let raw_fd = read_end.as_raw_fd();
+
+        {
+            // SAFETY: duplicating an owned descriptor for a scoped writer.
+            let mut writer =
+                unsafe { std::fs::File::from_raw_fd(libc::dup(write_end.as_raw_fd())) };
+            match writer.write_all(b"ping") {
+                Ok(()) => {}
+                Err(err) => panic!("pipe write failed: {err}"),
+            }
+        }
+        drop(write_end);
+
+        let collected = with_borrowed_reader(raw_fd, |reader| {
+            // SAFETY: reading through the borrowed handle's raw descriptor.
+            let mut file = unsafe {
+                std::mem::ManuallyDrop::new(std::fs::File::from_raw_fd(reader.as_raw_fd()))
+            };
+            let mut data = Vec::new();
+            match file.read_to_end(&mut data) {
+                Ok(_) => {}
+                Err(err) => panic!("pipe read failed: {err}"),
+            }
+            data
+        });
+
+        assert_eq!(collected, b"ping");
+        assert!(fd_is_open(raw_fd), "the borrowed FD must remain open");
+    }
 }
 
 mod errors;

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -3,8 +3,6 @@
 //! This crate exposes a `PyO3` module providing stream pump and consume
 //! helpers alongside an availability check for the Rust backend.
 
-use std::io;
-
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -22,6 +20,7 @@ mod io_utils;
 mod splice;
 mod utf8;
 
+use errors::PumpError;
 use io_utils::{StreamHandle, handle_write_result, read_stream};
 use utf8::{FinalChunk, decode_utf8_replace};
 
@@ -148,7 +147,7 @@ fn pump_stream(
     reader_fd: ReaderFd,
     writer_fd: WriterFd,
     buffer_size: BufferSize,
-) -> Result<u64, io::Error> {
+) -> Result<u64, PumpError> {
     let mut reader = stream_from_raw(reader_fd.0);
     let mut writer = stream_from_raw(writer_fd.0);
     let result = pump_stream_files(&mut reader, &mut writer, buffer_size);
@@ -159,7 +158,7 @@ fn pump_stream(
 }
 
 /// Consume bytes from a file descriptor and decode UTF-8 with replacement.
-fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String, io::Error> {
+fn consume_stream(reader_fd: ReaderFd, buffer_size: BufferSize) -> Result<String, PumpError> {
     let mut reader = stream_from_raw(reader_fd.0);
     let result = consume_stream_files(&mut reader, buffer_size);
     // The caller owns the reader FD; avoid closing it here.
@@ -192,7 +191,7 @@ fn pump_stream_files(
     reader: &mut StreamHandle,
     writer: &mut StreamHandle,
     buffer_size: BufferSize,
-) -> Result<u64, io::Error> {
+) -> Result<u64, PumpError> {
     // On Linux, attempt zero-copy splice first.
     #[cfg(target_os = "linux")]
     if let Some(result) = splice::try_splice_pump(reader, writer, buffer_size.value()) {
@@ -211,7 +210,7 @@ fn pump_stream_files_readwrite(
     reader: &mut StreamHandle,
     writer: &mut StreamHandle,
     buffer_size: BufferSize,
-) -> Result<u64, io::Error> {
+) -> Result<u64, PumpError> {
     let mut buffer = vec![0_u8; buffer_size.value()];
     let mut total_written = 0_u64;
     let mut writer_open = true;
@@ -227,7 +226,7 @@ fn pump_stream_files_readwrite(
 
         let chunk = buffer
             .get(..read_len)
-            .ok_or_else(|| io::Error::other("read length exceeded buffer"))?;
+            .ok_or(PumpError::BufferRangeExceeded)?;
 
         writer_open = handle_write_result(writer, chunk, &mut total_written)?;
     }
@@ -238,7 +237,7 @@ fn pump_stream_files_readwrite(
 fn consume_stream_files(
     reader: &mut StreamHandle,
     buffer_size: BufferSize,
-) -> Result<String, io::Error> {
+) -> Result<String, PumpError> {
     let mut buffer = vec![0_u8; buffer_size.value()];
     let mut pending: Vec<u8> = Vec::new();
     let mut output = String::new();
@@ -250,7 +249,7 @@ fn consume_stream_files(
         }
         let chunk = buffer
             .get(..read_len)
-            .ok_or_else(|| io::Error::other("read length exceeded buffer"))?;
+            .ok_or(PumpError::BufferRangeExceeded)?;
         pending.extend_from_slice(chunk);
         decode_utf8_replace(&mut pending, &mut output, FinalChunk::new(false));
     }
@@ -274,3 +273,5 @@ fn _rust_backend_native(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResul
     module.add("__loader__", py.None())?;
     Ok(())
 }
+
+mod errors;

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -5,6 +5,18 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use crate::with_borrowed_reader;
+use rstest::{fixture, rstest};
+
+struct BorrowedReaderPipe {
+    read_end: OwnedFd,
+    write_end: OwnedFd,
+    raw_fd: i32,
+}
+
+enum BorrowedReaderScenario {
+    Panic,
+    Success,
+}
 
 fn make_pipe() -> (OwnedFd, OwnedFd) {
     let mut fds = [0_i32; 2];
@@ -17,16 +29,57 @@ fn make_pipe() -> (OwnedFd, OwnedFd) {
 }
 
 fn fd_is_open(fd: i32) -> bool {
-    // SAFETY: F_GETFD on an arbitrary integer is safe; it reports EBADF for
-    // descriptors that are not open.
-    unsafe { libc::fcntl(fd, libc::F_GETFD) != -1 }
+    loop {
+        // SAFETY: F_GETFD on an arbitrary integer is safe; it reports EBADF
+        // for descriptors that are not open.
+        let result = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if result != -1 {
+            return true;
+        }
+
+        if io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
+            return false;
+        }
+    }
 }
 
-#[test]
-fn borrowed_reader_stays_open_after_panicking_operation() {
-    let (read_end, _write_end) = make_pipe();
+#[fixture]
+fn borrowed_reader_pipe() -> BorrowedReaderPipe {
+    let (read_end, write_end) = make_pipe();
     let raw_fd = read_end.as_raw_fd();
 
+    BorrowedReaderPipe {
+        read_end,
+        write_end,
+        raw_fd,
+    }
+}
+
+#[rstest]
+#[case::panicking_operation(BorrowedReaderScenario::Panic)]
+#[case::successful_operation(BorrowedReaderScenario::Success)]
+fn borrowed_reader_stays_open_after_operation(
+    borrowed_reader_pipe: BorrowedReaderPipe,
+    #[case] scenario: BorrowedReaderScenario,
+) {
+    let BorrowedReaderPipe {
+        read_end,
+        write_end,
+        raw_fd,
+    } = borrowed_reader_pipe;
+
+    match scenario {
+        BorrowedReaderScenario::Panic => assert_panicking_reader_keeps_fd_open(raw_fd),
+        BorrowedReaderScenario::Success => {
+            assert_successful_reader_keeps_fd_usable(raw_fd, write_end);
+        }
+    }
+
+    assert!(fd_is_open(raw_fd), "the borrowed FD must remain open");
+    drop(read_end);
+}
+
+fn assert_panicking_reader_keeps_fd_open(raw_fd: i32) {
     let outcome = catch_unwind(AssertUnwindSafe(|| {
         with_borrowed_reader(raw_fd, |_reader| -> () {
             panic!("simulated failure inside the borrowed scope");
@@ -34,20 +87,9 @@ fn borrowed_reader_stays_open_after_panicking_operation() {
     }));
 
     assert!(outcome.is_err(), "the panic must propagate to the caller");
-    assert!(
-        fd_is_open(raw_fd),
-        "a panicking operation must not close the caller-owned FD",
-    );
-    // `read_end` now drops and closes the FD exactly once, proving the guard
-    // did not already close it (a double close would surface as EBADF under
-    // stricter runtimes).
 }
 
-#[test]
-fn borrowed_reader_stays_open_and_usable_after_success() {
-    let (read_end, write_end) = make_pipe();
-    let raw_fd = read_end.as_raw_fd();
-
+fn assert_successful_reader_keeps_fd_usable(raw_fd: i32, write_end: OwnedFd) {
     {
         // SAFETY: duplicating an owned descriptor for a scoped writer.
         let duplicated_fd = unsafe { libc::dup(write_end.as_raw_fd()) };
@@ -80,5 +122,4 @@ fn borrowed_reader_stays_open_and_usable_after_success() {
     });
 
     assert_eq!(collected, b"ping");
-    assert!(fd_is_open(raw_fd), "the borrowed FD must remain open");
 }

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -1,9 +1,10 @@
 //! Tests for the borrowed file-descriptor ownership contract.
 
-use std::io::{self, Read, Write};
+use std::io::Read;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
+use crate::test_support::{fd_is_open, make_pipe, write_all_to};
 use crate::with_borrowed_reader;
 use rstest::{fixture, rstest};
 
@@ -16,31 +17,6 @@ struct BorrowedReaderPipe {
 enum BorrowedReaderScenario {
     Panic,
     Success,
-}
-
-fn make_pipe() -> (OwnedFd, OwnedFd) {
-    let mut fds = [0_i32; 2];
-    // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
-    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
-    assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
-    // SAFETY: on success `pipe(2)` returned two freshly opened FDs that this
-    // process exclusively owns.
-    unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
-}
-
-fn fd_is_open(fd: i32) -> bool {
-    loop {
-        // SAFETY: F_GETFD on an arbitrary integer is safe; it reports EBADF
-        // for descriptors that are not open.
-        let result = unsafe { libc::fcntl(fd, libc::F_GETFD) };
-        if result != -1 {
-            return true;
-        }
-
-        if io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
-            return false;
-        }
-    }
 }
 
 #[fixture]
@@ -90,23 +66,7 @@ fn assert_panicking_reader_keeps_fd_open(raw_fd: i32) {
 }
 
 fn assert_successful_reader_keeps_fd_usable(raw_fd: i32, write_end: OwnedFd) {
-    {
-        // SAFETY: duplicating an owned descriptor for a scoped writer.
-        let duplicated_fd = unsafe { libc::dup(write_end.as_raw_fd()) };
-        assert_ne!(
-            duplicated_fd,
-            -1,
-            "dup(2) failed: {}",
-            io::Error::last_os_error(),
-        );
-        // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and
-        // is now owned by this scoped `File`.
-        let mut writer = unsafe { std::fs::File::from_raw_fd(duplicated_fd) };
-        match writer.write_all(b"ping") {
-            Ok(()) => {}
-            Err(err) => panic!("pipe write failed: {err}"),
-        }
-    }
+    write_all_to(&write_end, b"ping");
     drop(write_end);
 
     let collected = with_borrowed_reader(raw_fd, |reader| {

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -1,0 +1,84 @@
+//! Tests for the borrowed file-descriptor ownership contract.
+
+use std::io::{self, Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use crate::with_borrowed_reader;
+
+fn make_pipe() -> (OwnedFd, OwnedFd) {
+    let mut fds = [0_i32; 2];
+    // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
+    // SAFETY: on success `pipe(2)` returned two freshly opened FDs that this
+    // process exclusively owns.
+    unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+}
+
+fn fd_is_open(fd: i32) -> bool {
+    // SAFETY: F_GETFD on an arbitrary integer is safe; it reports EBADF for
+    // descriptors that are not open.
+    unsafe { libc::fcntl(fd, libc::F_GETFD) != -1 }
+}
+
+#[test]
+fn borrowed_reader_stays_open_after_panicking_operation() {
+    let (read_end, _write_end) = make_pipe();
+    let raw_fd = read_end.as_raw_fd();
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        with_borrowed_reader(raw_fd, |_reader| -> () {
+            panic!("simulated failure inside the borrowed scope");
+        });
+    }));
+
+    assert!(outcome.is_err(), "the panic must propagate to the caller");
+    assert!(
+        fd_is_open(raw_fd),
+        "a panicking operation must not close the caller-owned FD",
+    );
+    // `read_end` now drops and closes the FD exactly once, proving the guard
+    // did not already close it (a double close would surface as EBADF under
+    // stricter runtimes).
+}
+
+#[test]
+fn borrowed_reader_stays_open_and_usable_after_success() {
+    let (read_end, write_end) = make_pipe();
+    let raw_fd = read_end.as_raw_fd();
+
+    {
+        // SAFETY: duplicating an owned descriptor for a scoped writer.
+        let duplicated_fd = unsafe { libc::dup(write_end.as_raw_fd()) };
+        assert_ne!(
+            duplicated_fd,
+            -1,
+            "dup(2) failed: {}",
+            io::Error::last_os_error(),
+        );
+        // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and
+        // is now owned by this scoped `File`.
+        let mut writer = unsafe { std::fs::File::from_raw_fd(duplicated_fd) };
+        match writer.write_all(b"ping") {
+            Ok(()) => {}
+            Err(err) => panic!("pipe write failed: {err}"),
+        }
+    }
+    drop(write_end);
+
+    let collected = with_borrowed_reader(raw_fd, |reader| {
+        // SAFETY: reading through the borrowed handle's raw descriptor.
+        let mut file =
+            unsafe { std::mem::ManuallyDrop::new(std::fs::File::from_raw_fd(reader.as_raw_fd())) };
+        let mut data = Vec::new();
+        match file.read_to_end(&mut data) {
+            Ok(_) => {}
+            Err(err) => panic!("pipe read failed: {err}"),
+        }
+        data
+    });
+
+    assert_eq!(collected, b"ping");
+    assert!(fd_is_open(raw_fd), "the borrowed FD must remain open");
+}

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -160,61 +160,11 @@ mod tests {
     //! drain: full transfer between pipes, fallback signalling for
     //! unsupported descriptor types, and broken-pipe draining.
 
-    use std::fmt::Debug;
     use std::fs::File;
-    use std::io::{self, Read, Write};
-    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::os::fd::{AsRawFd, OwnedFd};
 
     use super::{drain_reader, try_splice_pump};
-
-    fn unwrap_ok<T, E: Debug>(result: Result<T, E>) -> T {
-        match result {
-            Ok(value) => value,
-            Err(err) => panic!("unexpected error: {err:?}"),
-        }
-    }
-
-    fn make_pipe() -> (OwnedFd, OwnedFd) {
-        let mut fds = [0_i32; 2];
-        // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
-        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
-        assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
-        // SAFETY: on success `pipe(2)` returned two freshly opened FDs that
-        // this process exclusively owns.
-        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
-    }
-
-    /// Duplicate `fd` and wrap the duplicate in a scoped [`File`].
-    ///
-    /// The duplicate is owned by the returned [`File`]; the original `fd`
-    /// remains open and unaffected.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `dup(2)` fails.
-    fn dup_as_file(fd: &OwnedFd) -> File {
-        // SAFETY: duplicating an owned descriptor for a scoped File wrapper.
-        let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
-        assert_ne!(
-            duplicated_fd,
-            -1,
-            "dup(2) failed: {}",
-            io::Error::last_os_error(),
-        );
-        // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and
-        // is now owned by this scoped `File`.
-        unsafe { File::from_raw_fd(duplicated_fd) }
-    }
-
-    fn write_all_to(fd: &OwnedFd, payload: &[u8]) {
-        unwrap_ok(dup_as_file(fd).write_all(payload));
-    }
-
-    fn read_all_from(fd: &OwnedFd) -> Vec<u8> {
-        let mut collected = Vec::new();
-        unwrap_ok(dup_as_file(fd).read_to_end(&mut collected));
-        collected
-    }
+    use crate::test_support::{make_pipe, read_all_from, unwrap_ok, write_all_to};
 
     #[test]
     fn splice_transfers_all_bytes_between_pipes() {

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -63,23 +63,28 @@ pub(crate) fn try_splice_pump(
 fn splice_once(fd_in: libc::c_int, fd_out: libc::c_int, len: usize) -> Result<usize, PumpError> {
     let flags = SPLICE_F_MOVE | SPLICE_F_MORE;
 
-    // SAFETY: splice is a well-defined syscall; null offsets are valid for pipes.
-    let result = unsafe {
-        libc::splice(
-            fd_in,
-            std::ptr::null_mut(), // No offset for pipes
-            fd_out,
-            std::ptr::null_mut(), // No offset for pipes
-            len,
-            flags,
-        )
-    };
+    loop {
+        // SAFETY: splice is a well-defined syscall; null offsets are valid for pipes.
+        let result = unsafe {
+            libc::splice(
+                fd_in,
+                std::ptr::null_mut(), // No offset for pipes
+                fd_out,
+                std::ptr::null_mut(), // No offset for pipes
+                len,
+                flags,
+            )
+        };
 
-    if result < 0 {
-        Err(PumpError::from(io::Error::last_os_error()))
-    } else {
-        // Non-negative ssize_t fits in usize on Linux.
-        usize::try_from(result).map_err(|_| PumpError::LengthOverflow)
+        if result >= 0 {
+            // Non-negative ssize_t fits in usize on Linux.
+            return usize::try_from(result).map_err(|_| PumpError::LengthOverflow);
+        }
+
+        let err = io::Error::last_os_error();
+        if err.kind() != io::ErrorKind::Interrupted {
+            return Err(PumpError::from(err));
+        }
     }
 }
 

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -205,9 +205,10 @@ mod tests {
         let outcome = try_splice_pump(&source_read, &sink_write, 4096);
         drop(sink_write); // EOF for the verification read.
 
+        let expected_len = unwrap_ok(u64::try_from(payload.len()));
         match outcome {
             Some(Ok(transferred)) => {
-                assert_eq!(transferred, payload.len() as u64);
+                assert_eq!(transferred, expected_len);
             }
             other => panic!("expected Some(Ok(_)) from pipe splice, got {other:?}"),
         }

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -18,7 +18,7 @@
 use std::io;
 use std::os::fd::{AsRawFd, OwnedFd};
 
-use crate::io_utils::is_nonfatal_write_error;
+use crate::errors::PumpError;
 
 /// Flag for splice: move pages instead of copying (advisory).
 const SPLICE_F_MOVE: libc::c_uint = 0x01;
@@ -43,7 +43,7 @@ pub(crate) fn try_splice_pump(
     reader: &OwnedFd,
     writer: &OwnedFd,
     chunk_size: usize,
-) -> Option<Result<u64, io::Error>> {
+) -> Option<Result<u64, PumpError>> {
     let reader_fd = reader.as_raw_fd();
     let writer_fd = writer.as_raw_fd();
 
@@ -52,7 +52,7 @@ pub(crate) fn try_splice_pump(
         Ok(0) => Some(Ok(0)), // EOF on first call
         Ok(n) => Some(splice_loop(reader_fd, writer_fd, chunk_size, n)),
         Err(e) if is_splice_unsupported(&e) => None, // Fall back to read/write
-        Err(e) if is_nonfatal_write_error(&e) => {
+        Err(e) if e.is_nonfatal_write() => {
             // Broken pipe on first call: drain reader to avoid upstream deadlock.
             drain_reader(reader_fd, chunk_size);
             Some(Ok(0))
@@ -62,7 +62,7 @@ pub(crate) fn try_splice_pump(
 }
 
 /// Perform a single splice call.
-fn splice_once(fd_in: libc::c_int, fd_out: libc::c_int, len: usize) -> Result<usize, io::Error> {
+fn splice_once(fd_in: libc::c_int, fd_out: libc::c_int, len: usize) -> Result<usize, PumpError> {
     let flags = SPLICE_F_MOVE | SPLICE_F_MORE;
 
     // SAFETY: splice is a well-defined syscall; null offsets are valid for pipes.
@@ -78,10 +78,10 @@ fn splice_once(fd_in: libc::c_int, fd_out: libc::c_int, len: usize) -> Result<us
     };
 
     if result < 0 {
-        Err(io::Error::last_os_error())
+        Err(PumpError::from(io::Error::last_os_error()))
     } else {
         // Non-negative ssize_t fits in usize on Linux.
-        usize::try_from(result).map_err(|_| io::Error::other("splice length overflow"))
+        usize::try_from(result).map_err(|_| PumpError::LengthOverflow)
     }
 }
 
@@ -91,7 +91,7 @@ fn splice_loop(
     fd_out: libc::c_int,
     chunk_size: usize,
     initial_bytes: usize,
-) -> Result<u64, io::Error> {
+) -> Result<u64, PumpError> {
     let mut total = initial_bytes as u64;
 
     loop {
@@ -100,7 +100,7 @@ fn splice_loop(
             Ok(n) => {
                 total = total.saturating_add(n as u64);
             }
-            Err(e) if is_nonfatal_write_error(&e) => {
+            Err(e) if e.is_nonfatal_write() => {
                 // Broken pipe: drain reader and return bytes written so far.
                 drain_reader(fd_in, chunk_size);
                 break;
@@ -136,6 +136,6 @@ fn drain_reader(fd_in: libc::c_int, chunk_size: usize) {
 /// Other errors such as `EBADF` (bad file descriptor) or `ESPIPE` (illegal
 /// seek) are configuration or programming errors that should propagate to the
 /// caller rather than being masked by a fallback that will likely also fail.
-fn is_splice_unsupported(err: &io::Error) -> bool {
-    err.raw_os_error() == Some(libc::EINVAL)
+fn is_splice_unsupported(err: &PumpError) -> bool {
+    matches!(err, PumpError::Io(io_err) if io_err.raw_os_error() == Some(libc::EINVAL))
 }

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -19,6 +19,7 @@ use std::io;
 use std::os::fd::{AsRawFd, OwnedFd};
 
 use crate::errors::PumpError;
+use crate::io_utils::read_raw_fd;
 
 /// Flag for splice: move pages instead of copying (advisory).
 const SPLICE_F_MOVE: libc::c_uint = 0x01;
@@ -47,18 +48,15 @@ pub(crate) fn try_splice_pump(
     let reader_fd = reader.as_raw_fd();
     let writer_fd = writer.as_raw_fd();
 
-    // Attempt first splice to detect support.
-    match splice_once(reader_fd, writer_fd, chunk_size) {
-        Ok(0) => Some(Ok(0)), // EOF on first call
-        Ok(n) => Some(splice_loop(reader_fd, writer_fd, chunk_size, n)),
-        Err(e) if is_splice_unsupported(&e) => None, // Fall back to read/write
-        Err(e) if e.is_nonfatal_write() => {
-            // Broken pipe on first call: drain reader to avoid upstream deadlock.
-            drain_reader(reader_fd, chunk_size);
-            Some(Ok(0))
-        }
-        Err(e) => Some(Err(e)), // Fatal error
+    // The first splice call detects support: `EINVAL` here means the FD
+    // types cannot splice and the caller must fall back to read/write. Once
+    // a splice has succeeded, `EINVAL` can no longer mean "unsupported", so
+    // the loop below treats it as fatal like any other error.
+    let first = splice_once(reader_fd, writer_fd, chunk_size);
+    if matches!(&first, Err(e) if is_splice_unsupported(e)) {
+        return None;
     }
+    Some(splice_loop(reader_fd, writer_fd, chunk_size, first))
 }
 
 /// Perform a single splice call.
@@ -85,28 +83,37 @@ fn splice_once(fd_in: libc::c_int, fd_out: libc::c_int, len: usize) -> Result<us
     }
 }
 
-/// Continue splicing until EOF or error.
+/// Splice until EOF or error, starting from a pre-computed first outcome.
+///
+/// This is the single canonical accumulation loop: every iteration —
+/// including the first, whose outcome the caller supplies after the
+/// support-detection check — is handled by the same `Ok(0)` / `Ok(n)` /
+/// non-fatal / fatal arms. A non-fatal write error (broken pipe) drains the
+/// reader so upstream does not block, then reports the bytes transferred so
+/// far.
 fn splice_loop(
     fd_in: libc::c_int,
     fd_out: libc::c_int,
     chunk_size: usize,
-    initial_bytes: usize,
+    mut outcome: Result<usize, PumpError>,
 ) -> Result<u64, PumpError> {
-    let mut total = initial_bytes as u64;
+    let mut total = 0_u64;
 
     loop {
-        match splice_once(fd_in, fd_out, chunk_size) {
+        match outcome {
             Ok(0) => break, // EOF
             Ok(n) => {
-                total = total.saturating_add(n as u64);
+                let chunk = u64::try_from(n).map_err(|_| PumpError::LengthOverflow)?;
+                total = total.saturating_add(chunk);
             }
             Err(e) if e.is_nonfatal_write() => {
                 // Broken pipe: drain reader and return bytes written so far.
-                drain_reader(fd_in, chunk_size);
+                drain_reader(fd_in, chunk_size)?;
                 break;
             }
             Err(e) => return Err(e),
         }
+        outcome = splice_once(fd_in, fd_out, chunk_size);
     }
 
     Ok(total)
@@ -116,14 +123,16 @@ fn splice_loop(
 ///
 /// This matches the behaviour of the read/write fallback: when the writer
 /// breaks, we continue reading until EOF to ensure the upstream process
-/// does not block on a full pipe buffer.
-fn drain_reader(fd_in: libc::c_int, chunk_size: usize) {
-    let mut buf = vec![0u8; chunk_size];
+/// does not block on a full pipe buffer. The drain routes through the
+/// canonical raw-fd read helper, so interrupted reads (`EINTR`) retry
+/// instead of silently ending the drain, end of file terminates it, and
+/// any other error propagates.
+fn drain_reader(fd_in: libc::c_int, chunk_size: usize) -> Result<(), PumpError> {
+    let mut buf = vec![0_u8; chunk_size];
     loop {
-        // SAFETY: read is a well-defined syscall.
-        let n = unsafe { libc::read(fd_in, buf.as_mut_ptr().cast(), buf.len()) };
-        if n <= 0 {
-            break;
+        let n = read_raw_fd(fd_in, &mut buf)?;
+        if n == 0 {
+            return Ok(());
         }
     }
 }
@@ -138,4 +147,128 @@ fn drain_reader(fd_in: libc::c_int, chunk_size: usize) {
 /// caller rather than being masked by a fallback that will likely also fail.
 fn is_splice_unsupported(err: &PumpError) -> bool {
     matches!(err, PumpError::Io(io_err) if io_err.raw_os_error() == Some(libc::EINVAL))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Behavioural tests for the unified splice loop and the EINTR-correct
+    //! drain: full transfer between pipes, fallback signalling for
+    //! unsupported descriptor types, and broken-pipe draining.
+
+    use std::fmt::Debug;
+    use std::fs::File;
+    use std::io::{self, Read, Write};
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+    use super::{drain_reader, try_splice_pump};
+
+    fn unwrap_ok<T, E: Debug>(result: Result<T, E>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(err) => panic!("unexpected error: {err:?}"),
+        }
+    }
+
+    fn make_pipe() -> (OwnedFd, OwnedFd) {
+        let mut fds = [0_i32; 2];
+        // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
+        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
+        // SAFETY: on success `pipe(2)` returned two freshly opened FDs that
+        // this process exclusively owns.
+        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+    }
+
+    fn write_all_to(fd: &OwnedFd, payload: &[u8]) {
+        // SAFETY: duplicating an owned descriptor for a scoped File wrapper.
+        let mut file = unsafe { File::from_raw_fd(libc::dup(fd.as_raw_fd())) };
+        unwrap_ok(file.write_all(payload));
+    }
+
+    fn read_all_from(fd: &OwnedFd) -> Vec<u8> {
+        // SAFETY: duplicating an owned descriptor for a scoped File wrapper.
+        let mut file = unsafe { File::from_raw_fd(libc::dup(fd.as_raw_fd())) };
+        let mut collected = Vec::new();
+        unwrap_ok(file.read_to_end(&mut collected));
+        collected
+    }
+
+    #[test]
+    fn splice_transfers_all_bytes_between_pipes() {
+        let (source_read, source_write) = make_pipe();
+        let (sink_read, sink_write) = make_pipe();
+        let payload = b"unified splice loop payload";
+
+        write_all_to(&source_write, payload);
+        drop(source_write); // EOF for the splice loop.
+
+        let outcome = try_splice_pump(&source_read, &sink_write, 4096);
+        drop(sink_write); // EOF for the verification read.
+
+        match outcome {
+            Some(Ok(transferred)) => {
+                assert_eq!(transferred, payload.len() as u64);
+            }
+            other => panic!("expected Some(Ok(_)) from pipe splice, got {other:?}"),
+        }
+        assert_eq!(read_all_from(&sink_read), payload);
+    }
+
+    #[test]
+    fn unsupported_descriptors_signal_fallback() {
+        let dir = std::env::temp_dir();
+        let reader_path = dir.join("cuprum-splice-test-reader");
+        let writer_path = dir.join("cuprum-splice-test-writer");
+        unwrap_ok(std::fs::write(&reader_path, b"file payload"));
+        let reader = OwnedFd::from(unwrap_ok(File::open(&reader_path)));
+        let writer = OwnedFd::from(unwrap_ok(File::create(&writer_path)));
+
+        // Two regular files cannot splice; the first call must signal the
+        // read/write fallback rather than erroring.
+        let outcome = try_splice_pump(&reader, &writer, 4096);
+        assert!(
+            outcome.is_none(),
+            "expected fallback signal, got {outcome:?}"
+        );
+
+        unwrap_ok(std::fs::remove_file(&reader_path));
+        unwrap_ok(std::fs::remove_file(&writer_path));
+    }
+
+    #[test]
+    fn broken_pipe_drains_reader_and_reports_transferred_bytes() {
+        let (source_read, source_write) = make_pipe();
+        let (sink_read, sink_write) = make_pipe();
+        let payload = b"bytes that can no longer be delivered";
+
+        write_all_to(&source_write, payload);
+        drop(source_write);
+        drop(sink_read); // Break the downstream pipe before pumping.
+
+        let outcome = try_splice_pump(&source_read, &sink_write, 4096);
+        match outcome {
+            Some(Ok(0)) => {}
+            other => panic!("expected Some(Ok(0)) after broken pipe, got {other:?}"),
+        }
+
+        // The drain must have consumed the source to EOF so upstream writers
+        // cannot block on a full pipe buffer.
+        let leftover = read_all_from(&source_read);
+        assert!(
+            leftover.is_empty(),
+            "reader must be drained, got {leftover:?}"
+        );
+    }
+
+    #[test]
+    fn drain_reader_consumes_to_eof() {
+        let (read_end, write_end) = make_pipe();
+        write_all_to(&write_end, b"residual data");
+        drop(write_end);
+
+        unwrap_ok(drain_reader(read_end.as_raw_fd(), 8));
+
+        let leftover = read_all_from(&read_end);
+        assert!(leftover.is_empty(), "drain must consume the pipe to EOF");
+    }
 }

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -186,13 +186,31 @@ mod tests {
 
     fn write_all_to(fd: &OwnedFd, payload: &[u8]) {
         // SAFETY: duplicating an owned descriptor for a scoped File wrapper.
-        let mut file = unsafe { File::from_raw_fd(libc::dup(fd.as_raw_fd())) };
+        let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
+        assert_ne!(
+            duplicated_fd,
+            -1,
+            "dup(2) failed: {}",
+            io::Error::last_os_error(),
+        );
+        // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and
+        // is now owned by this scoped `File`.
+        let mut file = unsafe { File::from_raw_fd(duplicated_fd) };
         unwrap_ok(file.write_all(payload));
     }
 
     fn read_all_from(fd: &OwnedFd) -> Vec<u8> {
         // SAFETY: duplicating an owned descriptor for a scoped File wrapper.
-        let mut file = unsafe { File::from_raw_fd(libc::dup(fd.as_raw_fd())) };
+        let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
+        assert_ne!(
+            duplicated_fd,
+            -1,
+            "dup(2) failed: {}",
+            io::Error::last_os_error(),
+        );
+        // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and
+        // is now owned by this scoped `File`.
+        let mut file = unsafe { File::from_raw_fd(duplicated_fd) };
         let mut collected = Vec::new();
         unwrap_ok(file.read_to_end(&mut collected));
         collected

--- a/rust/cuprum-rust/src/splice.rs
+++ b/rust/cuprum-rust/src/splice.rs
@@ -184,7 +184,15 @@ mod tests {
         unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
     }
 
-    fn write_all_to(fd: &OwnedFd, payload: &[u8]) {
+    /// Duplicate `fd` and wrap the duplicate in a scoped [`File`].
+    ///
+    /// The duplicate is owned by the returned [`File`]; the original `fd`
+    /// remains open and unaffected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `dup(2)` fails.
+    fn dup_as_file(fd: &OwnedFd) -> File {
         // SAFETY: duplicating an owned descriptor for a scoped File wrapper.
         let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
         assert_ne!(
@@ -195,24 +203,16 @@ mod tests {
         );
         // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and
         // is now owned by this scoped `File`.
-        let mut file = unsafe { File::from_raw_fd(duplicated_fd) };
-        unwrap_ok(file.write_all(payload));
+        unsafe { File::from_raw_fd(duplicated_fd) }
+    }
+
+    fn write_all_to(fd: &OwnedFd, payload: &[u8]) {
+        unwrap_ok(dup_as_file(fd).write_all(payload));
     }
 
     fn read_all_from(fd: &OwnedFd) -> Vec<u8> {
-        // SAFETY: duplicating an owned descriptor for a scoped File wrapper.
-        let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
-        assert_ne!(
-            duplicated_fd,
-            -1,
-            "dup(2) failed: {}",
-            io::Error::last_os_error(),
-        );
-        // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and
-        // is now owned by this scoped `File`.
-        let mut file = unsafe { File::from_raw_fd(duplicated_fd) };
         let mut collected = Vec::new();
-        unwrap_ok(file.read_to_end(&mut collected));
+        unwrap_ok(dup_as_file(fd).read_to_end(&mut collected));
         collected
     }
 

--- a/rust/cuprum-rust/src/test_support.rs
+++ b/rust/cuprum-rust/src/test_support.rs
@@ -1,0 +1,69 @@
+//! Shared Unix file-descriptor fixtures and assertions for Rust unit tests.
+
+use std::fmt::Debug;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+pub(crate) fn make_pipe() -> (OwnedFd, OwnedFd) {
+    let mut fds = [0_i32; 2];
+    // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
+    // SAFETY: on success `pipe(2)` returned two freshly opened descriptors
+    // that this process exclusively owns.
+    unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+}
+
+pub(crate) fn dup_as_file(fd: &OwnedFd) -> File {
+    // SAFETY: duplicating an owned descriptor for a scoped `File` wrapper.
+    let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
+    assert_ne!(
+        duplicated_fd,
+        -1,
+        "dup(2) failed: {}",
+        io::Error::last_os_error(),
+    );
+    // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and is
+    // now owned by this scoped `File`.
+    unsafe { File::from_raw_fd(duplicated_fd) }
+}
+
+pub(crate) fn write_all_to(fd: &OwnedFd, payload: &[u8]) {
+    unwrap_ok(dup_as_file(fd).write_all(payload));
+}
+
+pub(crate) fn read_all_from(fd: &OwnedFd) -> Vec<u8> {
+    let mut collected = Vec::new();
+    unwrap_ok(dup_as_file(fd).read_to_end(&mut collected));
+    collected
+}
+
+pub(crate) fn unwrap_ok<T, E: Debug>(result: Result<T, E>) -> T {
+    match result {
+        Ok(value) => value,
+        Err(err) => panic!("expected Ok(..), got Err({err:?})"),
+    }
+}
+
+pub(crate) fn unwrap_err<T: Debug, E>(result: Result<T, E>) -> E {
+    match result {
+        Ok(value) => panic!("expected Err(..), got Ok({value:?})"),
+        Err(err) => err,
+    }
+}
+
+pub(crate) fn fd_is_open(fd: i32) -> bool {
+    loop {
+        // SAFETY: F_GETFD on an arbitrary integer reports EBADF for a closed
+        // descriptor without dereferencing memory.
+        let result = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if result != -1 {
+            return true;
+        }
+
+        if io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This branch applies the two mechanical Rust-hygiene fixes from the audit: caret dependency baselines and fallible integer casts.

Closes [#126](https://github.com/leynos/cuprum/issues/126).

## Review walkthrough

- [rust/cuprum-rust/Cargo.toml](https://github.com/leynos/cuprum/blob/issue-126-caret-deps-fallible-casts/rust/cuprum-rust/Cargo.toml): bare specs (`libc = "0.2"`, `trybuild = "1"`, `proptest = "1"`) become explicit caret minima matching the lockfile (`0.2.186` / `1.0.116` / `1.11.0`), and `thiserror` lifts to its locked `2.0.18`.
- [rust/cuprum-rust/src/lib.rs](https://github.com/leynos/cuprum/blob/issue-126-caret-deps-fallible-casts/rust/cuprum-rust/src/lib.rs): the Windows `convert_fd` lossy `i64 as u64 as usize` chain becomes an explicit negative-handle rejection (restoring symmetry with the Unix arm) plus a single `usize::try_from`; the remaining `usize as RawHandle` pointer cast is documented as a deliberate pointer-width reinterpretation.
- [rust/cuprum-rust/src/splice.rs](https://github.com/leynos/cuprum/blob/issue-126-caret-deps-fallible-casts/rust/cuprum-rust/src/splice.rs): the test's `len() as u64` widening becomes a fallible conversion.

## Validation

- `make check-fmt`: pass
- `make lint`: pass (clippy `-D warnings`, rustdoc, whitaker)
- `make typecheck`: pass
- `make test`: pass (Python 699 passed, 50 skipped; Rust suite 29 passed)

## Notes

The splice-path `as u64` widenings flagged by the audit were already replaced with `u64::try_from` (via `PumpError::LengthOverflow`) in [#160](https://github.com/leynos/cuprum/pull/160) ([#124](https://github.com/leynos/cuprum/issues/124)), which this branch stacks on; the `convert_fd` boundary behaviour will be property-tested under [#83](https://github.com/leynos/cuprum/issues/83). The Windows arm remains uncovered by Linux CI, as the issue notes.

## References

- [Lody session](https://lody.ai/leynos/sessions/c639396b-d1be-41e9-8d29-43716c36d7b1)
