### PR TITLE
Onboard CodeScene coverage upload via shared actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           npm install -g markdownlint-cli2
 
       - name: Install Rust toolchain
-        uses: leynos/shared-actions/.github/actions/setup-rust@2b09d10192627fd6e1034e7c12625dd266b45503
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           toolchain: '1.92.0'
 
@@ -130,16 +130,21 @@ jobs:
         run: make test
 
   coverage:
+    # Pull requests only. Pushes to main are handled by coverage-main.yml,
+    # which also uploads the report to CodeScene; guarding here stops
+    # coverage being generated twice on main.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs:
       - lint-test
       - typecheck-test
-    env:
-      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          # Full history so a future CodeScene changed-line gate
+          # (cs-coverage check) can reach the pull request merge base.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -152,41 +157,26 @@ jobs:
       - name: Install code
         run: make build
 
-      - name: Run tests with coverage
-        run: |
-          uv pip install slipcover pytest-forked
-          uv run python -m slipcover \
-            --source=./cuprum \
-            --omit="*/unittests/*,*/.venv/*" \
-            --branch \
-            --out coverage.xml \
-            -m pytest --forked -v
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v4
+      # Python-only coverage via the shared action. cuprum's repository
+      # root has no Cargo.toml (the Rust workspace lives under rust/), so
+      # detect.py classifies it as a Python project; cobertura is
+      # mandatory for non-Rust projects. pytest runs serially
+      # (pytest-workers: '') because the suite builds and shells out to
+      # the Rust toolchain, and the ratchet fails the run if line
+      # coverage drops below the baseline that coverage-main.yml stores.
+      #
+      # The changed-line CodeScene gate (upload-codescene-coverage with
+      # mode: check) is deliberately NOT wired yet: CodeScene has not
+      # enabled the coverage gate for project 74471, and mode: check
+      # fails on projects that lack a gates configuration. Add it in a
+      # follow-up once the gate is enabled (see ddlint#287).
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          name: coverage
-          path: coverage.xml
-
-      - name: Install CodeScene Coverage CLI
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
-          if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
-          fi
-
-      - name: Upload coverage to CodeScene
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          if [ ! -f coverage.xml ]; then
-            echo "coverage.xml not found!"
-            exit 1
-          fi
-          cs-coverage upload \
-            --format "cobertura" \
-            --metric "line-coverage" \
-            coverage.xml
+          format: cobertura
+          output-path: coverage.xml
+          pytest-workers: ''
+          with-ratchet: 'true'
 
   benchmark-ratchet:
     runs-on: ubicloud-standard-4-ubuntu-2404

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,63 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push. Pull requests generate
+# coverage in ci.yml's coverage job (ratchet only) instead. This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
+#
+# workflow_dispatch is intentional and required: merges performed by the
+# automerge workflow's GITHUB_TOKEN do not fire push-event workflows, so
+# automerged changes to main only get their coverage uploaded via a
+# manual dispatch.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Install code
+        run: make build
+
+      # Python-only coverage (see the note in ci.yml's coverage job):
+      # the repository root has no Cargo.toml, so the shared action
+      # detects a Python project and cobertura is mandatory. The ratchet
+      # writes the authoritative baseline that pull-request runs compare
+      # against.
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          output-path: coverage.xml
+          pytest-workers: ''
+          with-ratchet: 'true'
+
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          path: coverage.xml
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1990e9a6aaa73f0929e04dbc7da12326005606bf
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # Flat layout: the mutable source is the cuprum/ package at the
       # repository root, so change detection watches it directly.

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -31,7 +31,7 @@ WORKFLOW_PATH = (
 
 #: The commit SHA of leynos/shared-actions the caller must pin. Bump the
 #: workflow and this test together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

Onboards cuprum to the estate CodeScene coverage pattern, replacing the
bespoke slipcover run and hand-rolled `cs-coverage upload` with the
shared `generate-coverage` and `upload-codescene-coverage` actions
(CodeScene project [74471](https://codescene.io/projects/74471)).

- **Python-only coverage.** cuprum's repository root has no `Cargo.toml`
  (the Rust workspace lives under `rust/`), so `generate-coverage`'s
  `detect.py` classifies it as a Python project. Coverage therefore
  stays Python-only, matching the previous slipcover-only job, and uses
  the mandatory `cobertura` format (`output-path: coverage.xml`). Unlike
  the mutation-testing workflow (blocked by shared-actions#324 on
  subdirectory workspaces), `generate-coverage` *does* support a
  subdirectory Rust manifest via its `cargo-manifest` input; adopting a
  mixed Rust+Python report is a possible follow-up, deliberately left
  out here to keep the change behaviour-preserving.
- **Serial pytest.** `pytest-workers: ''` keeps the run serial, matching
  the prior `--forked` isolation and avoiding worker races on the Rust
  toolchain the suite builds against.
- **Ratchet.** `with-ratchet: 'true'` is enabled in both the
  pull-request coverage job and the new main-branch workflow. Caches
  saved on `main` are readable by every PR run, so `coverage-main.yml`
  writes the authoritative baseline and PR runs compare against it.
- **Main-branch upload.** New
  [`coverage-main.yml`](https://github.com/leynos/cuprum/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  uploads coverage to CodeScene on push to `main` (CodeScene accepts
  `cs-coverage upload` only for analysed branches) and includes
  `workflow_dispatch` so automerged changes — whose push events do not
  fire workflows — can be re-uploaded on demand.
- **Pin bump.** Every `leynos/shared-actions` reference is pinned to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` (the coverage floor, a
  descendant of every SHA previously in use), across `ci.yml`,
  `coverage-main.yml`, `mutation-testing.yml`, and
  `dependabot-automerge.yml`.

The changed-line CodeScene gate (`upload-codescene-coverage` with
`mode: check`) is **deferred**: CodeScene has not enabled the coverage
gate for project 74471, and `mode: check` fails on projects that lack a
gates configuration. It will be added in a small follow-up once the gate
is enabled (see ddlint#287 for the model).

## How the rollup unblocks

The CodeScene app posts a `Code Health Review` check on cuprum today,
not a `Code Coverage` check, so nothing is currently jammed. This PR is
the CI-side wiring so that coverage flows to CodeScene once the project
is analysed; enabling the coverage gate itself is a CodeScene-side
(UI-only) action.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/cuprum/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  — `coverage` job rewritten to use `generate-coverage`, guarded to
  pull requests, `fetch-depth: 0` for a future changed-line gate;
  `setup-rust` pin bumped.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/cuprum/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  — new main-branch upload + ratchet baseline workflow.
- [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/cuprum/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml)
  and
  [`dependabot-automerge.yml`](https://github.com/leynos/cuprum/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml)
  — pin bumps only.
- [`tests/test_workflow_contract.py`](https://github.com/leynos/cuprum/blob/codescene-coverage-gate/tests/test_workflow_contract.py)
  — `PINNED_SHA` updated to match the mutation-testing pin.

## Validation

- `python3 -c "import yaml; ..."` parses all four workflows.
- `tests/test_workflow_contract.py` passes (6/6).
