### PR TITLE
Stop pinning the exact mutation-testing SHA in the contract test

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -917,6 +917,42 @@ uv run pytest cuprum/unittests/test_maturin_build.py \
     --snapshot-update -k test_maturin_wheel_build_snapshot
 ```
 
+
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Compile-time UI tests (trybuild)
 
 The Rust crate at `rust/cuprum-rust/` uses

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -3,10 +3,16 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; cuprum's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the
+PyYAML and assert the contract it must uphold, so drift (repointing the
 pin at a branch, widening permissions, or losing the mutmut caller
 configuration) fails CI on the pull request rather than surfacing in a
 scheduled or manual run.
+
+The caller must reference the correct reusable workflow at a commit
+SHA; Dependabot owns the SHA value itself, so these tests match the
+pin shape (a 40-character lowercase hex commit SHA) rather than a
+specific documented SHA. That keeps routine Dependabot bump PRs from
+failing this contract.
 
 Only the Python package is enrolled: the pinned mutation-cargo.yml
 reusable workflow always fans a repository-root cargo-mutants target
@@ -17,6 +23,7 @@ workflow at this pin.
 
 from __future__ import annotations
 
+import re
 import typing as typ
 from pathlib import Path
 
@@ -29,12 +36,11 @@ WORKFLOW_PATH = (
     / "mutation-testing.yml"
 )
 
-#: The commit SHA of leynos/shared-actions the caller must pin. Bump the
-#: workflow and this test together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA
+#: Matches the caller pinning the correct reusable workflow path to a
+#: full 40-character lowercase hex commit SHA, without asserting which
+#: SHA: Dependabot owns that value.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: flat layout, so change detection
@@ -70,25 +76,15 @@ def _mutation_job(workflow: dict[typ.Any, typ.Any]) -> dict[typ.Any, typ.Any]:
     return jobs["mutation-python"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-mutmut.yml pinned to a full commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation-python.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-mutmut.yml", (
-        f"jobs.mutation-python.uses must reference mutation-mutmut.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation-python.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation-python.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation-python.uses pins {ref!r}; this test documents "
-        f"{PINNED_SHA!r} — bump the workflow and this test together"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation-python.uses must reference "
+        "leynos/shared-actions/.github/workflows/mutation-mutmut.yml pinned "
+        f"to a full 40-character lowercase hex commit SHA (not a branch or "
+        f"tag), got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Replace the exact-SHA equality assertion in the mutation-testing
  workflow contract test with a regex that checks the caller still
  references `mutation-mutmut.yml` pinned to a full 40-character
  lowercase hex commit SHA, without pinning which SHA.
- Hand SHA-value ownership to Dependabot: bump PRs for
  `leynos/shared-actions` no longer fail this contract test purely
  because the pinned commit changed.
- Keep every other structural assertion unchanged: job permissions,
  workflow-level default permissions, concurrency group and
  cancel-in-progress, triggers (schedule + plain `workflow_dispatch`),
  and the `with:` block.
- Document the shape-not-value convention in the developers' guide
  (`docs/developers-guide.md`, new "Workflow pins and Dependabot"
  section) so future contract tests follow the same pattern.

## Review walkthrough

- `tests/test_workflow_contract.py`: dropped `PINNED_SHA` and
  `EXPECTED_USES`; added `USES_RE`, a compiled pattern anchored on the
  reusable-workflow path plus `[0-9a-f]{40}`. Renamed the test to
  `test_uses_reference_is_pinned_to_a_commit_sha` and updated the
  module docstring to describe the shape contract instead of the
  pinned value.
- `docs/developers-guide.md`: added a "Workflow pins and Dependabot"
  section (canonical estate wording) explaining why contract tests
  must assert shape, not value.
- `.github/dependabot.yml` already has a `github-actions` ecosystem
  entry with `directory: "/"` and a weekly schedule, so Dependabot
  ownership of these bumps needs no further change.
- This is the only workflow contract test in the repository (no Rust
  contract test, no second pinned caller, no repo-wide
  "all-refs-must-match" assertion to relax).

## Validation

- `uv run pytest tests/test_workflow_contract.py -q` — 6 passed,
  including the new regex-based test against the currently pinned SHA
  (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`).
- Reasoned the regex would also accept a hypothetical different
  40-hex SHA (e.g. after a Dependabot bump), since it only constrains
  the path and the hex-digit shape, not the digits' value.
- `uv run ruff check tests/test_workflow_contract.py` — clean.
- Confirmed `make spelling` is not wired into any `.github/workflows/*.yml`
  gate in this repository, so pre-existing `artifact`/`Artifacts`
  Oxford-spelling drift in unrelated execplan docs and
  `docs/users-guide.md` is not a required-check blocker for this PR
  and is out of scope here.
