### PR TITLE
Run ruff from the locked virtualenv in make targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install CLI tools
         run: |
-          for tool in mbake ty ruff; do uv tool install ${tool}; done
+          for tool in mbake ty; do uv tool install ${tool}; done
           npm install -g markdownlint-cli2
 
       - name: Install Rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     env:
+      MBAKE_VERSION: '1.4.6'
+      TY_VERSION: '0.0.8'
       WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - name: Check out repository
@@ -28,7 +30,8 @@ jobs:
 
       - name: Install CLI tools
         run: |
-          for tool in mbake ty; do uv tool install ${tool}; done
+          uv tool install "mbake==${MBAKE_VERSION}"
+          uv tool install "ty==${TY_VERSION}"
           npm install -g markdownlint-cli2
 
       - name: Install Rust toolchain

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 MDFORMAT_ALL ?= mdformat-all
-TOOLS = $(MDFORMAT_ALL) ruff $(MDLINT) uv
-VENV_TOOLS = pytest
+TOOLS = $(MDFORMAT_ALL) $(MDLINT) uv
+VENV_TOOLS = pytest ruff
 RUST_DIR ?= rust
 CARGO ?= cargo
 BUILD_JOBS ?=
@@ -72,18 +72,18 @@ $(VENV_TOOLS): ## Verify required CLI tools in venv
 endif
 
 fmt: ruff $(MDFORMAT_ALL) ## Format sources
-	$(LOCAL_TOOL_ENV) ruff format
-	$(LOCAL_TOOL_ENV) ruff check --select I --fix
+	$(UV_RUN_ENV) uv run ruff format
+	$(UV_RUN_ENV) uv run ruff check --select I --fix
 	cd $(RUST_DIR) && $(CARGO) fmt --all
 	$(LOCAL_TOOL_ENV) $(MDFORMAT_ALL)
 
 check-fmt: ruff ## Verify formatting
-	$(LOCAL_TOOL_ENV) ruff format --check
+	$(UV_RUN_ENV) uv run ruff format --check
 	cd $(RUST_DIR) && $(CARGO) fmt --all -- --check
 	# mdformat-all doesn't currently do checking
 
 lint: ruff uv ## Run linters
-	$(LOCAL_TOOL_ENV) ruff check
+	$(UV_RUN_ENV) uv run ruff check
 	$(UV_RUN_ENV) uv run interrogate --fail-under 100 cuprum
 	$(PYLINT) $(PYLINT_TARGETS)
 	cd $(RUST_DIR) && RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,12 @@ PYLINT_PYTHON ?= pypy
 PYLINT_TARGETS ?= benchmarks conftest.py cuprum tests
 PYLINT_PYPY_SHIM_REF ?= 726d09f968b4d729ee4b29c71fc732e744854f3b
 PYLINT_PYPY_SHIM = git+https://github.com/leynos/pylint-pypy-shim.git@$(PYLINT_PYPY_SHIM_REF)
-PYLINT = $(UV_RUN_ENV) uv tool run --python $(PYLINT_PYTHON) --from '$(PYLINT_PYPY_SHIM)' pylint-pypy
+# Pin pylint itself: the shim ref is pinned but pylint is a floating
+# dependency of it, so new pylint releases would otherwise change lint
+# behaviour without any repository change (same skew class as ruff above).
+PYLINT_VERSION ?= 4.0.5
+PYLINT = $(UV_RUN_ENV) uv tool run --python $(PYLINT_PYTHON) \
+  --from '$(PYLINT_PYPY_SHIM)' --with 'pylint==$(PYLINT_VERSION)' pylint-pypy
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
         markdownlint nixie test typecheck benchmark-micro benchmark-e2e \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ UV_ENV = UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
 LOCAL_TOOL_PATH = $(HOME)/.local/bin:$(HOME)/.bun/bin:$(PATH)
 LOCAL_TOOL_ENV = PATH="$(LOCAL_TOOL_PATH)"
 UV_RUN_ENV = $(LOCAL_TOOL_ENV) $(UV_ENV)
+RUFF = $(UV_RUN_ENV) uv run ruff
 PYLINT_PYTHON ?= pypy
 PYLINT_TARGETS ?= benchmarks conftest.py cuprum tests
 PYLINT_PYPY_SHIM_REF ?= 726d09f968b4d729ee4b29c71fc732e744854f3b
@@ -77,18 +78,18 @@ $(VENV_TOOLS): ## Verify required CLI tools in venv
 endif
 
 fmt: ruff $(MDFORMAT_ALL) ## Format sources
-	$(UV_RUN_ENV) uv run ruff format
-	$(UV_RUN_ENV) uv run ruff check --select I --fix
+	$(RUFF) format
+	$(RUFF) check --select I --fix
 	cd $(RUST_DIR) && $(CARGO) fmt --all
 	$(LOCAL_TOOL_ENV) $(MDFORMAT_ALL)
 
 check-fmt: ruff ## Verify formatting
