### PR TITLE
Annotate rust_consume_stream as implemented but not integrated (#127)

### DIFF
--- a/cuprum/_streams_rs.py
+++ b/cuprum/_streams_rs.py
@@ -3,6 +3,14 @@
 This module provides a thin wrapper around the optional Rust extension. Import
 or use it only when the Rust backend is installed.
 
+Integration status: ``rust_pump_stream`` is wired into production through
+``_pump_stream_dispatch`` (``cuprum/_pipeline_streams.py``).
+``rust_consume_stream`` is **implemented but not yet integrated** — no
+production code routes a consume through it; every consume currently uses the
+pure-Python ``_consume_stream``. Consume-side dispatch is deliberately
+deferred, evidence-gated work tracked as Phase 2 of ADR-002
+(``docs/adr-002-additional-rust-components.md``).
+
 Example
 -------
 bytes_written = rust_pump_stream(reader_fd, writer_fd, buffer_size=65536)
@@ -96,6 +104,13 @@ def rust_consume_stream(
 
     This helper always decodes UTF-8 and replaces invalid sequences with the
     Unicode replacement character.
+
+    .. note:: Implemented but not yet integrated. No production code path
+       routes a consume through this function; the pump side has a
+       ``_pump_stream_dispatch`` counterpart, but consume dispatch is
+       deferred, evidence-gated work (ADR-002, Phase 2). The function is
+       exercised directly by tests and remains available for downstream
+       experimentation.
 
     Parameters
     ----------

--- a/cuprum/_streams_rs.py
+++ b/cuprum/_streams_rs.py
@@ -105,12 +105,14 @@ def rust_consume_stream(
     This helper always decodes UTF-8 and replaces invalid sequences with the
     Unicode replacement character.
 
-    .. note:: Implemented but not yet integrated. No production code path
-       routes a consume through this function; the pump side has a
-       ``_pump_stream_dispatch`` counterpart, but consume dispatch is
-       deferred, evidence-gated work (ADR-002, Phase 2). The function is
-       exercised directly by tests and remains available for downstream
-       experimentation.
+    Notes
+    -----
+    Implemented but not yet integrated. No production code path routes a
+    consume through this function; the pump side has a
+    ``_pump_stream_dispatch`` counterpart, but consume dispatch is
+    deferred, evidence-gated work (ADR-002, Phase 2). The function is
+    exercised directly by tests and remains available for downstream
+    experimentation.
 
     Parameters
     ----------

--- a/cuprum/unittests/test_rust_streams.py
+++ b/cuprum/unittests/test_rust_streams.py
@@ -308,3 +308,37 @@ class TestRustConsumeStream:
             _safe_close(write_fd)
             with pytest.raises(ValueError, match="buffer_size"):
                 rust_streams.rust_consume_stream(read_fd, buffer_size=0)
+
+
+def test_rust_consume_stream_is_annotated_not_integrated() -> None:
+    """``rust_consume_stream`` is documented as implemented-but-not-integrated.
+
+    ADR-002 defers consume-side dispatch to evidence-gated Phase 2 work
+    (issue #127). This guard keeps the annotation and reality in lockstep:
+    the docstring must carry the not-integrated marker, and no production
+    module may reference the symbol. Wiring a ``_consume_stream_dispatch``
+    later must remove both the marker and this guard together.
+    """
+    import pathlib
+
+    from cuprum import _streams_rs
+
+    docstring = _streams_rs.rust_consume_stream.__doc__ or ""
+    assert "not yet integrated" in docstring, (
+        "rust_consume_stream must declare its not-integrated status"
+    )
+
+    module_file = _streams_rs.__file__
+    assert module_file is not None, "_streams_rs must be a file-backed module"
+    package_root = pathlib.Path(module_file).parent
+    referencing = sorted(
+        path.name
+        for path in package_root.rglob("*.py")
+        if "unittests" not in path.parts
+        and path.name != "_streams_rs.py"
+        and "rust_consume_stream" in path.read_text(encoding="utf-8")
+    )
+    assert referencing == [], (
+        "production code now references rust_consume_stream; revisit the "
+        f"ADR-002 Phase 2 decision and this guard: {referencing}"
+    )

--- a/cuprum/unittests/test_rust_streams.py
+++ b/cuprum/unittests/test_rust_streams.py
@@ -25,6 +25,14 @@ if typ.TYPE_CHECKING:
     from types import ModuleType
 
 
+class _ModuleReferenceScanError(AssertionError):
+    """Raised when a module cannot be inspected for production references."""
+
+    def __init__(self, path: pathlib.Path, symbol: str) -> None:
+        """Describe the module reference scan failure."""
+        super().__init__(f"cannot inspect {path} for {symbol!r} production references")
+
+
 def _pump_payload(
     streams: ModuleType,
     payload: bytes,
@@ -79,7 +87,11 @@ def _consume_payload(
 
 def _module_references_symbol(path: pathlib.Path, symbol: str) -> bool:
     """Return whether *path* contains executable references to *symbol*."""
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError) as exc:
+        raise _ModuleReferenceScanError(path, symbol) from exc
     return any(_node_references_symbol(node, symbol) for node in ast.walk(tree))
 
 
@@ -102,16 +114,22 @@ def _node_references_symbol(node: ast.AST, symbol: str) -> bool:
         ("rust_consume_stream(reader_fd)\n", "referenced"),
         ("streams.rust_consume_stream(reader_fd)\n", "referenced"),
         ("from cuprum._streams_rs import rust_consume_stream\n", "referenced"),
+        ("if rust_consume_stream(\n", "invalid"),
     ],
 )
 def test_module_references_symbol_ignores_non_code_text(
     tmp_path: pathlib.Path,
     source: str,
-    expected_reference: typ.Literal["ignored", "referenced"],
+    expected_reference: typ.Literal["ignored", "referenced", "invalid"],
 ) -> None:
     """The production-reference guard detects symbols, not raw text."""
     module_path = tmp_path / "candidate.py"
     module_path.write_text(source, encoding="utf-8")
+
+    if expected_reference == "invalid":
+        with pytest.raises(AssertionError, match="cannot inspect"):
+            _module_references_symbol(module_path, "rust_consume_stream")
+        return
 
     has_reference = expected_reference == "referenced"
     assert (

--- a/cuprum/unittests/test_rust_streams.py
+++ b/cuprum/unittests/test_rust_streams.py
@@ -354,21 +354,19 @@ class TestRustConsumeStream:
                 rust_streams.rust_consume_stream(read_fd, buffer_size=0)
 
 
-def test_rust_consume_stream_is_annotated_not_integrated() -> None:
-    """``rust_consume_stream`` is documented as implemented-but-not-integrated.
-
-    ADR-002 defers consume-side dispatch to evidence-gated Phase 2 work
-    (issue #127). This guard keeps the annotation and reality in lockstep:
-    the docstring must carry the not-integrated marker, and no production
-    module may reference the symbol. Wiring a ``_consume_stream_dispatch``
-    later must remove both the marker and this guard together.
-    """
+def test_rust_consume_stream_docstring_not_integrated() -> None:
+    """``rust_consume_stream`` documents its deferred integration status."""
     from cuprum import _streams_rs
 
     docstring = _streams_rs.rust_consume_stream.__doc__ or ""
     assert "not yet integrated" in docstring, (
         "rust_consume_stream must declare its not-integrated status"
     )
+
+
+def test_rust_consume_stream_not_referenced_in_production() -> None:
+    """Production code does not route consumes through ``rust_consume_stream``."""
+    from cuprum import _streams_rs
 
     module_file = _streams_rs.__file__
     assert module_file is not None, "_streams_rs must be a file-backed module"

--- a/cuprum/unittests/test_rust_streams.py
+++ b/cuprum/unittests/test_rust_streams.py
@@ -127,7 +127,7 @@ def test_module_references_symbol_ignores_non_code_text(
     module_path.write_text(source, encoding="utf-8")
 
     if expected_reference == "invalid":
-        with pytest.raises(AssertionError, match="cannot inspect"):
+        with pytest.raises(_ModuleReferenceScanError, match="cannot inspect"):
             _module_references_symbol(module_path, "rust_consume_stream")
         return
 

--- a/cuprum/unittests/test_rust_streams.py
+++ b/cuprum/unittests/test_rust_streams.py
@@ -25,7 +25,7 @@ if typ.TYPE_CHECKING:
     from types import ModuleType
 
 
-class _ModuleReferenceScanError(AssertionError):
+class _ModuleReferenceScanError(Exception):
     """Raised when a module cannot be inspected for production references."""
 
     def __init__(self, path: pathlib.Path, symbol: str) -> None:
@@ -389,14 +389,22 @@ def test_rust_consume_stream_not_referenced_in_production() -> None:
     module_file = _streams_rs.__file__
     assert module_file is not None, "_streams_rs must be a file-backed module"
     package_root = pathlib.Path(module_file).parent
-    referencing = sorted(
-        path.name
-        for path in package_root.rglob("*.py")
-        if "unittests" not in path.parts
-        and path.name != "_streams_rs.py"
-        and _module_references_symbol(path, "rust_consume_stream")
+    scan_errors: list[str] = []
+    referencing: list[str] = []
+    for path in package_root.rglob("*.py"):
+        if "unittests" in path.parts or path.name == "_streams_rs.py":
+            continue
+        try:
+            if _module_references_symbol(path, "rust_consume_stream"):
+                referencing.append(path.name)
+        except _ModuleReferenceScanError as exc:
+            scan_errors.append(str(exc))
+
+    assert scan_errors == [], (
+        "could not inspect one or more production modules; "
+        f"fix the underlying read/parse errors: {scan_errors}"
     )
-    assert referencing == [], (
+    assert sorted(referencing) == [], (
         "production code now references rust_consume_stream; revisit the "
-        f"ADR-002 Phase 2 decision and this guard: {referencing}"
+        f"ADR-002 Phase 2 decision and this guard: {sorted(referencing)}"
     )

--- a/cuprum/unittests/test_rust_streams.py
+++ b/cuprum/unittests/test_rust_streams.py
@@ -10,9 +10,11 @@ pytest cuprum/unittests/test_rust_streams.py
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import errno
 import os
+import pathlib
 import typing as typ
 
 import pytest
@@ -73,6 +75,48 @@ def _consume_payload(
             "str",
             streams.rust_consume_stream(read_fd, **forwarded_kwargs),
         )
+
+
+def _module_references_symbol(path: pathlib.Path, symbol: str) -> bool:
+    """Return whether *path* contains executable references to *symbol*."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return any(_node_references_symbol(node, symbol) for node in ast.walk(tree))
+
+
+def _node_references_symbol(node: ast.AST, symbol: str) -> bool:
+    """Return whether an AST node references *symbol* as a Python symbol."""
+    if isinstance(node, ast.Name):
+        return node.id == symbol
+    if isinstance(node, ast.Attribute):
+        return node.attr == symbol
+    if isinstance(node, ast.alias):
+        return symbol in {node.name, node.asname}
+    return False
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_reference"),
+    [
+        ('"""rust_consume_stream is mentioned here."""\n', "ignored"),
+        ("# rust_consume_stream is mentioned here.\n", "ignored"),
+        ("rust_consume_stream(reader_fd)\n", "referenced"),
+        ("streams.rust_consume_stream(reader_fd)\n", "referenced"),
+        ("from cuprum._streams_rs import rust_consume_stream\n", "referenced"),
+    ],
+)
+def test_module_references_symbol_ignores_non_code_text(
+    tmp_path: pathlib.Path,
+    source: str,
+    expected_reference: typ.Literal["ignored", "referenced"],
+) -> None:
+    """The production-reference guard detects symbols, not raw text."""
+    module_path = tmp_path / "candidate.py"
+    module_path.write_text(source, encoding="utf-8")
+
+    has_reference = expected_reference == "referenced"
+    assert (
+        _module_references_symbol(module_path, "rust_consume_stream") is has_reference
+    )
 
 
 @pytest.mark.parametrize(
@@ -319,8 +363,6 @@ def test_rust_consume_stream_is_annotated_not_integrated() -> None:
     module may reference the symbol. Wiring a ``_consume_stream_dispatch``
     later must remove both the marker and this guard together.
     """
-    import pathlib
-
     from cuprum import _streams_rs
 
     docstring = _streams_rs.rust_consume_stream.__doc__ or ""
@@ -336,7 +378,7 @@ def test_rust_consume_stream_is_annotated_not_integrated() -> None:
         for path in package_root.rglob("*.py")
         if "unittests" not in path.parts
         and path.name != "_streams_rs.py"
-        and "rust_consume_stream" in path.read_text(encoding="utf-8")
+        and _module_references_symbol(path, "rust_consume_stream")
     )
     assert referencing == [], (
         "production code now references rust_consume_stream; revisit the "

--- a/cuprum/unittests/test_rust_streams.py
+++ b/cuprum/unittests/test_rust_streams.py
@@ -390,15 +390,21 @@ def test_rust_consume_stream_not_referenced_in_production() -> None:
     assert module_file is not None, "_streams_rs must be a file-backed module"
     package_root = pathlib.Path(module_file).parent
     scan_errors: list[str] = []
-    referencing: list[str] = []
+    referencing: list[pathlib.Path] = []
     for path in package_root.rglob("*.py"):
         if "unittests" in path.parts or path.name == "_streams_rs.py":
             continue
         try:
             if _module_references_symbol(path, "rust_consume_stream"):
-                referencing.append(path.name)
+                referencing.append(path.relative_to(package_root))
         except _ModuleReferenceScanError as exc:
-            scan_errors.append(str(exc))
+            cause = exc.__cause__
+            cause_context = (
+                f"; caused by {type(cause).__name__}: {cause}"
+                if cause is not None
+                else ""
+            )
+            scan_errors.append(f"{exc}{cause_context}")
 
     assert scan_errors == [], (
         "could not inspect one or more production modules; "

--- a/docs/adr-002-additional-rust-components.md
+++ b/docs/adr-002-additional-rust-components.md
@@ -313,10 +313,10 @@ regression checks listed above. The first dispatcher must remain narrower
 than the public helper: fd-backed, UTF-8/replace, capture-only streams with no
 echo sink and no line callbacks.
 
-`rust_consume_stream()` ships in the wheel and is exercised by tests, but no
-production code routes a consume through it; the symbol is annotated as
-"implemented but not yet integrated" in `cuprum/_streams_rs.py` and the users'
-guide so it is not mistaken for a wired bridge. A guard test
+`rust_consume_stream()` ships in the wheel and is exercised by tests, but
+production code does not route stream consumption through it yet. The symbol is
+annotated as "implemented but not yet integrated" in `cuprum/_streams_rs.py` and
+the users' guide so it is not mistaken for a wired bridge. A guard test
 (`cuprum/unittests/test_rust_streams.py`) fails if production code starts
 referencing the symbol without revisiting this decision. Phase 2 integration
 should remove that marker only alongside the dispatcher, fallback path, and the

--- a/docs/adr-002-additional-rust-components.md
+++ b/docs/adr-002-additional-rust-components.md
@@ -303,11 +303,15 @@ behavioural, and property tests that prove parity for stdout, stderr, empty
 streams, invalid UTF-8, large payloads, and forced Python fallback.
 
 **Status (issue #127):** implemented but not yet integrated. The Phase 1 tee
-hot-path profiling baseline now supports capture-only consume dispatch:
-capture double-touch accounts for about 51% of parent CPU in the measured tee
-scenario, comfortably above the 20% acceptance threshold. The first dispatcher
-must still remain narrower than the public helper: fd-backed, UTF-8/replace,
-capture-only streams with no echo sink and no line callbacks.
+hot-path profiling baseline provides hotspot evidence for capture-only consume
+dispatch: capture double-touch accounts for about 51% of parent CPU in the
+measured tee scenario. This evidence justifies the Phase 2 dispatcher
+experiment, but it does not satisfy the wall-time acceptance gate by itself;
+that gate still requires a Rust-versus-Python dispatcher benchmark showing at
+least 20% lower median wall time for the targeted heavy scenario, plus the
+regression checks listed above. The first dispatcher must still remain narrower
+than the public helper: fd-backed, UTF-8/replace, capture-only streams with no
+echo sink and no line callbacks.
 
 `rust_consume_stream()` ships in the wheel and is exercised by tests, but no
 production code routes a consume through it; the symbol is annotated as

--- a/docs/adr-002-additional-rust-components.md
+++ b/docs/adr-002-additional-rust-components.md
@@ -302,6 +302,14 @@ Route eligible capture-only streams through `rust_consume_stream()`. Add unit,
 behavioural, and property tests that prove parity for stdout, stderr, empty
 streams, invalid UTF-8, large payloads, and forced Python fallback.
 
+**Status (issue #127):** deliberately deferred until the Phase 1 measurement
+schema lands. `rust_consume_stream()` ships in the wheel and is exercised by
+tests, but no production code routes a consume through it; the symbol is
+annotated as "implemented but not yet integrated" in `cuprum/_streams_rs.py`
+and the users' guide so it is not mistaken for a wired bridge. A guard test
+(`cuprum/unittests/test_rust_streams.py`) fails if production code starts
+referencing the symbol without revisiting this decision.
+
 ### Phase 3: Raw sink echo and tee helper
 
 Add the Rust raw sink helper behind capability checks. Extend the profiling

--- a/docs/adr-002-additional-rust-components.md
+++ b/docs/adr-002-additional-rust-components.md
@@ -309,7 +309,7 @@ measured tee scenario. This evidence justifies the Phase 2 dispatcher
 experiment, but it does not satisfy the wall-time acceptance gate by itself;
 that gate still requires a Rust-versus-Python dispatcher benchmark showing at
 least 20% lower median wall time for the targeted heavy scenario, plus the
-regression checks listed above. The first dispatcher must still remain narrower
+regression checks listed above. The first dispatcher must remain narrower
 than the public helper: fd-backed, UTF-8/replace, capture-only streams with no
 echo sink and no line callbacks.
 

--- a/docs/adr-002-additional-rust-components.md
+++ b/docs/adr-002-additional-rust-components.md
@@ -302,13 +302,31 @@ Route eligible capture-only streams through `rust_consume_stream()`. Add unit,
 behavioural, and property tests that prove parity for stdout, stderr, empty
 streams, invalid UTF-8, large payloads, and forced Python fallback.
 
-**Status (issue #127):** deliberately deferred until the Phase 1 measurement
-schema lands. `rust_consume_stream()` ships in the wheel and is exercised by
-tests, but no production code routes a consume through it; the symbol is
-annotated as "implemented but not yet integrated" in `cuprum/_streams_rs.py`
-and the users' guide so it is not mistaken for a wired bridge. A guard test
+**Status (issue #127):** implemented but not yet integrated. The Phase 1 tee
+hot-path profiling baseline now supports capture-only consume dispatch:
+capture double-touch accounts for about 51% of parent CPU in the measured tee
+scenario, comfortably above the 20% acceptance threshold. The first dispatcher
+must still remain narrower than the public helper: fd-backed, UTF-8/replace,
+capture-only streams with no echo sink and no line callbacks.
+
+`rust_consume_stream()` ships in the wheel and is exercised by tests, but no
+production code routes a consume through it; the symbol is annotated as
+"implemented but not yet integrated" in `cuprum/_streams_rs.py` and the users'
+guide so it is not mistaken for a wired bridge. A guard test
 (`cuprum/unittests/test_rust_streams.py`) fails if production code starts
-referencing the symbol without revisiting this decision.
+referencing the symbol without revisiting this decision. Phase 2 integration
+should remove that marker only alongside the dispatcher, fallback path, and the
+Python/Rust parity property tests tracked by issue #90.
+
+The same profiling baseline records adjacent work that should not be folded
+into the initial `rust_consume_stream()` dispatcher:
+
+- increasing `_READ_SIZE` to 16-64 KiB is a cheap Python-path improvement that
+  stacks with Rust consume dispatch;
+- line-callback workloads are dominated by Python observe-hook event
+  construction and should be optimized separately;
+- pseudo-terminal echo cost is mostly kernel-side, so raw-sink Rust helpers
+  should not be expected to remove that cost.
 
 ### Phase 3: Raw sink echo and tee helper
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1538,7 +1538,7 @@ flowchart TD
     subgraph Rust Pathway
         H[cuprum._streams_rs]
         I[rust_pump_stream]
-        J[rust_consume_stream]
+        J[rust_consume_stream implemented, not integrated]
     end
 
     A --> B
@@ -1549,13 +1549,18 @@ flowchart TD
     E --> F
     E --> G
     H --> I
-    H --> J
+    H -. exposes .-> J
+    J -. Phase 2 candidate .-> G
 ```
 
 ### 13.3 API Boundary
 
 The Rust extension exposes three functions via PyO3. As of 4.2.2,
 `rust_pump_stream`, `rust_consume_stream`, and `is_available` are implemented.
+Only `rust_pump_stream` is currently routed by production dispatch.
+`rust_consume_stream` is implemented, tested, and exported for direct internal
+experimentation, but stdout and stderr consumption still uses the Python
+implementation until ADR-002 Phase 2 lands.
 
 ```python
 # cuprum/_streams_rs.pyi (type stubs)
@@ -1627,6 +1632,16 @@ def is_available() -> bool:
 `rust_consume_stream` performs incremental UTF-8 decoding with a pending byte
 buffer so that chunk boundaries do not affect output. Invalid byte sequences
 are replaced with the Unicode replacement character (U+FFFD).
+
+The Phase 1 tee hot-path profiling baseline
+([2026-06-12](tee-hotpath-profiling-baseline-2026-06-12.md)) supports wiring a
+future capture-only dispatcher: the measured tee scenario spends about 51% of
+parent CPU in capture double-touch (`bytearray` growth plus final full-buffer
+decode), which is the overhead `rust_consume_stream` targets. That evidence
+does not broaden the first integration boundary. The Phase 2 dispatcher should
+select Rust only for fd-backed, UTF-8/replace, capture-only streams with no
+echo sink and no line callbacks, and should keep Python fallback as the
+behavioural reference.
 
 For screen readers: The following sequence diagram shows the Python-to-Rust
 call flow for `rust_consume_stream`, including buffer validation, file
@@ -1729,6 +1744,11 @@ Cuprum selects the stream backend at runtime using the following precedence:
    - if extraction fails for either side, dispatch falls back to Python
      `_pump_stream()` for that transfer.
 
+Final stdout and stderr consumption currently bypasses this Rust dispatch
+pathway. `rust_consume_stream()` remains a Phase 2 candidate behind the
+ADR-002 measurement and parity-test gates, so backend selection does not change
+capture semantics yet.
+
 This strategy ensures:
 
 - existing pure Python installations continue to work unchanged;
@@ -1810,7 +1830,7 @@ and call is_available"]
     E --> I["Use cuprum._streams
 (_pump_stream / _consume_stream)"]
     H --> J["Use cuprum._streams_rs
-(rust_pump_stream / rust_consume_stream)"]
+(rust_pump_stream for pipeline pump)"]
 
     I --> K["Return result to caller"]
     J --> K
@@ -1831,6 +1851,15 @@ The following table summarizes when each pathway is recommended:
 
 Current Rust acceleration applies to inter-stage pipeline pumping, not
 stdout/stderr capture.
+
+The `rust_consume_stream()` helper targets a measured capture-only hotspot but
+is not yet integrated. The tee profiling baseline found that capture plus echo
+is 2.1 times slower than echo-only for the large deterministic fixture, with
+about half of parent CPU in Python buffer growth and final decode. It also
+found that line-callback workloads are dominated by Python event construction,
+and that pseudo-terminal echo cost is mostly kernel-side. Those findings keep
+the first consume integration scoped to capture-only streams and leave
+callbacks, echo sinks, and terminal-specific work on later phases.
 
 The Rust pathway provides the greatest benefit for:
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1870,7 +1870,7 @@ The Rust pathway provides the greatest benefit for:
 The Python pathway remains preferable when:
 
 - line-by-line observation hooks (`on_line`) are registered;
-- teeing to sinks (`echo_output`) is required;
+- teeing to sinks (`echo=True`) is required;
 - stdout/stderr capture behaviour must exactly follow the current Python decode
   and sink-handling path;
 - debugging requires visibility into the event loop;
@@ -1885,18 +1885,20 @@ pathway. The following behaviours are only available via the Python backend:
   requires Python callbacks for each decoded line. When an `on_line` handler is
   registered, the dispatcher automatically routes to the Python pathway.
 
-- **Teeing to sinks (`echo_output`):** The Python pathway can write chunks to a
+- **Teeing to sinks (`echo=True`):** The Python pathway can write chunks to a
   `sink` (e.g. `sys.stdout`) whilst simultaneously capturing output. The Rust
-  extension does not support this; when `echo_io=True`, the dispatcher routes
+  extension does not support this; when `echo=True`, the dispatcher routes
   to Python.
 
 - **Custom encodings:** The Rust extension always decodes as UTF-8 with
   replacement semantics. Other encodings or error modes require the Python
   pathway.
 
-The dispatcher in `cuprum/_backend.py` inspects the stream configuration and
-automatically selects the Python pathway when any unsupported feature is
-requested. Callers do not need to manage this routing explicitly.
+Only pump-side routing has Rust backing today: `_pump_stream_dispatch` can use
+Rust for inter-stage pipe transfer, but final stdout/stderr consume still routes
+through the Python `_consume_stream` path. There is no production
+`_consume_stream_dispatch` for `rust_consume_stream()` yet, so callers do not
+need to manage consume routing explicitly.
 
 ### 13.6 Thread Safety and Asyncio Integration
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1887,18 +1887,19 @@ pathway. The following behaviours are only available via the Python backend:
 
 - **Teeing to sinks (`echo=True`):** The Python pathway can write chunks to a
   `sink` (e.g. `sys.stdout`) whilst simultaneously capturing output. The Rust
-  extension does not support this; when `echo=True`, the dispatcher routes
-  to Python.
+  extension does not support this; `echo=True` keeps consumption on the Python
+  path.
 
 - **Custom encodings:** The Rust extension always decodes as UTF-8 with
   replacement semantics. Other encodings or error modes require the Python
   pathway.
 
 Only pump-side routing has Rust backing today: `_pump_stream_dispatch` can use
-Rust for inter-stage pipe transfer, but final stdout/stderr consume still routes
-through the Python `_consume_stream` path. There is no production
-`_consume_stream_dispatch` for `rust_consume_stream()` yet, so callers do not
-need to manage consume routing explicitly.
+Rust for inter-stage pipe transfer, but final stdout/stderr consumption still
+uses the Python `_consume_stream` path directly. Phase 2 deferment remains in
+force until a production `_consume_stream_dispatch` for `rust_consume_stream()`
+is wired and tested, so callers do not need to manage consume routing
+explicitly.
 
 ### 13.6 Thread Safety and Asyncio Integration
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1883,7 +1883,7 @@ pathway. The following behaviours are only available via the Python backend:
 
 - **Line callbacks (`on_line`):** The `_consume_stream_with_lines()` code path
   requires Python callbacks for each decoded line. When an `on_line` handler is
-  registered, the dispatcher automatically routes to the Python pathway.
+  registered, stream consumption stays on the Python pathway.
 
 - **Teeing to sinks (`echo=True`):** The Python pathway can write chunks to a
   `sink` (e.g. `sys.stdout`) whilst simultaneously capturing output. The Rust

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -42,7 +42,6 @@ uv run pytest -q cuprum/unittests/test_line_splitting.py
 Run `make test` before committing so the stream behaviour and the pure helper
 contracts stay aligned.
 
-
 ## `rust_consume_stream` integration status
 
 `rust_consume_stream` is implemented, tested, and exported, but not yet routed

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -42,6 +42,17 @@ uv run pytest -q cuprum/unittests/test_line_splitting.py
 Run `make test` before committing so the stream behaviour and the pure helper
 contracts stay aligned.
 
+
+## `rust_consume_stream` integration status
+
+`rust_consume_stream` is implemented, tested, and exported, but not yet routed
+through production consume paths.
+Integration is deferred to
+[ADR-002: Additional Rust components](adr-002-additional-rust-components.md)
+(Phase 2). The rationale is to keep consume dispatch on hold until the
+ADR-002 Phase 2 stack is complete, including dispatcher wiring, the Python
+fallback path, and parity/property coverage.
+
 ## Fail-fast reducer properties
 
 `_build_final_results` in `cuprum/concurrent.py` is the pure reducer that

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -5,7 +5,10 @@ test, lint, release, debugging, and extension workflows and acts as the source
 of truth for day-to-day contributor expectations. For the system design, see
 the [design document](cuprum-design.md); for where code lives, see the
 [repository layout](repository-layout.md); and for accepted architectural
-decisions, see [ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md).
+decisions, see
+[ADR-002: Additional Rust components](adr-002-additional-rust-components.md),
+[ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md), and
+[ADR-004: Interrogate docstring gate](adr-004-interrogate-docstring-gate.md).
 
 ## Stream line-splitting properties
 
@@ -44,8 +47,9 @@ contracts stay aligned.
 
 ## `rust_consume_stream` integration status
 
-`rust_consume_stream` is implemented, tested, and exported, but not yet routed
-through production consume paths.
+`rust_consume_stream` is implemented, tested, and exported, but production
+consumes currently go through the pure-Python `_consume_stream` function until
+Phase 2 is complete.
 Integration is deferred to
 [ADR-002: Additional Rust components](adr-002-additional-rust-components.md)
 (Phase 2). The rationale is to defer consume-side dispatch until the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -48,7 +48,7 @@ contracts stay aligned.
 through production consume paths.
 Integration is deferred to
 [ADR-002: Additional Rust components](adr-002-additional-rust-components.md)
-(Phase 2). The rationale is to keep consume dispatch on hold until the
+(Phase 2). The rationale is to defer consume-side dispatch until the
 ADR-002 Phase 2 stack is complete, including dispatcher wiring, the Python
 fallback path, and parity/property coverage.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -8,7 +8,7 @@ the [design document](cuprum-design.md); for where code lives, see the
 decisions, see
 [ADR-002: Additional Rust components](adr-002-additional-rust-components.md),
 [ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md), and
-[ADR-004: Interrogate docstring gate](adr-004-interrogate-docstring-gate.md).
+[ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md).
 
 ## Stream line-splitting properties
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -206,3 +206,262 @@ scenarios whilst maintaining pure Python as a first-class pathway.
 - [x] 4.5.4. Add a troubleshooting section for common issues: missing wheels on
   exotic platforms, forced fallback behaviour, and benchmark result
   interpretation.
+
+## 5. Reclaim the pure-Python consume hot path
+
+Idea: if the cheap, Rust-free tuning that the tee profiling baseline identified
+— a larger read size and a lean per-line event path — lands before any consume
+dispatcher, the Rust bridge must prove itself against an already-tuned Python
+baseline. This keeps the 20% acceptance gate honest rather than crediting Rust
+for wins a one-line Python change already captures.
+
+This phase turns the baseline's two pure-Python findings into shipped
+improvements: the read-size plateau (about a 20% win on every parent-side
+consume path) and the per-line observe-hook dispatch cost (the dominant tee-path
+cost when line callbacks are active). Both are independent of the Rust extension
+and deliver value on their own.
+
+### 5.1. Bank the read-size win on every parent-side consume path
+
+This step answers how much consume overhead a buffer-size bump alone reclaims
+and where it plateaus. Its outcome sets the tuned Python baseline that the
+consume dispatcher in phase 6 must beat. See
+tee-hotpath-profiling-baseline-2026-06-12.md §1 (Table 3) and
+adr-002-additional-rust-components.md Proposal 3.
+
+- [ ] 5.1.1. Raise `_READ_SIZE` (`cuprum/_streams.py:14`) from 4 KiB to the
+  profiled plateau in the 16-64 KiB range, choosing the value from a fresh
+  read-size sweep rather than assuming the baseline number.
+  - Update `test_stream_preserves_random_payloads_around_python_read_size_boundary`
+    (`cuprum/unittests/test_stream_property_based.py:120`) to exercise chunk
+    boundaries around the new size.
+  - Success: the `tee-devnull-nocb-s1` scenario wall time falls by roughly 20%
+    against the recorded baseline with no parity regressions, and the chosen
+    value plus its measurement are recorded alongside the baseline document.
+
+### 5.2. Make per-line event emission cheap for line-callback workloads
+
+This step answers whether the roughly 46x line-callback slowdown can be cut by
+removing per-line work from the observe-hook path without changing observable
+event semantics. Its outcome informs whether per-line events ever need to become
+opt-in. See tee-hotpath-profiling-baseline-2026-06-12.md §5 (Table 4).
+
+- [ ] 5.2.1. Hoist the invariant `ExecEvent` / `_EventDetails`
+  (`cuprum/events.py:31`, `cuprum/_pipeline_types.py:40`) fields out of the
+  per-line path in `_StageObservation.emit` (`cuprum/_pipeline_types.py:62`),
+  precomputing programme, argv (`SafeCmd.argv_with_program`, `cuprum/sh.py:363`),
+  cwd, env, and pid once per stream rather than per line.
+  - Success: per-line emission no longer reconstructs invariant fields, and the
+    callback scenario's dataclass-construction share (about 39% per the baseline)
+    drops measurably while emitted event payloads are unchanged.
+- [ ] 5.2.2. Remove the per-hook `inspect.isawaitable` call from the per-line
+  path in `_emit_exec_event` (`cuprum/_observability.py:35`) by classifying each
+  hook as sync or async once at registration.
+  - Requires 5.2.1.
+  - Success: known-sync hooks dispatch without per-line awaitable detection, and
+    async hooks retain identical scheduling behaviour.
+- [ ] 5.2.3. Add a combinatorial event-parity suite proving the optimized path is
+  behaviour-preserving across the hook-type and stream-mode matrix.
+  - Requires 5.2.1 and 5.2.2.
+  - Cover sync and async hooks crossed with capture, echo, and line-callback
+    modes.
+  - Success: emitted event payloads (programme, argv, cwd, env, pid, line, and
+    timestamp semantics) are equivalent before and after the optimization for
+    every combination in the matrix.
+
+## 6. Trustworthy, accelerated capture-only consume (issues `#90`, `#127`)
+
+Idea: if a narrowly scoped capture-only consume dispatcher clears the 20%
+wall-time gate the baseline projects from the roughly 51% capture double-touch —
+measured against the tuned phase 5 baseline — Cuprum can route the measured
+hotspot through Rust while keeping Python as the behavioural reference. If it
+cannot clear the gate, `rust_consume_stream` stays inert and the negative result
+is recorded.
+
+Issue `#127` deliberately took the annotate-first fork: `rust_consume_stream` is
+shipped, tested, and documented as "implemented but not integrated", guarded by
+tests that fail if production code routes through it. This phase resolves that
+ambiguity by either wiring the dispatcher symmetric to `_pump_stream_dispatch`
+or recording why the gate was not met. Issue `#90` (proptest at the PyO3
+boundary) is folded in as the correctness de-risking step.
+
+### 6.1. Harden the PyO3 stream boundary so Rust and Python are interchangeable
+
+This step answers whether `rust_pump_stream` and `rust_consume_stream` map errors
+and decode identically to Python across the full input domain, not just scenario
+fixtures. Its outcome is the correctness foundation the dispatcher relies on. See
+issue `#90`, tee-hotpath-profiling-baseline-2026-06-12.md §§3-4, and
+adr-002-additional-rust-components.md (decoding-drift and FD-ownership risks).
+
+- [ ] 6.1.1. Introduce a `RustStreamError` enum in `rust/cuprum-rust/src/lib.rs`
+  and convert it to PyO3 errors at a single boundary point.
+  - Success: invalid `buffer_size` raises `ValueError` and I/O failures raise
+    `OSError`, with the conversion centralized rather than scattered across call
+    sites.
+- [ ] 6.1.2. Add proptest parity and error-mapping coverage at the boundary.
+  - Requires 6.1.1.
+  - Cover empty, ASCII, and 2-, 3-, and 4-byte UTF-8 payloads, invalid bytes
+    replaced with U+FFFD, and payloads around 1 MiB, plus default-versus-explicit
+    `buffer_size` equivalence.
+  - Success: proptest proves Rust-versus-Python consume parity across the
+    generated domain with shrinking enabled and regression seeds committed.
+
+### 6.2. Establish the wall-time acceptance gate against the tuned baseline
+
+This step answers whether native read-and-decode beats the tuned Python consume
+by the 20% the ADR requires, on the one eligible scenario. Its outcome decides
+whether wiring proceeds at all. See
+adr-002-additional-rust-components.md Phase 2,
+tee-hotpath-profiling-baseline-2026-06-12.md §"Implications" item 1, and roadmap
+step 4.4.
+
+- [ ] 6.2.1. Add a Rust-versus-Python consume dispatcher benchmark for the
+  fd-backed, UTF-8/replace, capture-only, no-echo, no-callback scenario, measured
+  against the phase 5 tuned baseline.
+  - Requires phase 5 and 6.1.1.
+  - Success: the benchmark reports median wall time for both paths and publishes
+    it to the workflow summary; the gate passes only when the Rust median is at
+    least 20% lower, and the verdict (pass or fail) is recorded in
+    adr-002-additional-rust-components.md.
+
+### 6.3. Wire `_consume_stream_dispatch` and route capture through it
+
+This step answers whether consume dispatch can reuse the pump-dispatch shape with
+a strict eligibility predicate and transparent fallback. It proceeds only if the
+gate in 6.2 passed. See `cuprum/_pipeline_streams.py:290`
+(`_pump_stream_dispatch`) and the `_StreamConfig` fields in `cuprum/_streams.py`.
+
+- [ ] 6.3.1. Implement `_consume_stream_dispatch` mirroring
+  `_pump_stream_dispatch`, with an eligibility predicate over `_StreamConfig`:
+  `capture_output and not echo_output`, UTF-8 `encoding`, `errors == "replace"`,
+  no line callback (`on_line is None`), and an extractable reader FD; otherwise
+  fall back to the Python `_consume_stream`.
+  - Requires 6.1.1 and 6.2.1.
+  - Route the consume call sites at `cuprum/_subprocess_execution.py:229,236` and
+    `cuprum/_pipeline_stage_streams.py:71,94` through the dispatcher.
+  - Success: a backend-selection test proves Rust is engaged only when the
+    predicate holds and `get_stream_backend()` is `RUST`, and that dispatch falls
+    back to Python when the extension is absent, the FD is unavailable, or the
+    config is ineligible (verified with a monkeypatched fake and call-count
+    assertions).
+- [ ] 6.3.2. Remove the inert-status markers and invert the guards now that
+  production routes through the symbol.
+  - Requires 6.3.1.
+  - Update the `rust_consume_stream` docstring in `cuprum/_streams_rs.py`, and
+    flip `test_rust_consume_stream_not_referenced_in_production` and
+    `test_rust_consume_stream_docstring_not_integrated`
+    (`cuprum/unittests/test_rust_streams.py`) to assert the wired state.
+  - Success: `make check-fmt lint test` is green with the guards asserting
+    production routing rather than its absence.
+- [ ] 6.3.3. Add a combinatorial fallback E2E suite across the eligibility matrix.
+  - Requires 6.3.1.
+  - Cover backend (`auto`, `rust`, `python`) crossed with capture, echo,
+    line-callback, encoding (UTF-8 and non-UTF-8), error policy (`replace` and
+    `strict`), and reader kind (fd-backed versus in-memory).
+  - Success: every ineligible combination produces byte-identical output to the
+    Python reference, and only the single eligible combination engages Rust.
+
+### 6.4. Reflect the outcome in the ADR and the guides
+
+This step answers how readers learn the symbol's true status, whichever way the
+gate fell. See adr-002-additional-rust-components.md Phase 2, cuprum-design.md
+§13, and docs/users-guide.md.
+
+- [ ] 6.4.1. Record the phase 6 outcome in the documentation set.
+  - Requires 6.2.1 and 6.3.2.
+  - If the gate passed: mark ADR-002 Phase 2 as integrated, update the design-doc
+    §13 diagrams and prose, and describe the consume eligibility conditions and
+    transparent fallback in the users' guide.
+  - If the gate failed: record the measured shortfall, keep the inert annotation,
+    and note the negative result so the symbol is not mistaken for a wired bridge.
+  - Success: no documentation describes `rust_consume_stream` in a way that
+    contradicts its actual production status.
+
+## 7. Raw-sink echo and tee acceleration (ADR-002 Proposal 2)
+
+Idea: if a Rust raw-sink echo and tee helper removes the Python read-write loop
+for fd-backed sinks, the echo and tee paths gain the same native benefit as the
+pump. The baseline predicts PTY echo cost is kernel-side, so this slice must
+prove where the helper actually helps and refuse to promise wins it cannot
+deliver.
+
+This phase extends the established Rust pathway to the echo and tee directions
+rather than building a parallel path, reusing the boundary hardening from step
+6.1. See adr-002-additional-rust-components.md Phase 3 and Proposal 2.
+
+### 7.1. Profile and bound the raw-sink opportunity before building
+
+This step answers which sink types a native echo and tee loop actually
+accelerates, given that PTY cost is kernel-side. Its outcome scopes the helper
+and prevents building dispatch for sinks it cannot help. See
+tee-hotpath-profiling-baseline-2026-06-12.md §"Implications" item 4 and Table 2
+(`echo-pty-nocb-s1` at 33 s).
+
+- [ ] 7.1.1. Extend the profiling harness to compare the Python loop with a
+  prototype native raw-sink loop across devnull, text-blackhole, and PTY sinks.
+  - Success: a documented verdict names which sink kinds clear a 20% gate, with
+    PTY explicitly characterized as kernel-bound and excluded from dispatch if it
+    does not clear the gate.
+
+### 7.2. Ship the raw-sink helper behind capability checks for qualifying sinks
+
+This step answers whether the native helper can accelerate qualifying sinks while
+falling back transparently for the rest. See
+adr-002-additional-rust-components.md Proposal 2 and cuprum-design.md §13.
+
+- [ ] 7.2.1. Implement the Rust raw-sink echo and tee helper with FD capability
+  detection and Python fallback, routing only the sink kinds qualified by 7.1.1.
+  - Requires 6.1.1 and 7.1.1.
+  - Success: qualifying fd-backed sinks route through Rust with parity to Python;
+    non-qualifying sinks (including PTY unless 7.1.1 qualified it) fall back
+    transparently; and the open question of which raw sink types qualify is
+    resolved in adr-002-additional-rust-components.md.
+
+## 8. Deferred reliability and native-orchestration extensions
+
+Idea: if the consume and echo acceleration paths are already trustworthy and
+boring to operate, the remaining native-orchestration bets and the latent
+reliability issues the baseline surfaced can be evaluated on their own merits
+rather than gating the acceleration work.
+
+### 8.1. Close the Rust pump file-descriptor close race
+
+This step removes a silent failure the baseline observed on the shipped pump
+path. See tee-hotpath-profiling-baseline-2026-06-12.md §"Incidental findings"
+item 1, adr-002-additional-rust-components.md (FD ownership risk), and issues
+`#124` / `#125`.
+
+- [ ] 8.1.1. Fix the silent `OSError: [Errno 9] Bad file descriptor` raised from
+  `_UnixWritePipeTransport._call_connection_lost` during Rust pump shutdown.
+  - Success: the `echo-devnull-nocb-s4-rust` scenario logs no bad-FD errors
+    across repeated runs, FD ownership at pump teardown is documented, and a
+    regression test reproduces the close race and asserts clean shutdown.
+
+### 8.2. Restore Python-frame attribution in perf captures
+
+This step removes a tooling gap that weakens the evidence base future phases rely
+on. See tee-hotpath-profiling-baseline-2026-06-12.md §"Incidental findings" item
+2.
+
+- [ ] 8.2.1. Investigate why distro perf 6.12 drops `py::` trampoline frames in
+  `perf script` while resolving them in `perf report`.
+  - Success: `stacks.folded` and `summary.json` carry Python-level frames, or the
+    limitation is documented and the py-spy corroboration workaround is promoted
+    to a first-class harness default.
+
+### 8.3. Decide on native subprocess and pipeline orchestration
+
+This step resolves the two heaviest ADR-002 bets, which the design explicitly
+defers. See adr-002-additional-rust-components.md Proposals 4 and 5 (Phases 4 and
+5).
+
+- [ ] 8.3.1. Prototype the synchronous Rust subprocess fast path and record a
+  go/no-go decision.
+  - Requires phase 6.
+  - Success: a benchmark-backed decision is captured in
+    adr-002-additional-rust-components.md.
+- [ ] 8.3.2. Decide whether full native pipeline orchestration graduates from
+  deferral.
+  - Requires 8.3.1.
+  - Success: the decision and its rationale (likely continued deferral) are
+    recorded in adr-002-additional-rust-components.md.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -321,8 +321,10 @@ step 4.4.
   - Requires phase 5 and 6.1.1.
   - Success: the benchmark reports median wall time for both paths and publishes
     it to the workflow summary; the gate passes only when the Rust median is at
-    least 20% lower, and the verdict (pass or fail) is recorded in
-    adr-002-additional-rust-components.md.
+    least 20% lower on the eligible path, small-output fallback scenarios stay
+    within a 5% median wall-time regression budget, Python/Rust parity is
+    confirmed before any Rust routing, and the verdict (pass or fail) is recorded
+    in adr-002-additional-rust-components.md.
 
 ### 6.3. Wire `_consume_stream_dispatch` and route capture through it
 
@@ -368,7 +370,7 @@ gate fell. See adr-002-additional-rust-components.md Phase 2, cuprum-design.md
 §13, and docs/users-guide.md.
 
 - [ ] 6.4.1. Record the phase 6 outcome in the documentation set.
-  - Requires 6.2.1 and 6.3.2.
+  - Requires 6.2.1 in all cases. The passed-gate branch also requires 6.3.2.
   - If the gate passed: mark ADR-002 Phase 2 as integrated, update the design-doc
     §13 diagrams and prose, and describe the consume eligibility conditions and
     transparent fallback in the users' guide.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -235,9 +235,10 @@ adr-002-additional-rust-components.md Proposal 3.
   - Update `test_stream_preserves_random_payloads_around_python_read_size_boundary`
     (`cuprum/unittests/test_stream_property_based.py:120`) to exercise chunk
     boundaries around the new size.
-  - Success: the `tee-devnull-nocb-s1` scenario wall time falls by roughly 20%
-    against the recorded baseline with no parity regressions, and the chosen
-    value plus its measurement are recorded alongside the baseline document.
+  - Success: the `tee-devnull-nocb-s1` scenario median wall time is at least 20%
+    lower than tee-hotpath-profiling-baseline-2026-06-12.md §1 (Table 3), with
+    no parity regressions, and the chosen value plus its benchmark artefact are
+    recorded alongside the baseline document.
 
 ### 5.2. Make per-line event emission cheap for line-callback workloads
 
@@ -251,15 +252,18 @@ opt-in. See tee-hotpath-profiling-baseline-2026-06-12.md §5 (Table 4).
   per-line path in `_StageObservation.emit` (`cuprum/_pipeline_types.py:62`),
   precomputing programme, argv (`SafeCmd.argv_with_program`, `cuprum/sh.py:363`),
   cwd, env, and pid once per stream rather than per line.
-  - Success: per-line emission no longer reconstructs invariant fields, and the
-    callback scenario's dataclass-construction share (about 39% per the baseline)
-    drops measurably while emitted event payloads are unchanged.
+  - Success: per-line emission no longer reconstructs invariant fields, the
+    callback scenario's dataclass-construction share falls from the 39% baseline
+    to no more than 10% in a committed profiler artefact, and emitted event
+    payloads are unchanged.
 - [ ] 5.2.2. Remove the per-hook `inspect.isawaitable` call from the per-line
   path in `_emit_exec_event` (`cuprum/_observability.py:35`) by classifying each
   hook as sync or async once at registration.
   - Requires 5.2.1.
-  - Success: known-sync hooks dispatch without per-line awaitable detection, and
-    async hooks retain identical scheduling behaviour.
+  - Success: known-sync hooks dispatch without per-line awaitable detection,
+    async hooks retain identical scheduling behaviour, and a committed profiler
+    artefact shows `inspect.isawaitable` contributes 0 sampled frames in the
+    per-line hot path.
 - [ ] 5.2.3. Add a combinatorial event-parity suite proving the optimized path is
   behaviour-preserving across the hook-type and stream-mode matrix.
   - Requires 5.2.1 and 5.2.2.
@@ -318,7 +322,7 @@ step 4.4.
 - [ ] 6.2.1. Add a Rust-versus-Python consume dispatcher benchmark for the
   fd-backed, UTF-8/replace, capture-only, no-echo, no-callback scenario, measured
   against the phase 5 tuned baseline.
-  - Requires phase 5 and 6.1.1.
+  - Requires phase 5, 6.1.1, and 6.1.2.
   - Success: the benchmark reports median wall time for both paths and publishes
     it to the workflow summary; the gate passes only when the Rust median is at
     least 20% lower on the eligible path, small-output fallback scenarios stay

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1095,8 +1095,10 @@ for the internal stream dispatcher and may change without notice.
 unlike the pump side (which is routed through a Rust-then-Python dispatcher),
 no production code path routes stream consumption through it, and every consume
 uses the pure-Python implementation regardless of the selected backend.
-Consume-side dispatch is deferred, evidence-gated work tracked as Phase 2 of
-ADR-002.
+Consume-side dispatch is evidence-gated Phase 2 work in ADR-002. The tee
+hot-path profiling baseline now supports a future capture-only dispatcher, but
+that dispatcher has not landed yet and will be limited to fd-backed,
+UTF-8/replace, capture-only streams without echo sinks or line callbacks.
 
 The Rust consume helper always decodes UTF-8 with replacement semantics for
 invalid sequences. Other encodings or error modes require the Python

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1091,6 +1091,13 @@ The Rust extension also exposes `cuprum._streams_rs.rust_consume_stream`, which
 reads a file descriptor and returns decoded text. This private API is intended
 for the internal stream dispatcher and may change without notice.
 
+`rust_consume_stream` is currently **implemented but not yet integrated**:
+unlike the pump side (which is routed through a Rust-then-Python dispatcher),
+no production code path routes stream consumption through it, and every consume
+uses the pure-Python implementation regardless of the selected backend.
+Consume-side dispatch is deferred, evidence-gated work tracked as Phase 2 of
+ADR-002.
+
 The Rust consume helper always decodes UTF-8 with replacement semantics for
 invalid sequences. Other encodings or error modes require the Python
 implementation.


### PR DESCRIPTION
## Summary

This branch resolves the asymmetric status of `rust_consume_stream` by annotating it as implemented but not yet integrated, per the ADR-002 migration plan.

Closes #127.

The pump half of the Rust acceleration story is wired (`_pump_stream_dispatch` with Rust-then-Python fallback), but `rust_consume_stream` — though shipped, public, tested, and documented — has no production caller. ADR-002 gates consume-routing on its Phase 1 measurement schema, so of the two resolutions the issue offers, this takes the annotation path; wiring a `_consume_stream_dispatch` now would bypass that evidence gate.

## Review walkthrough

- [cuprum/_streams_rs.py](https://github.com/leynos/cuprum/blob/issue-127-consume-stream-dispatch/cuprum/_streams_rs.py): module and function docstrings state the integration status and point at ADR-002 Phase 2.
- [docs/users-guide.md](https://github.com/leynos/cuprum/blob/issue-127-consume-stream-dispatch/docs/users-guide.md): the private-API section no longer presents the symbol as a wired bridge.
- [docs/adr-002-additional-rust-components.md](https://github.com/leynos/cuprum/blob/issue-127-consume-stream-dispatch/docs/adr-002-additional-rust-components.md): the decision is recorded under the Phase 2 heading.
- [cuprum/unittests/test_rust_streams.py](https://github.com/leynos/cuprum/blob/issue-127-consume-stream-dispatch/cuprum/unittests/test_rust_streams.py): a guard test asserts the docstring marker is present and that no production module references the symbol, so the annotation and reality cannot drift.

## Validation

- `make check-fmt`: pass
- `make lint`: pass
- `make typecheck`: pass
- `make test`: pass (603 passed, 44 skipped; Rust suite passes with 4 passed)
- `make markdownlint`: pass
- `make nixie`: pass
- `coderabbit review --agent`: 0 findings

## Notes

When Phase 2 work lands (parity property tests per #90, dispatcher with fallback), the marker and the guard test are removed together — the guard's failure message says exactly that.

## References

- Lody session: https://lody.ai/leynos/sessions/25d2c4f7-aed5-4016-9644-a5680845ea70
