### PR TITLE
Add property-based tests for ProgramCatalogue indexing (#68)

### DIFF
--- a/cuprum/catalogue.py
+++ b/cuprum/catalogue.py
@@ -29,6 +29,33 @@ class UnknownProgramError(LookupError):
     """Raised when a program is not present in the catalogue allowlist."""
 
 
+class DuplicateProjectError(ValueError):
+    """Raised when a project name is registered more than once.
+
+    Carries the offending project name so callers can assert on the
+    rejection category and payload rather than parsing the message.
+    """
+
+    def __init__(self, project_name: str) -> None:
+        """Record the duplicated project name and build the message."""
+        self.project_name = project_name
+        super().__init__(f"Project '{project_name}' registered more than once")
+
+
+class DuplicateProgramError(ValueError):
+    """Raised when a program is claimed by more than one project.
+
+    Carries the contested program and the name of the project that
+    already owns it.
+    """
+
+    def __init__(self, program: Program, owner: str) -> None:
+        """Record the contested program and its existing owner."""
+        self.program = program
+        self.owner = owner
+        super().__init__(f"Program '{program}' already owned by '{owner}'")
+
+
 @dc.dataclass(frozen=True, slots=True)
 class ProjectSettings:
     """Metadata shared by a project's curated programs."""
@@ -101,8 +128,7 @@ class ProgramCatalogue:
         indexed: dict[str, ProjectSettings] = {}
         for project in projects:
             if project.name in indexed:
-                msg = f"Project '{project.name}' registered more than once"
-                raise ValueError(msg)
+                raise DuplicateProjectError(project.name)
             indexed[project.name] = project
         return indexed
 
@@ -115,9 +141,7 @@ class ProgramCatalogue:
         for project in projects.values():
             for program in project.programs:
                 if program in program_map:
-                    owner = program_map[program].name
-                    msg = f"Program '{program}' already owned by '{owner}'"
-                    raise ValueError(msg)
+                    raise DuplicateProgramError(program, program_map[program].name)
                 program_map[program] = project
         return program_map
 
@@ -160,6 +184,8 @@ __all__ = [
     "LS",
     "RSYNC",
     "TAR",
+    "DuplicateProgramError",
+    "DuplicateProjectError",
     "ProgramCatalogue",
     "ProgramEntry",
     "ProjectSettings",

--- a/cuprum/catalogue.py
+++ b/cuprum/catalogue.py
@@ -32,8 +32,15 @@ class UnknownProgramError(LookupError):
 class DuplicateProjectError(ValueError):
     """Raised when a project name is registered more than once.
 
-    Carries the offending project name so callers can assert on the
-    rejection category and payload rather than parsing the message.
+    Parameters
+    ----------
+    project_name : str
+        The duplicated project name.
+
+    Attributes
+    ----------
+    project_name : str
+        The duplicated project name.
     """
 
     def __init__(self, project_name: str) -> None:
@@ -45,8 +52,19 @@ class DuplicateProjectError(ValueError):
 class DuplicateProgramError(ValueError):
     """Raised when a program is claimed by more than one project.
 
-    Carries the contested program and the name of the project that
-    already owns it.
+    Parameters
+    ----------
+    program : Program
+        The contested program.
+    owner : str
+        The name of the project that already owns the program.
+
+    Attributes
+    ----------
+    program : Program
+        The contested program.
+    owner : str
+        The existing owner's project name.
     """
 
     def __init__(self, program: Program, owner: str) -> None:

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -60,6 +60,7 @@
       'cuprum/unittests/test_build_final_results_property.py',
       'cuprum/unittests/test_builder_library.py',
       'cuprum/unittests/test_catalogue.py',
+      'cuprum/unittests/test_catalogue_property_based.py',
       'cuprum/unittests/test_ci_benchmark_ratchet_profile.py',
       'cuprum/unittests/test_concurrency.py',
       'cuprum/unittests/test_context.py',

--- a/cuprum/unittests/test_catalogue.py
+++ b/cuprum/unittests/test_catalogue.py
@@ -13,6 +13,8 @@ from cuprum.catalogue import (
     LS,
     RSYNC,
     TAR,
+    DuplicateProgramError,
+    DuplicateProjectError,
     ProgramCatalogue,
     ProjectSettings,
     UnknownProgramError,
@@ -87,9 +89,11 @@ def test_duplicate_project_names_are_rejected() -> None:
         documentation_locations=("https://example.test/docs",),
         noise_rules=(r"^info",),
     )
-    with pytest.raises(ValueError, match="duplicate") as exc:
+    with pytest.raises(DuplicateProjectError, match="duplicate") as exc:
         ProgramCatalogue(projects=(dup, dup))
-    assert "duplicate" in str(exc.value), "Error message must mention duplicate name"
+    assert exc.value.project_name == "duplicate", (
+        "Error must carry the duplicated project name"
+    )
 
 
 def test_duplicate_programs_across_projects_are_rejected() -> None:
@@ -107,11 +111,11 @@ def test_duplicate_programs_across_projects_are_rejected() -> None:
         documentation_locations=("https://example.test/second",),
         noise_rules=(r"^second",),
     )
-    with pytest.raises(ValueError, match="shared") as exc:
+    with pytest.raises(DuplicateProgramError, match="shared") as exc:
         ProgramCatalogue(projects=(first, second))
-    assert "shared" in str(exc.value), "Error must mention the shared program name"
-    assert "first" in str(exc.value), (
-        "Error must include the original owning project name"
+    assert exc.value.program == shared, "Error must carry the contested program"
+    assert exc.value.owner == "first", (
+        "Error must carry the original owning project name"
     )
 
 

--- a/cuprum/unittests/test_catalogue_property_based.py
+++ b/cuprum/unittests/test_catalogue_property_based.py
@@ -28,7 +28,7 @@ import typing as typ
 from itertools import starmap
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from cuprum.catalogue import (
@@ -163,8 +163,7 @@ def test_duplicate_program_ownership_raises_structured_error(
     owned = [
         (program, project.name) for project in projects for program in project.programs
     ]
-    if not owned:
-        return  # Graph generated no programs; nothing to contest.
+    assume(owned)
     contested, owner_name = data.draw(
         st.sampled_from(owned),
         label="contested program",

--- a/cuprum/unittests/test_catalogue_property_based.py
+++ b/cuprum/unittests/test_catalogue_property_based.py
@@ -1,0 +1,178 @@
+"""Property-based tests for ``ProgramCatalogue`` indexing.
+
+These tests exercise catalogue construction over randomly generated
+ownership graphs instead of the fixed examples in ``test_catalogue.py``.
+Catalogue construction is pure data shuffling, so Hypothesis can explore
+the input domain cheaply.
+
+The invariants checked here are:
+
+- For any set of projects with unique names and disjoint program sets,
+  construction succeeds, the allowlist is exactly the union of all
+  project programs, and ``lookup``/``project_for``/``is_allowed`` agree
+  with the generated ownership graph.
+- Programs outside the generated universe are rejected uniformly:
+  ``is_allowed`` returns False and ``lookup`` raises
+  ``UnknownProgramError``.
+- A repeated project name is rejected with ``DuplicateProjectError``
+  carrying the duplicated name, regardless of where the duplicate sits
+  in the iterable.
+- A program owned by two projects is rejected with
+  ``DuplicateProgramError`` carrying the contested program and the name
+  of the project that registered it first.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from itertools import starmap
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from cuprum.catalogue import (
+    DuplicateProgramError,
+    DuplicateProjectError,
+    ProgramCatalogue,
+    ProjectSettings,
+    UnknownProgramError,
+)
+from cuprum.program import Program
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+# Small alphabets keep the namespace bounded so generated graphs overlap
+# and shrink well, while still covering multi-character names.
+_NAME_ALPHABET = "abcdef-"
+_PROJECT_NAMES = st.text(alphabet=_NAME_ALPHABET, min_size=1, max_size=8)
+_PROGRAM_NAMES = st.text(alphabet=_NAME_ALPHABET, min_size=1, max_size=8)
+
+
+def _make_project(name: str, programs: cabc.Sequence[str]) -> ProjectSettings:
+    """Build minimal ``ProjectSettings`` owning the given program names."""
+    return ProjectSettings(
+        name=name,
+        programs=tuple(Program(p) for p in programs),
+        documentation_locations=(f"https://example.test/{name}",),
+        noise_rules=(rf"^{name}:",),
+    )
+
+
+@st.composite
+def _ownership_graphs(
+    draw: st.DrawFn,
+) -> tuple[ProjectSettings, ...]:
+    """Generate projects with unique names and disjoint program sets."""
+    names = draw(
+        st.lists(_PROJECT_NAMES, min_size=1, max_size=5, unique=True),
+    )
+    programs = draw(
+        st.lists(
+            _PROGRAM_NAMES,
+            max_size=12,
+            unique=True,
+        ),
+    )
+    # Partition the program pool across projects; some projects may end
+    # up empty, which is a valid (if useless) configuration.
+    assignments: dict[str, list[str]] = {name: [] for name in names}
+    for program in programs:
+        owner = draw(st.sampled_from(names))
+        assignments[owner].append(program)
+    return tuple(starmap(_make_project, assignments.items()))
+
+
+@settings(max_examples=200)
+@given(projects=_ownership_graphs())
+def test_catalogue_indexes_match_generated_ownership(
+    projects: tuple[ProjectSettings, ...],
+) -> None:
+    """Construction over a valid graph reproduces the ownership exactly."""
+    catalogue = ProgramCatalogue(projects=projects)
+    expected = {
+        program: project for project in projects for program in project.programs
+    }
+    assert catalogue.allowlist == frozenset(expected), (
+        "Allowlist must equal the union of project programs"
+    )
+    for program, project in expected.items():
+        assert catalogue.is_allowed(program), "Owned program must be allowed"
+        entry = catalogue.lookup(program)
+        assert entry.program == program, "Lookup must return the queried program"
+        assert entry.project is project, "Lookup must attach the owning project"
+        assert catalogue.project_for(program) is project, (
+            "project_for must agree with lookup"
+        )
+    visible = catalogue.visible_settings()
+    assert dict(visible) == {project.name: project for project in projects}, (
+        "visible_settings must expose every project by name"
+    )
+
+
+@settings(max_examples=200)
+@given(projects=_ownership_graphs(), data=st.data())
+def test_programs_outside_graph_are_rejected(
+    projects: tuple[ProjectSettings, ...],
+    data: st.DataObject,
+) -> None:
+    """Programs not in the generated universe are uniformly blocked."""
+    catalogue = ProgramCatalogue(projects=projects)
+    owned = {str(p) for project in projects for p in project.programs}
+    unknown = data.draw(
+        _PROGRAM_NAMES.filter(lambda name: name not in owned),
+        label="unknown program",
+    )
+    assert not catalogue.is_allowed(unknown), "Unknown program must not be allowed"
+    with pytest.raises(UnknownProgramError):
+        catalogue.lookup(unknown)
+
+
+@settings(max_examples=200)
+@given(projects=_ownership_graphs(), data=st.data())
+def test_duplicate_project_name_raises_structured_error(
+    projects: tuple[ProjectSettings, ...],
+    data: st.DataObject,
+) -> None:
+    """Re-registering any project name fails with the duplicated name."""
+    duplicated = data.draw(
+        st.sampled_from([project.name for project in projects]),
+        label="duplicated project",
+    )
+    clone = _make_project(duplicated, [])
+    position = data.draw(
+        st.integers(min_value=0, max_value=len(projects)),
+        label="insertion position",
+    )
+    sequence = [*projects[:position], clone, *projects[position:]]
+    with pytest.raises(DuplicateProjectError) as exc:
+        ProgramCatalogue(projects=sequence)
+    assert exc.value.project_name == duplicated, (
+        "Error must carry the duplicated project name"
+    )
+
+
+@settings(max_examples=200)
+@given(projects=_ownership_graphs(), data=st.data())
+def test_duplicate_program_ownership_raises_structured_error(
+    projects: tuple[ProjectSettings, ...],
+    data: st.DataObject,
+) -> None:
+    """A program owned by two projects fails, naming the first owner."""
+    owned = [
+        (program, project.name) for project in projects for program in project.programs
+    ]
+    if not owned:
+        return  # Graph generated no programs; nothing to contest.
+    contested, owner_name = data.draw(
+        st.sampled_from(owned),
+        label="contested program",
+    )
+    rival = _make_project("rival-project", [str(contested)])
+    with pytest.raises(DuplicateProgramError) as exc:
+        ProgramCatalogue(projects=(*projects, rival))
+    assert exc.value.program == contested, "Error must carry the contested program"
+    assert exc.value.owner == owner_name, (
+        "Error must name the project that registered the program first"
+    )

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -10,6 +10,22 @@ of truth for day-to-day contributor expectations. For the system design, see the
 - [ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md)
 - [ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md)
 
+## Program catalogue duplicate diagnostics
+
+`ProgramCatalogue` indexes project settings in two passes: first by project
+name, then by program ownership. Keep duplicate diagnostics structured so tests
+and configuration tooling can assert on fields instead of parsing messages.
+
+- `DuplicateProjectError` is raised for repeated project names and exposes the
+  duplicated name as `project_name`.
+- `DuplicateProgramError` is raised when a program is claimed by more than one
+  project and exposes the contested `program` plus the existing owner's project
+  name as `owner`.
+
+Both exceptions intentionally subclass `ValueError` to preserve compatibility
+with callers that already treat catalogue construction failures as invalid
+configuration.
+
 ## Stream line-splitting properties
 
 Line callbacks in the Python stream backend use two pure helpers from

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -39,6 +39,19 @@ catalogue = ProgramCatalogue(projects=(project,))
 Downstream services can fetch metadata via `catalogue.visible_settings()` to
 propagate noise filters and documentation links alongside the allowlist.
 
+### Handling duplicate catalogue entries
+
+Catalogue construction rejects ambiguous project metadata before any command is
+built. If two project entries use the same name, `ProgramCatalogue` raises
+`DuplicateProjectError`; the exception carries the duplicated name in its
+`project_name` attribute. If two projects claim the same `Program`, catalogue
+construction raises `DuplicateProgramError`; the exception carries the contested
+`program` and the first owning project name in `owner`.
+
+Both duplicate exceptions subclass `ValueError`, so existing configuration
+loading code that catches `ValueError` continues to work while newer callers can
+inspect the structured payloads directly.
+
 ## Typed command core
 
 Cuprum provides `sh.make` to build typed `SafeCmd` instances from curated


### PR DESCRIPTION
## Summary

Closes #68

Adds Hypothesis property-based tests for `ProgramCatalogue` indexing, exercising random ownership graphs rather than the fixed examples in `test_catalogue.py`:

- **Index fidelity**: for any set of projects with unique names and disjoint program sets, the allowlist equals the union of project programs, and `lookup`/`project_for`/`is_allowed` agree with the generated graph; `visible_settings` exposes every project by name.
- **Unknown-program rejection**: programs outside the generated universe fail `is_allowed` and raise `UnknownProgramError` from `lookup`.
- **Duplicate project names**: re-registering any project name at an arbitrary position raises a structured error carrying the duplicated name.
- **Duplicate program ownership**: a program claimed by a second project raises a structured error carrying the contested program and the first owner's name.

Per the issue's verifiability recommendation, the private validators now raise structured duplicate diagnostics: `DuplicateProjectError` (carries `project_name`) and `DuplicateProgramError` (carries `program` and `owner`). Both subclass `ValueError`, so existing callers catching `ValueError` are unaffected; messages are unchanged. The example-based duplicate tests now assert on the structured payloads.

## Stacking

Based on `fix-interrogate-docstring-gaps` (PR #133); will rebase onto `main` once that merges.

## Testing

- `make check-fmt` passes
- `make lint` passes
- `make typecheck` passes
- `make test`: 643 passed, 44 skipped (Python); 4 passed, 0 skipped (Rust)
- `make markdownlint` passes
- `make nixie` passes

## References

- Lody session: https://lody.ai/leynos/sessions/4ee23873-95aa-4eba-b2cf-0d2e962d937c