-	$(UV_RUN_ENV) uv run ruff format --check
+	$(RUFF) format --check
 	cd $(RUST_DIR) && $(CARGO) fmt --all -- --check
 	# mdformat-all doesn't currently do checking
 
 lint: ruff uv ## Run linters
-	$(UV_RUN_ENV) uv run ruff check
+	$(RUFF) check
 	$(UV_RUN_ENV) uv run interrogate --fail-under 100 cuprum
 	$(PYLINT) $(PYLINT_TARGETS)
 	cd $(RUST_DIR) && RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -96,12 +96,12 @@ startup overhead.
 Each worker process executes `worker_iterations` pipeline runs (default: 20).
 Hyperfine therefore measures a batched worker invocation rather than one cold
 pipeline execution, reducing Python interpreter startup noise in the ratchet.
-The ratchet itself compares each scenario's within-run `rust_mean /
-python_mean` ratio between the baseline and candidate runs, so runner-speed
-differences and residual startup overhead cancel out of the comparison.
-Dry-run plans record `benchmark_profile_version` and `worker_iterations`;
-ratchet comparison skips older baseline artefacts whose profile metadata does
-not match the current benchmark shape.
+The ratchet itself compares each scenario's within-run
+`rust_mean / python_mean` ratio between the baseline and candidate runs, so
+runner-speed differences and residual startup overhead cancel out of the
+comparison. Dry-run plans record `benchmark_profile_version` and
+`worker_iterations`; ratchet comparison skips older baseline artefacts whose
+profile metadata does not match the current benchmark shape.
 
 The remaining fields follow the benchmark plan: `output_path` receives
 hyperfine JSON or dry-run plan JSON, `worker_path` points at the worker module,
@@ -498,14 +498,22 @@ make lint
 
 `make lint` performs the following commands in order:
 
-1. `ruff check`
-2. `interrogate --fail-under 100 cuprum`
+1. `$(RUFF) check`
+2. `uv run interrogate --fail-under 100 cuprum`
 3. The PyPy-backed `pylint-pypy` command stored in `$(PYLINT)`, with
    `$(PYLINT_TARGETS)` appended.
 
 Each tier must pass before the next runs. When investigating a lint failure,
 fix the Ruff findings first, then the `interrogate` gaps, then rerun
 `make lint` to reach the Pylint tier.
+
+Ruff must be invoked through the project virtual environment, not as a floating
+host tool. The `RUFF` variable expands to `$(UV_RUN_ENV) uv run ruff`, and the
+`ruff` probe lives in `VENV_TOOLS` so `make` verifies that the locked
+dependency from `uv.lock` is available before running `fmt`, `check-fmt`, or
+`lint`. Continuous Integration (CI) and local runs must keep using this
+`uv run` path for Ruff linting and formatting so preview-rule changes only
+arrive through an explicit lockfile update.
 
 Because `interrogate` requires a docstring on every documentable node,
 documenting a large module can take it over the project's 400-line ceiling
@@ -520,15 +528,18 @@ The root `Makefile` exposes the following lint-related variables:
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable               | Default                                                                      | Purpose                                                                |
-| ---------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `PYLINT_PYTHON`        | `pypy`                                                                       | Python interpreter requested by `uv tool run` for the Pylint tier.     |
-| `PYLINT_TARGETS`       | `benchmarks conftest.py cuprum tests`                                        | Directories and files passed to `pylint-pypy`.                         |
-| `PYLINT_PYPY_SHIM_REF` | `726d09f968b4d729ee4b29c71fc732e744854f3b`                                   | Pinned revision of `leynos/pylint-pypy-shim`.                          |
-| `PYLINT_PYPY_SHIM`     | `git+https://github.com/leynos/pylint-pypy-shim.git@$(PYLINT_PYPY_SHIM_REF)` | Install source used by `uv tool run`.                                  |
-| `PYLINT`               | Derived command                                                              | Full PyPy-backed Pylint command used by `make lint`.                   |
-| `LOCAL_TOOL_ENV`       | Derived `PATH`                                                               | Adds local binary directories before invoking host tools such as Ruff. |
-| `UV_ENV`               | `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools`                               | Keeps `uv` cache and tool installs local to the worktree.              |
+| Variable               | Default                                                                      | Purpose                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `VENV_TOOLS`           | `pytest ruff`                                                                | Tools that must resolve through `uv run` from the locked virtualenv.       |
+| `RUFF`                 | `$(UV_RUN_ENV) uv run ruff`                                                  | Locked Ruff command used by `fmt`, `check-fmt`, and `lint`.                |
+| `PYLINT_PYTHON`        | `pypy`                                                                       | Python interpreter requested by `uv tool run` for the Pylint tier.         |
+| `PYLINT_TARGETS`       | `benchmarks conftest.py cuprum tests`                                        | Directories and files passed to `pylint-pypy`.                             |
+| `PYLINT_PYPY_SHIM_REF` | `726d09f968b4d729ee4b29c71fc732e744854f3b`                                   | Pinned revision of `leynos/pylint-pypy-shim`.                              |
+| `PYLINT_PYPY_SHIM`     | `git+https://github.com/leynos/pylint-pypy-shim.git@$(PYLINT_PYPY_SHIM_REF)` | Install source used by `uv tool run`.                                      |
+| `PYLINT`               | Derived command                                                              | Full PyPy-backed Pylint command used by `make lint`.                       |
+| `LOCAL_TOOL_ENV`       | Derived `PATH`                                                               | Adds local binary directories before invoking host and `uv`-managed tools. |
+| `UV_ENV`               | `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools`                               | Keeps `uv` cache and tool installs local to the worktree.                  |
+| `UV_RUN_ENV`           | `$(LOCAL_TOOL_ENV) $(UV_ENV)`                                                | Shared environment for locked `uv run` commands such as `$(RUFF)`.         |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -502,7 +502,7 @@ make lint
 `make lint` performs the following commands in order:
 
 1. `$(RUFF) check`
