### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       MBAKE_VERSION: '1.4.6'
       TY_VERSION: '0.0.8'
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4


### PR DESCRIPTION
## Summary

This pull request bumps the `WHITAKER_INSTALLER_VERSION` pin in [`.github/workflows/ci.yml`](https://github.com/leynos/cuprum/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml) from `0.2.5` to `0.2.6`, because the Whitaker Dylint suite's rolling release now pins toolchain `nightly-2026-05-28`, which requires `cargo-dylint` 6.0.1. Installer `0.2.5` provisions `cargo-dylint` 4.1.0, whose driver cannot compile on that nightly, leaving the repository's CI lint step red. `whitaker-installer` 0.2.6, published today, provisions `cargo-dylint` 6.0.1 and resolves the failure.

The repository was searched for other `0.2.5` occurrences tied to `WHITAKER_INSTALLER_VERSION` or `whitaker-installer`; none were found beyond the single environment variable in the CI workflow. Unrelated `0.2.5`-style strings in `uv.lock` and `rust/Cargo.lock` (package hashes and checksums for other dependencies) were left untouched, as they have no relationship to the Whitaker installer.

## Note

The v0.2.6 GitHub release currently has no prebuilt assets, so `cargo binstall` will fall back to compiling `whitaker-installer` from crates.io during CI. This is expected and acceptable.

## Test plan

- [ ] CI lint step passes on `nightly-2026-05-28` with `cargo-dylint` 6.0.1 provisioned by `whitaker-installer` 0.2.6
