### PR TITLE
Add property-based tests for tar and rsync builders (#71)

### DIFF
--- a/cuprum/builders/__init__.py
+++ b/cuprum/builders/__init__.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 from cuprum.builders.args import GitRef, SafePath, git_ref, safe_path
 from cuprum.builders.git import git_checkout, git_rev_parse, git_status
 from cuprum.builders.rsync import RsyncOptions, rsync_sync
-from cuprum.builders.tar import TarCreateOptions, tar_create, tar_extract
+from cuprum.builders.tar import (
+    Compression,
+    TarCreateOptions,
+    tar_create,
+    tar_extract,
+)
 
 __all__ = [
+    "Compression",
     "GitRef",
     "RsyncOptions",
     "SafePath",

--- a/cuprum/builders/rsync.py
+++ b/cuprum/builders/rsync.py
@@ -58,7 +58,30 @@ def rsync_sync(
     *,
     options: RsyncOptions | None = None,
 ) -> SafeCmd:
-    """Build an `rsync` synchronisation command."""
+    """Build an ``rsync`` synchronisation command.
+
+    Parameters
+    ----------
+    source
+        Source path to synchronise from.
+    destination
+        Destination path to synchronise to.
+    options
+        Optional rsync settings. When omitted, the command uses
+        ``RsyncOptions()``.
+
+    Returns
+    -------
+    SafeCmd
+        Safe command wrapper for the curated ``rsync`` program and generated
+        argv.
+
+    Raises
+    ------
+    ValueError
+        If ``source`` or ``destination`` is relative while relative paths are
+        not allowed.
+    """
     argv = _rsync_argv(source, destination, options or RsyncOptions())
     return sh.make(RSYNC)(*argv)
 

--- a/cuprum/builders/rsync.py
+++ b/cuprum/builders/rsync.py
@@ -27,6 +27,31 @@ class RsyncOptions:
     allow_relative: bool = False
 
 
+# Flag emission order is part of the argv contract: option attributes are
+# rendered in this sequence, ahead of the source and destination paths.
+_FLAG_ORDER: tuple[tuple[str, str], ...] = (
+    ("archive", "--archive"),
+    ("delete", "--delete"),
+    ("dry_run", "--dry-run"),
+    ("verbose", "--verbose"),
+    ("compress", "--compress"),
+)
+
+
+def _rsync_argv(
+    source: str | Path,
+    destination: str | Path,
+    options: RsyncOptions,
+) -> tuple[str, ...]:
+    """Build the immutable argv for ``rsync_sync`` without a catalogue."""
+    flags = tuple(flag for attr, flag in _FLAG_ORDER if getattr(options, attr))
+    paths = (
+        str(safe_path(source, allow_relative=options.allow_relative)),
+        str(safe_path(destination, allow_relative=options.allow_relative)),
+    )
+    return flags + paths
+
+
 def rsync_sync(
     source: str | Path,
     destination: str | Path,
@@ -34,29 +59,8 @@ def rsync_sync(
     options: RsyncOptions | None = None,
 ) -> SafeCmd:
     """Build an `rsync` synchronisation command."""
-    resolved_options = options or RsyncOptions()
-    args: list[str] = []
-    if resolved_options.archive:
-        args.append("--archive")
-    if resolved_options.delete:
-        args.append("--delete")
-    if resolved_options.dry_run:
-        args.append("--dry-run")
-    if resolved_options.verbose:
-        args.append("--verbose")
-    if resolved_options.compress:
-        args.append("--compress")
-
-    args.extend([
-        str(safe_path(source, allow_relative=resolved_options.allow_relative)),
-        str(
-            safe_path(
-                destination,
-                allow_relative=resolved_options.allow_relative,
-            )
-        ),
-    ])
-    return sh.make(RSYNC)(*args)
+    argv = _rsync_argv(source, destination, options or RsyncOptions())
+    return sh.make(RSYNC)(*argv)
 
 
 __all__ = ["RsyncOptions", "rsync_sync"]

--- a/cuprum/builders/rsync.py
+++ b/cuprum/builders/rsync.py
@@ -58,14 +58,14 @@ def rsync_sync(
     *,
     options: RsyncOptions | None = None,
 ) -> SafeCmd:
-    """Build an ``rsync`` synchronisation command.
+    """Build an ``rsync`` synchronization command.
 
     Parameters
     ----------
     source
-        Source path to synchronise from.
+        Source path to synchronize from.
     destination
-        Destination path to synchronise to.
+        Destination path to synchronize to.
     options
         Optional rsync settings. When omitted, the command uses
         ``RsyncOptions()``.

--- a/cuprum/builders/tar.py
+++ b/cuprum/builders/tar.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses as dc
+import enum
 import typing as typ
 from pathlib import Path
 
@@ -16,6 +17,39 @@ if typ.TYPE_CHECKING:
     from cuprum.sh import SafeCmd
 
 
+class Compression(enum.Enum):
+    """Compression algorithm for ``tar_create``.
+
+    Modelling compression as a single enum makes the "exactly one algorithm"
+    invariant unrepresentable as an invalid state: the previous design used
+    three mutually-exclusive booleans that had to be reconciled at runtime.
+
+    Members
+    -------
+    NONE
+        No compression (the default); ``tar_create`` emits no flag.
+    GZIP
+        gzip compression (``-z``).
+    BZIP2
+        bzip2 compression (``-j``).
+    XZ
+        xz compression (``-J``).
+    """
+
+    NONE = "none"
+    GZIP = "gzip"
+    BZIP2 = "bzip2"
+    XZ = "xz"
+
+
+_COMPRESSION_FLAGS: dict[Compression, str] = {
+    Compression.NONE: "",
+    Compression.GZIP: "-z",
+    Compression.BZIP2: "-j",
+    Compression.XZ: "-J",
+}
+
+
 @dc.dataclass(frozen=True, slots=True)
 class TarCreateOptions:
     """Optional flags for tar_create.
@@ -23,29 +57,13 @@ class TarCreateOptions:
     The allow_relative flag applies to both archive and source paths.
     """
 
-    gzip: bool = False
-    bzip2: bool = False
-    xz: bool = False
+    compression: Compression = Compression.NONE
     allow_relative: bool = False
 
 
 def _get_compression_flag(options: TarCreateOptions) -> str:
-    """Return the compression flag for tar_create, if any."""
-    compression_flags = [
-        options.gzip,
-        options.bzip2,
-        options.xz,
-    ]
-    if sum(1 for flag in compression_flags if flag) > 1:
-        msg = "Select only one compression option for tar_create"
-        raise ValueError(msg)
-    if options.gzip:
-        return "-z"
-    if options.bzip2:
-        return "-j"
-    if options.xz:
-        return "-J"
-    return ""
+    """Return the compression flag for tar_create, or ``""`` for none."""
+    return _COMPRESSION_FLAGS[options.compression]
 
 
 def tar_create(
@@ -107,4 +125,4 @@ def tar_extract(
     return sh.make(TAR)(*args)
 
 
-__all__ = ["TarCreateOptions", "tar_create", "tar_extract"]
+__all__ = ["Compression", "TarCreateOptions", "tar_create", "tar_extract"]

--- a/cuprum/builders/tar.py
+++ b/cuprum/builders/tar.py
@@ -46,7 +46,14 @@ class Compression(enum.Enum):
 class TarCreateOptions:
     """Optional flags for tar_create.
 
-    The allow_relative flag applies to both archive and source paths.
+    Attributes
+    ----------
+    compression : Compression
+        Compression algorithm for the archive. Defaults to
+        ``Compression.NONE``.
+    allow_relative : bool
+        Allow relative archive and source paths. This applies to both archive
+        and source paths. Defaults to ``False``.
     """
 
     compression: Compression = Compression.NONE

--- a/cuprum/builders/tar.py
+++ b/cuprum/builders/tar.py
@@ -42,14 +42,6 @@ class Compression(enum.Enum):
     XZ = "xz"
 
 
-_COMPRESSION_FLAGS: dict[Compression, str] = {
-    Compression.NONE: "",
-    Compression.GZIP: "-z",
-    Compression.BZIP2: "-j",
-    Compression.XZ: "-J",
-}
-
-
 @dc.dataclass(frozen=True, slots=True)
 class TarCreateOptions:
     """Optional flags for tar_create.
@@ -63,7 +55,17 @@ class TarCreateOptions:
 
 def _get_compression_flag(options: TarCreateOptions) -> str:
     """Return the compression flag for tar_create, or ``""`` for none."""
-    return _COMPRESSION_FLAGS[options.compression]
+    match options.compression:
+        case Compression.NONE:
+            return ""
+        case Compression.GZIP:
+            return "-z"
+        case Compression.BZIP2:
+            return "-j"
+        case Compression.XZ:
+            return "-J"
+        case never:
+            typ.assert_never(never)
 
 
 def _tar_create_argv(
@@ -101,7 +103,32 @@ def tar_create(
     *,
     options: TarCreateOptions | None = None,
 ) -> SafeCmd:
-    """Build a `tar` create command."""
+    """Build a ``tar`` create command.
+
+    Parameters
+    ----------
+    archive
+        Archive path passed after ``-f``.
+    sources
+        Source paths added to the archive, in order.
+    options
+        Optional create settings. When omitted, the command uses
+        ``TarCreateOptions()``.
+
+    Returns
+    -------
+    SafeCmd
+        Safe command wrapper for the curated ``tar`` program and generated
+        argv.
+
+    Raises
+    ------
+    ValueError
+        If ``sources`` is empty, or if any path is relative while relative
+        paths are not allowed.
+    TypeError
+        If ``sources`` is a bare string or ``Path`` instead of a sequence.
+    """
     argv = _tar_create_argv(archive, sources, options or TarCreateOptions())
     return sh.make(TAR)(*argv)
 
@@ -129,7 +156,28 @@ def tar_extract(
     destination: str | Path | None = None,
     allow_relative: bool = False,
 ) -> SafeCmd:
-    """Build a `tar` extract command."""
+    """Build a ``tar`` extract command.
+
+    Parameters
+    ----------
+    archive
+        Archive path passed after ``-f``.
+    destination
+        Optional extraction directory passed after ``-C``.
+    allow_relative
+        Allow ``archive`` and ``destination`` to be relative paths.
+
+    Returns
+    -------
+    SafeCmd
+        Safe command wrapper for the curated ``tar`` program and generated
+        argv.
+
+    Raises
+    ------
+    ValueError
+        If any path is relative while ``allow_relative`` is false.
+    """
     argv = _tar_extract_argv(archive, destination, allow_relative=allow_relative)
     return sh.make(TAR)(*argv)
 

--- a/cuprum/builders/tar.py
+++ b/cuprum/builders/tar.py
@@ -81,12 +81,13 @@ def _tar_create_argv(
     options: TarCreateOptions,
 ) -> tuple[str, ...]:
     """Build the immutable argv for ``tar_create`` without a catalogue."""
+    match sources:
+        case str() | Path():
+            msg = "tar_create requires a sequence of source paths, not a single path"
+            raise TypeError(msg)
     if not sources:
         msg = "tar_create requires at least one source path"
         raise ValueError(msg)
-    if isinstance(sources, (str, Path)):
-        msg = "tar_create requires a sequence of source paths, not a single path"
-        raise TypeError(msg)
 
     compression_flag = _get_compression_flag(options)
     args: list[str] = ["-c"]

--- a/cuprum/builders/tar.py
+++ b/cuprum/builders/tar.py
@@ -66,13 +66,12 @@ def _get_compression_flag(options: TarCreateOptions) -> str:
     return _COMPRESSION_FLAGS[options.compression]
 
 
-def tar_create(
+def _tar_create_argv(
     archive: str | Path,
     sources: cabc.Sequence[str | Path],
-    *,
-    options: TarCreateOptions | None = None,
-) -> SafeCmd:
-    """Build a `tar` create command."""
+    options: TarCreateOptions,
+) -> tuple[str, ...]:
+    """Build the immutable argv for ``tar_create`` without a catalogue."""
     if not sources:
         msg = "tar_create requires at least one source path"
         raise ValueError(msg)
@@ -80,32 +79,48 @@ def tar_create(
         msg = "tar_create requires a sequence of source paths, not a single path"
         raise TypeError(msg)
 
-    resolved_options = options or TarCreateOptions()
-    compression_flag = _get_compression_flag(resolved_options)
-
+    compression_flag = _get_compression_flag(options)
     args: list[str] = ["-c"]
     if compression_flag:
         args.append(compression_flag)
 
     args.extend([
         "-f",
-        str(
-            safe_path(
-                archive,
-                allow_relative=resolved_options.allow_relative,
-            )
-        ),
+        str(safe_path(archive, allow_relative=options.allow_relative)),
     ])
     args.extend(
-        str(
-            safe_path(
-                source,
-                allow_relative=resolved_options.allow_relative,
-            )
-        )
+        str(safe_path(source, allow_relative=options.allow_relative))
         for source in sources
     )
-    return sh.make(TAR)(*args)
+    return tuple(args)
+
+
+def tar_create(
+    archive: str | Path,
+    sources: cabc.Sequence[str | Path],
+    *,
+    options: TarCreateOptions | None = None,
+) -> SafeCmd:
+    """Build a `tar` create command."""
+    argv = _tar_create_argv(archive, sources, options or TarCreateOptions())
+    return sh.make(TAR)(*argv)
+
+
+def _tar_extract_argv(
+    archive: str | Path,
+    destination: str | Path | None,
+    *,
+    allow_relative: bool,
+) -> tuple[str, ...]:
+    """Build the immutable argv for ``tar_extract`` without a catalogue."""
+    args: list[str] = [
+        "-x",
+        "-f",
+        str(safe_path(archive, allow_relative=allow_relative)),
+    ]
+    if destination is not None:
+        args.extend(["-C", str(safe_path(destination, allow_relative=allow_relative))])
+    return tuple(args)
 
 
 def tar_extract(
@@ -115,14 +130,8 @@ def tar_extract(
     allow_relative: bool = False,
 ) -> SafeCmd:
     """Build a `tar` extract command."""
-    args: list[str] = [
-        "-x",
-        "-f",
-        str(safe_path(archive, allow_relative=allow_relative)),
-    ]
-    if destination is not None:
-        args.extend(["-C", str(safe_path(destination, allow_relative=allow_relative))])
-    return sh.make(TAR)(*args)
+    argv = _tar_extract_argv(archive, destination, allow_relative=allow_relative)
+    return sh.make(TAR)(*argv)
 
 
 __all__ = ["Compression", "TarCreateOptions", "tar_create", "tar_extract"]

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -59,6 +59,7 @@
       'cuprum/unittests/test_benchmark_suite.py',
       'cuprum/unittests/test_build_final_results_property.py',
       'cuprum/unittests/test_builder_library.py',
+      'cuprum/unittests/test_builder_property_based.py',
       'cuprum/unittests/test_catalogue.py',
       'cuprum/unittests/test_catalogue_property_based.py',
       'cuprum/unittests/test_ci_benchmark_ratchet_profile.py',

--- a/cuprum/unittests/test_builder_library.py
+++ b/cuprum/unittests/test_builder_library.py
@@ -6,8 +6,11 @@ import typing as typ
 from pathlib import Path
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from cuprum.builders import (
+    Compression,
     RsyncOptions,
     TarCreateOptions,
     git_checkout,
@@ -158,7 +161,11 @@ def test_tar_create_builder_outputs_args(tmp_path: Path) -> None:
     """tar_create builds the expected argv ordering."""
     archive = tmp_path / "archive.tar.gz"
     sources = [tmp_path / "source-a", tmp_path / "source-b"]
-    cmd = tar_create(archive, sources, options=TarCreateOptions(gzip=True))
+    cmd = tar_create(
+        archive,
+        sources,
+        options=TarCreateOptions(compression=Compression.GZIP),
+    )
     assert cmd.argv == (
         "-c",
         "-z",
@@ -169,16 +176,63 @@ def test_tar_create_builder_outputs_args(tmp_path: Path) -> None:
     ), "tar_create argv mismatch"
 
 
-def test_tar_create_rejects_multiple_compression(tmp_path: Path) -> None:
-    """tar_create rejects multiple compression flags."""
+@pytest.mark.parametrize(
+    ("compression", "expected_flag"),
+    [
+        (Compression.NONE, None),
+        (Compression.GZIP, "-z"),
+        (Compression.BZIP2, "-j"),
+        (Compression.XZ, "-J"),
+    ],
+)
+def test_tar_create_maps_each_compression(
+    tmp_path: Path,
+    compression: Compression,
+    expected_flag: str | None,
+) -> None:
+    """Each Compression member maps to its single tar flag, or none."""
     archive = tmp_path / "archive.tar"
     source = tmp_path / "source"
-    with pytest.raises(ValueError, match="tar_create"):
-        tar_create(
-            archive,
-            [source],
-            options=TarCreateOptions(gzip=True, bzip2=True),
-        )
+    cmd = tar_create(
+        archive,
+        [source],
+        options=TarCreateOptions(compression=compression),
+    )
+    expected = ["-c"]
+    if expected_flag is not None:
+        expected.append(expected_flag)
+    expected.extend(["-f", archive.as_posix(), source.as_posix()])
+    assert cmd.argv == tuple(expected), "tar_create compression flag mismatch"
+
+
+_ALL_COMPRESSION_FLAGS = frozenset({"-z", "-j", "-J"})
+
+
+@given(compression=st.sampled_from(Compression))
+def test_tar_create_emits_at_most_one_compression_flag(
+    compression: Compression,
+) -> None:
+    """Property: no compression choice can produce two compression flags.
+
+    Modelling compression as a single enum makes the "two algorithms at once"
+    state unrepresentable, so the constructed argv may carry at most one of
+    the mutually-exclusive compression flags.
+
+    Parameters
+    ----------
+    compression : Compression
+        Generated compression member drawn from every enum value.
+    """
+    archive = Path("/srv/archive.tar")
+    cmd = tar_create(
+        archive,
+        [Path("/srv/source")],
+        options=TarCreateOptions(compression=compression),
+    )
+    flags_present = [arg for arg in cmd.argv if arg in _ALL_COMPRESSION_FLAGS]
+    assert len(flags_present) <= 1, "tar_create must emit at most one compression flag"
+    if compression is Compression.NONE:
+        assert not flags_present, "Compression.NONE must emit no compression flag"
 
 
 def test_tar_create_rejects_missing_sources(tmp_path: Path) -> None:

--- a/cuprum/unittests/test_builder_library.py
+++ b/cuprum/unittests/test_builder_library.py
@@ -212,17 +212,7 @@ _ALL_COMPRESSION_FLAGS = frozenset({"-z", "-j", "-J"})
 def test_tar_create_emits_at_most_one_compression_flag(
     compression: Compression,
 ) -> None:
-    """Property: no compression choice can produce two compression flags.
-
-    Modelling compression as a single enum makes the "two algorithms at once"
-    state unrepresentable, so the constructed argv may carry at most one of
-    the mutually-exclusive compression flags.
-
-    Parameters
-    ----------
-    compression : Compression
-        Generated compression member drawn from every enum value.
-    """
+    """No compression choice can produce two compression flags."""
     archive = Path("/srv/archive.tar")
     cmd = tar_create(
         archive,

--- a/cuprum/unittests/test_builder_property_based.py
+++ b/cuprum/unittests/test_builder_property_based.py
@@ -32,7 +32,6 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from cuprum.builders.rsync import (
-    _FLAG_ORDER,
     RsyncOptions,
     _rsync_argv,
     rsync_sync,
@@ -54,6 +53,13 @@ _COMPRESSION_BY_MEMBER = {
     Compression.XZ: "-J",
 }
 _ALL_COMPRESSION_FLAGS = {"-z", "-j", "-J"}
+_EXPECTED_RSYNC_FLAG_ORDER = (
+    ("archive", "--archive"),
+    ("delete", "--delete"),
+    ("dry_run", "--dry-run"),
+    ("verbose", "--verbose"),
+    ("compress", "--compress"),
+)
 
 # Path segments avoid ".", NUL, and separators so generated paths are
 # always SafePath-valid and normalisation is the identity.
@@ -136,9 +142,11 @@ def test_rsync_argv_flags_match_options_in_fixed_order(
     destination: str,
     options: RsyncOptions,
 ) -> None:
-    """Exactly the enabled flags appear, in _FLAG_ORDER, then the paths."""
+    """Exactly the enabled flags appear in expected order, then the paths."""
     argv = _rsync_argv(source, destination, options)
-    expected_flags = tuple(flag for attr, flag in _FLAG_ORDER if getattr(options, attr))
+    expected_flags = tuple(
+        flag for attr, flag in _EXPECTED_RSYNC_FLAG_ORDER if getattr(options, attr)
+    )
     assert argv == (*expected_flags, source, destination), (
         "argv must be the enabled flags in fixed order, then source and destination"
     )
@@ -178,6 +186,9 @@ def test_rsync_path_conversion_is_deterministic_and_type_insensitive(
 ) -> None:
     """Equal inputs give equal argv; Path and str inputs agree."""
     rsync_from_strings = _rsync_argv(source, destination, options)
+    assert rsync_from_strings == _rsync_argv(source, destination, options), (
+        "rsync argv construction must be deterministic"
+    )
     assert rsync_from_strings == _rsync_argv(
         Path(source),
         Path(destination),

--- a/cuprum/unittests/test_builder_property_based.py
+++ b/cuprum/unittests/test_builder_property_based.py
@@ -1,0 +1,230 @@
+"""Property-based tests for the tar and rsync command builders.
+
+These tests pin down the argv contracts of ``tar_create``, ``tar_extract``,
+and ``rsync_sync`` over generated paths and option combinations, via the
+pure argv builders (``_tar_create_argv``, ``_tar_extract_argv``,
+``_rsync_argv``) extracted for verifiability (issue #71).
+
+The invariants checked here are:
+
+- ``tar_create`` argv is exactly ``-c``, at most one compression flag,
+  ``-f``, the archive, then the sources in order; the compression flag
+  matches the ``Compression`` member and never appears twice.
+- ``tar_create`` rejects empty source sequences (``ValueError``) and a
+  bare string or ``Path`` passed instead of a sequence (``TypeError``).
+- ``tar_extract`` argv is ``-x -f <archive>`` with an optional trailing
+  ``-C <destination>``.
+- ``rsync_sync`` emits exactly the flags enabled on ``RsyncOptions`` in
+  the documented fixed order, followed by source then destination.
+- Path conversion is deterministic: equal inputs give equal argv, and a
+  ``Path`` yields the same argv as the equivalent string.
+- The public wrappers attach the curated program and the argv produced
+  by the pure builders.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from cuprum.builders.rsync import (
+    _FLAG_ORDER,
+    RsyncOptions,
+    _rsync_argv,
+    rsync_sync,
+)
+from cuprum.builders.tar import (
+    Compression,
+    TarCreateOptions,
+    _tar_create_argv,
+    _tar_extract_argv,
+    tar_create,
+    tar_extract,
+)
+from cuprum.catalogue import RSYNC, TAR
+
+_COMPRESSION_BY_MEMBER = {
+    Compression.NONE: None,
+    Compression.GZIP: "-z",
+    Compression.BZIP2: "-j",
+    Compression.XZ: "-J",
+}
+_ALL_COMPRESSION_FLAGS = {"-z", "-j", "-J"}
+
+# Path segments avoid ".", NUL, and separators so generated paths are
+# always SafePath-valid and normalisation is the identity.
+_SEGMENTS = st.text(alphabet="abcxyz09-_", min_size=1, max_size=6)
+_ABS_PATHS = st.lists(_SEGMENTS, min_size=1, max_size=4).map(
+    lambda parts: "/" + "/".join(parts),
+)
+_COMPRESSIONS = st.sampled_from(sorted(Compression, key=lambda c: c.value))
+_RSYNC_OPTIONS = st.builds(
+    RsyncOptions,
+    archive=st.booleans(),
+    delete=st.booleans(),
+    dry_run=st.booleans(),
+    verbose=st.booleans(),
+    compress=st.booleans(),
+)
+
+
+@settings(max_examples=200)
+@given(
+    archive=_ABS_PATHS,
+    sources=st.lists(_ABS_PATHS, min_size=1, max_size=5),
+    compression=_COMPRESSIONS,
+)
+def test_tar_create_argv_shape_and_single_compression_flag(
+    archive: str,
+    sources: list[str],
+    compression: Compression,
+) -> None:
+    """The argv is -c, one optional compression flag, -f, archive, sources."""
+    options = TarCreateOptions(compression=compression)
+    argv = _tar_create_argv(archive, sources, options)
+
+    flag = _COMPRESSION_BY_MEMBER[compression]
+    expected_head = ("-c",) if flag is None else ("-c", flag)
+    assert argv == (*expected_head, "-f", archive, *sources), (
+        "argv must be the documented head followed by archive and sources"
+    )
+    present = [entry for entry in argv if entry in _ALL_COMPRESSION_FLAGS]
+    assert present == ([] if flag is None else [flag]), (
+        "exactly one compression flag must appear, and only when requested"
+    )
+
+
+@settings(max_examples=100)
+@given(archive=_ABS_PATHS, compression=_COMPRESSIONS)
+def test_tar_create_rejects_invalid_source_collections(
+    archive: str,
+    compression: Compression,
+) -> None:
+    """Empty sources raise ValueError; a bare path raises TypeError."""
+    options = TarCreateOptions(compression=compression)
+    with pytest.raises(ValueError, match="at least one source"):
+        _tar_create_argv(archive, [], options)
+    # Deliberately defeat static typing: the contract under test is the
+    # runtime rejection of a bare path where a sequence is required.
+    bare_str = typ.cast("list[str]", archive)
+    bare_path = typ.cast("list[str]", Path(archive))
+    with pytest.raises(TypeError, match="sequence of source paths"):
+        _tar_create_argv(archive, bare_str, options)
+    with pytest.raises(TypeError, match="sequence of source paths"):
+        _tar_create_argv(archive, bare_path, options)
+
+
+@settings(max_examples=200)
+@given(archive=_ABS_PATHS, destination=st.none() | _ABS_PATHS)
+def test_tar_extract_argv_shape(archive: str, destination: str | None) -> None:
+    """The argv is -x -f archive, with -C destination only when supplied."""
+    argv = _tar_extract_argv(archive, destination, allow_relative=False)
+    expected_tail = () if destination is None else ("-C", destination)
+    assert argv == ("-x", "-f", archive, *expected_tail), (
+        "argv must be -x -f <archive> with an optional -C <destination>"
+    )
+
+
+@settings(max_examples=200)
+@given(source=_ABS_PATHS, destination=_ABS_PATHS, options=_RSYNC_OPTIONS)
+def test_rsync_argv_flags_match_options_in_fixed_order(
+    source: str,
+    destination: str,
+    options: RsyncOptions,
+) -> None:
+    """Exactly the enabled flags appear, in _FLAG_ORDER, then the paths."""
+    argv = _rsync_argv(source, destination, options)
+    expected_flags = tuple(flag for attr, flag in _FLAG_ORDER if getattr(options, attr))
+    assert argv == (*expected_flags, source, destination), (
+        "argv must be the enabled flags in fixed order, then source and destination"
+    )
+
+
+@settings(max_examples=200)
+@given(
+    archive=_ABS_PATHS,
+    sources=st.lists(_ABS_PATHS, min_size=1, max_size=3),
+    compression=_COMPRESSIONS,
+    source=_ABS_PATHS,
+    destination=_ABS_PATHS,
+    options=_RSYNC_OPTIONS,
+)
+def test_path_conversion_is_deterministic_and_type_insensitive(
+    archive: str,
+    sources: list[str],
+    compression: Compression,
+    source: str,
+    destination: str,
+    options: RsyncOptions,
+) -> None:
+    """Equal inputs give equal argv; Path and str inputs agree."""
+    tar_options = TarCreateOptions(compression=compression)
+    from_strings = _tar_create_argv(archive, sources, tar_options)
+    assert from_strings == _tar_create_argv(archive, sources, tar_options), (
+        "tar argv construction must be deterministic"
+    )
+    from_paths = _tar_create_argv(
+        Path(archive),
+        [Path(s) for s in sources],
+        tar_options,
+    )
+    assert from_paths == from_strings, "Path inputs must match str inputs"
+
+    rsync_from_strings = _rsync_argv(source, destination, options)
+    assert rsync_from_strings == _rsync_argv(
+        Path(source),
+        Path(destination),
+        options,
+    ), "rsync argv must agree between Path and str inputs"
+
+
+@settings(max_examples=50)
+@given(
+    archive=_ABS_PATHS,
+    sources=st.lists(_ABS_PATHS, min_size=1, max_size=3),
+    source=_ABS_PATHS,
+    destination=_ABS_PATHS,
+)
+def test_wrappers_attach_curated_program_and_pure_argv(
+    archive: str,
+    sources: list[str],
+    source: str,
+    destination: str,
+) -> None:
+    """The sh.make wrappers carry the curated program and builder argv."""
+    create_cmd = tar_create(archive, sources)
+    assert create_cmd.program == TAR
+    assert create_cmd.argv == _tar_create_argv(
+        archive,
+        sources,
+        TarCreateOptions(),
+    )
+
+    extract_cmd = tar_extract(archive, destination=destination)
+    assert extract_cmd.program == TAR
+    assert extract_cmd.argv == _tar_extract_argv(
+        archive,
+        destination,
+        allow_relative=False,
+    )
+
+    sync_cmd = rsync_sync(source, destination)
+    assert sync_cmd.program == RSYNC
+    assert sync_cmd.argv == _rsync_argv(source, destination, RsyncOptions())
+
+
+@settings(max_examples=100)
+@given(segments=st.lists(_SEGMENTS, min_size=1, max_size=3))
+def test_relative_paths_require_explicit_opt_in(segments: list[str]) -> None:
+    """Relative paths are rejected unless allow_relative is set."""
+    relative = "/".join(segments)
+    with pytest.raises(ValueError, match="absolute path"):
+        _tar_extract_argv(relative, None, allow_relative=False)
+    argv = _tar_extract_argv(relative, None, allow_relative=True)
+    assert argv == ("-x", "-f", relative), (
+        "allow_relative must accept the same path verbatim"
+    )

--- a/cuprum/unittests/test_builder_property_based.py
+++ b/cuprum/unittests/test_builder_property_based.py
@@ -149,17 +149,11 @@ def test_rsync_argv_flags_match_options_in_fixed_order(
     archive=_ABS_PATHS,
     sources=st.lists(_ABS_PATHS, min_size=1, max_size=3),
     compression=_COMPRESSIONS,
-    source=_ABS_PATHS,
-    destination=_ABS_PATHS,
-    options=_RSYNC_OPTIONS,
 )
-def test_path_conversion_is_deterministic_and_type_insensitive(
+def test_tar_path_conversion_is_deterministic_and_type_insensitive(
     archive: str,
     sources: list[str],
     compression: Compression,
-    source: str,
-    destination: str,
-    options: RsyncOptions,
 ) -> None:
     """Equal inputs give equal argv; Path and str inputs agree."""
     tar_options = TarCreateOptions(compression=compression)
@@ -174,6 +168,15 @@ def test_path_conversion_is_deterministic_and_type_insensitive(
     )
     assert from_paths == from_strings, "Path inputs must match str inputs"
 
+
+@settings(max_examples=200)
+@given(source=_ABS_PATHS, destination=_ABS_PATHS, options=_RSYNC_OPTIONS)
+def test_rsync_path_conversion_is_deterministic_and_type_insensitive(
+    source: str,
+    destination: str,
+    options: RsyncOptions,
+) -> None:
+    """Equal inputs give equal argv; Path and str inputs agree."""
     rsync_from_strings = _rsync_argv(source, destination, options)
     assert rsync_from_strings == _rsync_argv(
         Path(source),

--- a/cuprum/unittests/test_builder_property_based.py
+++ b/cuprum/unittests/test_builder_property_based.py
@@ -242,3 +242,43 @@ def test_relative_paths_require_explicit_opt_in(segments: list[str]) -> None:
     assert argv == ("-x", "-f", relative), (
         "allow_relative must accept the same path verbatim"
     )
+
+
+@settings(max_examples=100)
+@given(
+    archive=st.lists(_SEGMENTS, min_size=1, max_size=3).map("/".join),
+    sources=st.lists(_SEGMENTS, min_size=1, max_size=3).map("/".join),
+)
+def test_tar_create_rejects_relative_paths_unless_opted_in(
+    archive: str,
+    sources: str,
+) -> None:
+    """tar_create rejects relative paths unless allow_relative is set."""
+    with pytest.raises(ValueError, match="absolute path"):
+        tar_create(archive, [sources])
+
+    options = TarCreateOptions(allow_relative=True)
+    command = tar_create(archive, [sources], options=options)
+    assert command.argv == _tar_create_argv(archive, [sources], options), (
+        "tar_create must pass allow_relative through to its argv builder"
+    )
+
+
+@settings(max_examples=100)
+@given(
+    source=st.lists(_SEGMENTS, min_size=1, max_size=3).map("/".join),
+    destination=st.lists(_SEGMENTS, min_size=1, max_size=3).map("/".join),
+)
+def test_rsync_sync_rejects_relative_paths_unless_opted_in(
+    source: str,
+    destination: str,
+) -> None:
+    """rsync_sync rejects relative paths unless allow_relative is set."""
+    with pytest.raises(ValueError, match="absolute path"):
+        rsync_sync(source, destination)
+
+    options = RsyncOptions(allow_relative=True)
+    command = rsync_sync(source, destination, options=options)
+    assert command.argv == _rsync_argv(source, destination, options), (
+        "rsync_sync must pass allow_relative through to its argv builder"
+    )

--- a/cuprum/unittests/test_builder_property_based.py
+++ b/cuprum/unittests/test_builder_property_based.py
@@ -124,6 +124,12 @@ def test_tar_create_rejects_invalid_source_collections(
         _tar_create_argv(archive, bare_path, options)
 
 
+def test_tar_create_rejects_empty_bare_string_source() -> None:
+    """An empty bare string is a type error, not an empty source sequence."""
+    with pytest.raises(TypeError, match="sequence of source paths"):
+        tar_create("/archive.tar", typ.cast("list[str]", ""))
+
+
 @settings(max_examples=200)
 @given(archive=_ABS_PATHS, destination=st.none() | _ABS_PATHS)
 def test_tar_extract_argv_shape(archive: str, destination: str | None) -> None:

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1441,7 +1441,10 @@ extend. The following decisions guide the core builder set:
 - Builders validate inputs internally and expose `allow_relative` parameters
   on option dataclasses where relative paths are expected to be legitimate.
 - `RsyncOptions` and `TarCreateOptions` bundle flag choices to keep builder
-  function signatures short and lint-friendly.
+  function signatures short and lint-friendly. `TarCreateOptions.compression`
+  is a single `Compression` enum (`NONE`, `GZIP`, `BZIP2`, `XZ`) rather than
+  mutually-exclusive booleans, so selecting two algorithms at once is not a
+  representable state.
 
 ______________________________________________________________________
 
@@ -1463,6 +1466,7 @@ than a rigid class diagram, and should favour boring, explicit implementations
 over cleverness—especially in the type‑system and configuration layers.
 
 ______________________________________________________________________
+
 
 ## 13. Performance-Optimized Stream Operations
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1467,7 +1467,6 @@ over cleverness—especially in the type‑system and configuration layers.
 
 ______________________________________________________________________
 
-
 ## 13. Performance-Optimized Stream Operations
 
 Cuprum's stream operations route data through Python's asyncio event loop in

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -258,7 +258,7 @@ namespace exposes functions that construct `DynamicCmd` for the rare cases
 where arbitrary composition is required.
 
 High‑level facilities (pipelines, context‑scoped allowlists, etc.) are
-optimized for `SafeCmd`. You can adapt a `DynamicCmd` into these facilities,
+optimized for `SafeCmd`. `DynamicCmd` can be adapted into these facilities,
 but doing so is visually explicit and reviewable.
 
 ### 5.3 Execution Context

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -10,6 +10,30 @@ of truth for day-to-day contributor expectations. For the system design, see the
 - [ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md)
 - [ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md)
 
+
+## Tar and rsync builder helpers
+
+`TarCreateOptions.compression` in `cuprum/builders/tar.py` selects one member
+of the `Compression` enum: `NONE`, `GZIP`, `BZIP2`, or `XZ`. This makes the
+compression choice mutually exclusive while keeping `TarCreateOptions`
+immutable.
+
+The private `_tar_create_argv` and `_tar_extract_argv` helpers in
+`cuprum/builders/tar.py`, together with `_rsync_argv` in
+`cuprum/builders/rsync.py`, construct immutable argument vectors independently
+of `sh.make` wrapping. They exist so the command construction contract can be
+tested directly for issue #71, while the public builders remain responsible for
+attaching their curated program.
+
+`_FLAG_ORDER` in `cuprum/builders/rsync.py` defines the fixed rsync flag
+emission order: `archive`, `delete`, `dry_run`, `verbose`, then `compress`.
+This is a documented contract covered by the property tests in
+`cuprum/unittests/test_builder_property_based.py`.
+
+Both `TarCreateOptions` and `RsyncOptions` provide `allow_relative`. It defaults
+to `False`, so `safe_path` rejects relative paths unless a caller explicitly
+opts in.
+
 ## Command argument construction
 
 `cuprum.sh.build_argv(*args, **kwargs)` is the public, pure argv-construction

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1012,7 +1012,7 @@ behaviour as a `RunOutputOptions`, not as loose `capture` / `echo` flags.
 `Pipeline.run` and `Pipeline.run_sync` retain `capture` and `echo` keyword
 arguments only for compatibility. Those flags emit `DeprecationWarning` and
 must not be combined with `output=RunOutputOptions(...)`; mixed usage raises
-`ValueError` before any deprecation warning is emitted so warning filters do
+`ValueError` before any deprecation warning is emitted, so warning filters do
 not obscure the documented ambiguity error.
 
 ## Subprocess stdin injection

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -10,7 +10,6 @@ of truth for day-to-day contributor expectations. For the system design, see the
 - [ADR-003: Two-tier Python linting](adr-003-two-tier-python-linting.md)
 - [ADR-004: Interrogate docstring-coverage gate](adr-004-interrogate-docstring-gate.md)
 
-
 ## Tar and rsync builder helpers
 
 `TarCreateOptions.compression` in `cuprum/builders/tar.py` selects one member

--- a/docs/execplans/3-1-1-core-builder-set-for-common-tools.md
+++ b/docs/execplans/3-1-1-core-builder-set-for-common-tools.md
@@ -236,12 +236,6 @@ underlying issue and rerun the same command. If a change must be reverted, use
 `git checkout -- <path>` for the specific files that were changed, then reapply
 the step carefully.
 
-
-## Artefacts and notes
-
-Capture key outputs (for example, failing test excerpts) in the work log when
-iterating, but keep the repository clean.
-
 ## Artefacts and notes
 
 Capture key outputs (for example, failing test excerpts) in the work log when

--- a/docs/execplans/3-1-1-core-builder-set-for-common-tools.md
+++ b/docs/execplans/3-1-1-core-builder-set-for-common-tools.md
@@ -236,6 +236,12 @@ underlying issue and rerun the same command. If a change must be reverted, use
 `git checkout -- <path>` for the specific files that were changed, then reapply
 the step carefully.
 
+
+## Artefacts and notes
+
+Capture key outputs (for example, failing test excerpts) in the work log when
+iterating, but keep the repository clean.
+
 ## Artefacts and notes
 
 Capture key outputs (for example, failing test excerpts) in the work log when
@@ -299,9 +305,7 @@ cuprum/builders/rsync.py
 cuprum/builders/tar.py
   @dataclass(frozen=True, slots=True)
   class TarCreateOptions:
-      gzip: bool = False
-      bzip2: bool = False
-      xz: bool = False
+      compression: Compression = Compression.NONE
       allow_relative: bool = False
 
   def tar_create(
@@ -317,6 +321,9 @@ cuprum/builders/tar.py
       allow_relative: bool = False,
   ) -> SafeCmd
 ```
+
+`Compression` selects one mutually exclusive member: `NONE`, `GZIP`, `BZIP2`,
+or `XZ`.
 
 Exports and catalogue updates:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -146,6 +146,7 @@ Builder functions validate inputs internally, so callers may pass `str` or
 from pathlib import Path
 
 from cuprum.builders import (
+    Compression,
     RsyncOptions,
     TarCreateOptions,
     git_checkout,
@@ -163,7 +164,7 @@ rsync_cmd = rsync_sync(
 tar_cmd = tar_create(
     Path("/backups/data.tar.gz"),
     [Path("/srv/data")],
-    options=TarCreateOptions(gzip=True),
+    options=TarCreateOptions(compression=Compression.GZIP),
 )
 restore_cmd = tar_extract(
     Path("/backups/data.tar.gz"),

--- a/tests/behaviour/test_builder_library_behaviour.py
+++ b/tests/behaviour/test_builder_library_behaviour.py
@@ -8,6 +8,7 @@ import typing as typ
 from pytest_bdd import given, parsers, scenario, then, when
 
 from cuprum.builders import (
+    Compression,
     RsyncOptions,
     TarCreateOptions,
     git_checkout,
@@ -129,7 +130,7 @@ def when_build_tar_command(tar_inputs: _TarInputs) -> _CommandResult:
     cmd = tar_create(
         tar_inputs.archive,
         tar_inputs.sources,
-        options=TarCreateOptions(gzip=True),
+        options=TarCreateOptions(compression=Compression.GZIP),
     )
     return _CommandResult(argv_with_program=cmd.argv_with_program)
 


### PR DESCRIPTION
## Summary

Closes #71

Adds Hypothesis property-based tests for the tar and rsync command builders:

- **Required argv shape**: `tar_create` produces exactly `-c`, an optional compression flag, `-f`, the archive, then the sources in order; `tar_extract` produces `-x -f <archive>` with `-C <destination>` only when supplied.
- **Exactly-one compression flag**: the flag matches the `Compression` member (`-z`/`-j`/`-J`) and never appears more than once; `Compression.NONE` emits none.
- **Fixed rsync flag order**: exactly the flags enabled on `RsyncOptions` appear, in the documented order, followed by source then destination.
- **Deterministic path conversion**: equal inputs give equal argv, and `Path` inputs agree with their string equivalents.
- **Rejection contracts**: empty source sequences raise `ValueError`; a bare `str`/`Path` where a sequence is required raises `TypeError`; relative paths require `allow_relative=True`.
- **Wrapper fidelity**: the public builders attach the curated `TAR`/`RSYNC` programs and the argv produced by the pure builders.

Per the issue's verifiability recommendation, the pure argv builders `_tar_create_argv`, `_tar_extract_argv`, and `_rsync_argv` are extracted (with an explicit `_FLAG_ORDER` table making the rsync flag sequence part of the stated contract); the public builders wrap them in `sh.make` and their behaviour is unchanged.

## Stacking

Based on `issue-119-tar-compression-enum` (PR #142, the `Compression` enum) atop `fix-ci-lint-ruff-version-skew` (PR #167); will rebase as those merge.

## Testing

- `make check-fmt`, `make lint`, `make typecheck` all pass
- `make test`: 571 passed, 43 skipped (Python); Rust suite passing
- CodeRabbit review: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a Compression enum for tar builders, refactor tar and rsync command construction into pure argv helpers, and add property-based tests to pin down their argv contracts.

New Features:
- Expose a Compression enum and updated TarCreateOptions API for selecting tar compression algorithms via a single choice.

Enhancements:
- Refactor tar_create, tar_extract, and rsync_sync to delegate to internal pure argv builder functions with a defined flag order.
- Adjust Makefile tasks and tooling integration to run ruff via uv and align local/CI tooling usage.

Build:
- Update Makefile tooling targets so ruff is treated as a venv tool and executed through uv-run commands.

CI:
- Stop installing ruff as a global uv tool in the CI workflow, relying instead on the venv-based setup.

Documentation:
- Document the Compression enum design and update user guide examples to use the new TarCreateOptions.compression API.

Tests:
- Add Hypothesis-based property tests for tar and rsync builders to verify argv shape, flag ordering, path handling, and wrapper behaviour.
- Adjust existing unit and behaviour tests to use the new Compression-based tar options instead of boolean flags.

## References

- Lody session: https://lody.ai/leynos/sessions/704b357f-024d-46b7-8a51-021f58ec1c01
