### PR TITLE
Align Whitaker lint wiring with the estate rollout conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,16 @@ jobs:
       - name: Install Whitaker
         run: |
           if [ "${{ steps.cache-whitaker.outputs.cache-hit }}" != "true" ]; then
-            cargo binstall --no-confirm --locked \
-              --git https://github.com/leynos/whitaker \
-              --version "${WHITAKER_INSTALLER_VERSION}" \
-              whitaker-installer
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked \
+                --git https://github.com/leynos/whitaker \
+                --version "${WHITAKER_INSTALLER_VERSION}" \
+                whitaker-installer
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer \
+                --version "${WHITAKER_INSTALLER_VERSION}"
+            fi
           fi
           whitaker-installer --cranelift
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ working on the Rust portions of the project:
     ```sh
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
     cargo clippy --all-targets --all-features -- -D warnings
-    whitaker --all -- --all-targets --all-features
+    RUSTFLAGS="-D warnings" whitaker --all -- --all-targets --all-features
     ```
 
     linting every target with all features enabled and denying all Clippy

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TOOLS = $(MDFORMAT_ALL) $(MDLINT) uv
 VENV_TOOLS = pytest ruff
 RUST_DIR ?= rust
 CARGO ?= cargo
+WHITAKER ?= whitaker
 BUILD_JOBS ?=
 RUST_FLAGS ?= -D warnings
 RUSTDOC_FLAGS ?= -D warnings
@@ -88,17 +89,17 @@ check-fmt: ruff ## Verify formatting
 	cd $(RUST_DIR) && $(CARGO) fmt --all -- --check
 	# mdformat-all doesn't currently do checking
 
-lint: ruff uv ## Run linters
+lint: ruff uv ## Run linters (Ruff, pylint, Clippy, Whitaker)
 	$(RUFF) check
 	$(UV_RUN_ENV) uv run interrogate --fail-under 100 cuprum
 	$(PYLINT) $(PYLINT_TARGETS)
 	cd $(RUST_DIR) && RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
 	cd $(RUST_DIR) && $(CARGO) clippy $(CLIPPY_FLAGS)
-	@if ! $(LOCAL_TOOL_ENV) command -v whitaker >/dev/null 2>&1; then \
+	@if ! $(LOCAL_TOOL_ENV) command -v $(WHITAKER) >/dev/null 2>&1; then \
 	  echo "whitaker is required for linting. Install it before running this target." >&2; \
 	  exit 1; \
 	fi
-	cd $(RUST_DIR) && $(LOCAL_TOOL_ENV) whitaker --all -- $(CARGO_FLAGS)
+	cd $(RUST_DIR) && $(LOCAL_TOOL_ENV) RUSTFLAGS="$(RUST_FLAGS)" $(WHITAKER) --all -- $(CARGO_FLAGS)
 
 typecheck: build ## Run typechecking
 	$(UV_RUN_ENV) uv sync --group dev

--- a/rust/dylint.toml
+++ b/rust/dylint.toml
@@ -1,2 +1,5 @@
 [no_std_fs_operations]
+# _rust_backend_native never opens filesystem paths itself; it wraps raw file
+# descriptors and handles received from the Python caller in std::fs::File, so
+# capability-based alternatives such as cap-std do not apply here.
 excluded_crates = ["_rust_backend_native"]


### PR DESCRIPTION
## Summary

This change aligns cuprum's existing Whitaker Dylint wiring with the
conventions adopted across the estate rollout (see leynos/netsuke#410).
Cuprum already ran the suite in `make lint` and installed it in the CI
lint-test job; this pull request closes the remaining gaps rather than
introducing the suite from scratch:

- The Makefile gains a `WHITAKER ?= whitaker` tool variable, used by the
  lint recipe, so the binary can be overridden like the other tools; the
  lint target's help text now mentions Whitaker.
- The Whitaker invocation now runs with `RUSTFLAGS="$(RUST_FLAGS)"`
  (`-D warnings`), matching the Clippy and test invocations.
- The CI install step gains the binstall-or-build fallback required by
  the rollout: runners whose Rust setup does not provide `cargo binstall`
  fall back to `cargo install --locked whitaker-installer` instead of
  failing. The Cranelift-backed `whitaker-installer --cranelift` call is
  unchanged.
- The existing `no_std_fs_operations` exclusion in `rust/dylint.toml`
  now carries a rationale: the extension crate never opens filesystem
  paths itself; it wraps raw file descriptors and handles received from
  the Python caller in `std::fs::File`.
- The `make lint` command listing in `AGENTS.md` is synchronized with
  the new invocation.

The suite itself reports no findings; no code fixes were required.

## Review walkthrough

- [`Makefile`](https://github.com/leynos/cuprum/blob/adopt-whitaker/Makefile):
  new `WHITAKER` variable and the updated lint recipe.
- [`.github/workflows/ci.yml`](https://github.com/leynos/cuprum/blob/adopt-whitaker/.github/workflows/ci.yml):
  binstall-or-build fallback in the Install Whitaker step.
- [`rust/dylint.toml`](https://github.com/leynos/cuprum/blob/adopt-whitaker/rust/dylint.toml):
  rationale comment for the existing exclusion.
- [`AGENTS.md`](https://github.com/leynos/cuprum/blob/adopt-whitaker/AGENTS.md):
  documentation kept in step with the Makefile.

## Validation

- `RUSTFLAGS="-D warnings" whitaker --all -- --all-targets --all-features`
  from `rust/`: exit 0, no findings.
- `make check-fmt lint typecheck test markdownlint nixie`: all gates
  pass (Ruff, interrogate, pylint, cargo doc, Clippy, Whitaker, ty,
  pytest, cargo nextest, markdownlint-cli2, nixie).
- `mbake validate Makefile`: valid syntax.
