### PR TITLE
Document environment overlay behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [0.2.0] - 2026-06-21
+
+### Changed
+
+- **Environment overlays (breaking):** Document that scoped `env(...)` overlays
+  resolve against the live `os.environ` at subprocess spawn time, so callers
+  that depended on an import-time or scope-entry snapshot must pass explicit
+  values through the overlay or `ExecutionContext.env` instead
+  ([#175](https://github.com/leynos/cuprum/pull/175), [d2e2b92](https://github.com/leynos/cuprum/commit/d2e2b921bde69b8162ba0ca37ed68d36c5d6c8a6)).
+
+[0.2.0]: https://github.com/leynos/cuprum/commit/d2e2b921bde69b8162ba0ca37ed68d36c5d6c8a6

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -7,6 +7,8 @@ open each document.
 
 - [Documentation contents](contents.md) - the canonical index for project
   documentation.
+- [Changelog](../CHANGELOG.md) - consumer-facing release notes and migration
+  impact summaries.
 - [Users' guide](users-guide.md) - user-facing command-building, catalogue,
   runtime, pipeline, and Rust backend behaviour.
 - [Developers' guide](developers-guide.md) - maintainer workflows for profiling,

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -455,6 +455,12 @@ with scoped(ScopeConfig()):
 
 ### Scoped environment overlays
 
+**Breaking behaviour note:** `env(...)` resolves overlays against the live
+`os.environ` when a subprocess is spawned, not against an import-time or
+scope-entry snapshot. Code that relied on snapshot semantics should pass stable
+values explicitly through `env(...)` or the per-call `ExecutionContext.env`
+mapping.
+
 Use `env()` to overlay environment variables on top of the live `os.environ`
 for the duration of a scope. The overlay is resolved at subprocess spawn time,
 not at registration time, so variables added to `os.environ` *after* the scope


### PR DESCRIPTION
## Summary

This branch documents the breaking environment-overlay behaviour represented by `d2e2b921bde69b8162ba0ca37ed68d36c5d6c8a6`. It adds a consumer-facing changelog entry and makes the users' guide explicit that `env(...)` resolves against the live `os.environ` at subprocess spawn time, not an import-time or scope-entry snapshot.

## Review walkthrough

- Start with [CHANGELOG.md](https://github.com/leynos/cuprum/blob/1e128de5cbac1a9b9001bc3eb41d72d1255cf3a0/CHANGELOG.md) for the breaking-change release note and upstream references.
- Then review [docs/users-guide.md](https://github.com/leynos/cuprum/blob/1e128de5cbac1a9b9001bc3eb41d72d1255cf3a0/docs/users-guide.md#L456) for the user-facing migration note beside scoped environment overlays.
- Finish with [docs/contents.md](https://github.com/leynos/cuprum/blob/1e128de5cbac1a9b9001bc3eb41d72d1255cf3a0/docs/contents.md#L8) for changelog discoverability from the documentation index.

## Validation

- `make fmt`: passed.
- `make markdownlint`: passed.
- `make nixie`: passed.

## References

- Lody session: https://lody.ai/leynos/sessions/642d6216-f826-4d13-ac70-8c011413543a
