### PR TITLE
Enable the CodeScene changed-line coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,11 +165,6 @@ jobs:
       # the Rust toolchain, and the ratchet fails the run if line
       # coverage drops below the baseline that coverage-main.yml stores.
       #
-      # The changed-line CodeScene gate (upload-codescene-coverage with
-      # mode: check) is deliberately NOT wired yet: CodeScene has not
-      # enabled the coverage gate for project 74471, and mode: check
-      # fails on projects that lack a gates configuration. Add it in a
-      # follow-up once the gate is enabled (see ddlint#287).
       - name: Generate coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
@@ -177,6 +172,18 @@ jobs:
           output-path: coverage.xml
           pytest-workers: ''
           with-ratchet: 'true'
+
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/74471
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 
   benchmark-ratchet:
     runs-on: ubicloud-standard-4-ubuntu-2404


### PR DESCRIPTION
## Summary

- CodeScene has enabled the coverage gate for project 74471 (probed
  `GET /v2/code-coverage/projects/74471/config`: the `gates` array is
  now populated, matching the shape of mxd's working project), so the
  deferred `mode: check` step can land.
- Add the guarded `upload-codescene-coverage` step (`mode: check`,
  `format: cobertura`, `project-url:
  https://api.codescene.io/v2/projects/74471`) to the pull-request
  `coverage` job in [`ci.yml`](../blob/codescene-mode-check/.github/workflows/ci.yml),
  immediately after the existing `generate-coverage` step, and remove
  the deferred-gate comment it replaces.
- `coverage-main.yml` is untouched — it keeps the default `mode:
  upload` for pushes to `main`.

Note for reviewers: the `CodeScene Code Coverage` check is not a
required status check in the branch ruleset; it participates via the
overall status rollup instead, so it will not appear in the required
checks list even though it now gates the PR head.

## Review walkthrough

- `.github/workflows/ci.yml`: the `coverage` job (pull-request only)
  now runs `generate-coverage` (cobertura, ratchet on) followed by the
  new `Check coverage against CodeScene gates` step, guarded on a
  non-empty `CS_ACCESS_TOKEN` and `github.event_name ==
  'pull_request'`. The step reuses the same
  `leynos/shared-actions` pin (`927edd4`) already used by
  `generate-coverage` and `setup-rust` elsewhere in this workflow — no
  new pin introduced.

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly.
- [x] `tests/test_workflow_contract.py` targets `mutation-testing.yml`
      only; no workflow-contract test asserts the `ci.yml` coverage
      step shape, so none needed updating.
- [x] `CS_ACCESS_TOKEN` confirmed present in both the Actions and
      Dependabot secret stores for this repository.
- [ ] Confirm in CI that the new step executes (not skipped) and that
      `cs-coverage check` succeeds, and that the `CodeScene Code
      Coverage` check completes on this PR's head rather than timing
      out.