-2. `uv run interrogate --fail-under 100 cuprum`
+2. `$(UV_RUN_ENV) uv run interrogate --fail-under 100 cuprum`
 3. The PyPy-backed `pylint-pypy` command stored in `$(PYLINT)`, with
    `$(PYLINT_TARGETS)` appended.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -489,6 +489,9 @@ The short version is:
 - Pylint runs through the PyPy shim so that the third tier is isolated from the
   project virtual environment and matches the lint approach used by
   `leynos/episodic`.
+- `$(PYLINT)` pins Pylint itself with
+  `--with 'pylint==$(PYLINT_VERSION)'` because the shim revision and Pylint
+  package version are separate sources of lint behaviour.
 
 Run the complete lint gate with:
 
@@ -536,6 +539,7 @@ The root `Makefile` exposes the following lint-related variables:
 | `PYLINT_TARGETS`       | `benchmarks conftest.py cuprum tests`                                        | Directories and files passed to `pylint-pypy`.                             |
 | `PYLINT_PYPY_SHIM_REF` | `726d09f968b4d729ee4b29c71fc732e744854f3b`                                   | Pinned revision of `leynos/pylint-pypy-shim`.                              |
 | `PYLINT_PYPY_SHIM`     | `git+https://github.com/leynos/pylint-pypy-shim.git@$(PYLINT_PYPY_SHIM_REF)` | Install source used by `uv tool run`.                                      |
+| `PYLINT_VERSION`       | `4.0.5`                                                                      | Pylint package version supplied to `uv tool run` through `--with`.         |
 | `PYLINT`               | Derived command                                                              | Full PyPy-backed Pylint command used by `make lint`.                       |
 | `LOCAL_TOOL_ENV`       | Derived `PATH`                                                               | Adds local binary directories before invoking host and `uv`-managed tools. |
 | `UV_ENV`               | `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools`                               | Keeps `uv` cache and tool installs local to the worktree.                  |


### PR DESCRIPTION
## Summary

Fixes the systemic `lint-test` failure that was breaking every open PR (and `main` itself), and pins the second tool with the same exposure.

**ruff.** The CI lint job installed ruff with `uv tool install ruff`, which floats to the latest release (0.15.17 at the time of writing), while the project lockfile pins ruff 0.14.7. Because `pyproject.toml` sets `preview = true`, any new preview rule shipped upstream starts failing the gate without any change in this repository — RUF076 (`autouse=True` fixtures) fired on `conftest.py` and `tests/behaviour/test_stream_backend_pipeline.py`, both untouched by the open PRs.

- `Makefile`: the `fmt`, `check-fmt`, and `lint` targets invoke ruff through `uv run`, so CI and local runs both resolve the locked version; the `ruff` probe moves from the PATH tool list (`TOOLS`) to the virtualenv tool list (`VENV_TOOLS`).
- `.github/workflows/ci.yml`: drop the floating `uv tool install ruff` (the lint job already runs `make build`, which syncs the locked environment).

**pylint.** The `pylint-pypy-shim` git ref was already pinned, but pylint itself was a floating dependency of it — the same skew class: pylint 4.0.5 started flagging bound `str.format` references (`consider-using-f-string`) overnight, with no repository change. The `PYLINT` invocation now passes `--with 'pylint==$(PYLINT_VERSION)'` (4.0.5), so bumping pylint becomes an explicit, reviewable change to `PYLINT_VERSION`.

Adopting ruff 0.15.x (and addressing RUF076) is left as a separate, deliberate upgrade.

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, `make test` all pass locally with the locked ruff 0.14.7 (via `uv run`) and pinned pylint 4.0.5
- CodeRabbit reviews: 0 findings (both commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin Python linters to locked versions and run ruff from the project virtualenv to keep CI and local lint behaviour consistent.

Enhancements:
- Run ruff via the locked virtualenv using uv run in Make targets so linting uses the project-pinned version.
- Pin pylint to a specific version through the pylint-pypy shim to prevent unexpected lint behaviour changes.

CI:
- Stop installing a floating ruff tool in the CI workflow, relying instead on the locked environment created by make build.