### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1182,6 +1182,79 @@ If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
 
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow, [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-mutmut.yml`. The heavy
+lifting — running `mutmut` and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check. Only the Python package
+is enrolled: the pinned `mutation-cargo.yml` reusable workflow always fans a
+repository-root `cargo-mutants` target out for `workflow_dispatch` full runs,
+and Cuprum has no repository-root `Cargo.toml` (the Rust workspace manifest
+lives at `rust/Cargo.toml`), so a Rust job cannot ride the shared workflow at
+this pin. The mutation targets and test selection are configured separately in
+`[tool.mutmut]` in `pyproject.toml` (`source_paths`,
+`pytest_add_cli_args_test_selection`, `do_not_mutate`).
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped run
+that mutates only the source files touched within the detection window, so
+quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run workflow"
+control) mutates the whole package; select a branch in that control to
+exercise a feature branch.
+
+The caller passes two configuration inputs:
+
+- `paths` — `cuprum/`, the change-detection glob that decides whether a
+  scheduled run has anything to mutate. The flat repository layout puts the
+  mutable source directly at the repository root, so change detection watches
+  the package itself.
+- `module-prefix-strip` — the empty string, because the flat layout has no
+  `src/` prefix to strip before module-glob translation.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit (see
+[Workflow pins and Dependabot](#workflow-pins-and-dependabot) above for the
+shape-only rationale).
+
+### Workflow contract tests
+
+Because the caller is configuration rather than code, `tests/test_workflow_contract.py`
+pins the shape it must uphold, failing the pull request when the caller
+drifts — repointing the pin at a branch, widening the token scope, or
+dropping a configuration input — rather than letting the breakage surface
+only in a scheduled run. Unlike some sibling repositories, this module has no
+`skipif` guard: `.github/` is listed in `[tool.mutmut].also_copy`, so the
+workflow file is present inside mutmut's sandbox and the contract test runs
+there too. Run it locally with:
+
+```bash
+uv run --with pytest --with pyyaml pytest tests/test_workflow_contract.py -q
+```
+
+There is no dedicated Makefile target for this test; it also falls outside
+`PYTEST_TARGETS`, the glob list `make test` uses, so it must be run directly
+with the command above (or as part of a full mutmut pass). The test
+validates:
+
+- the `uses:` reference targets `mutation-mutmut.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly `{"paths": "cuprum/",
+  "module-prefix-strip": ""}`;
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily 08:20 UTC schedule and a plain
+  `workflow_dispatch` with no inputs.
+
 ## Compile-time UI tests (trybuild)
 
 The Rust crate at `rust/cuprum-rust/` uses


### PR DESCRIPTION
## Summary

Document the repository's mutmut mutation-testing workflow and the pytest
module that pins its shape.

- Add a "Mutation-testing workflow contract tests" section to
  `docs/developers-guide.md`, describing the mutmut caller workflow
  (`.github/workflows/mutation-testing.yml` → `shared-actions`'
  `mutation-mutmut.yml`), its two configuration inputs (`paths`,
  `module-prefix-strip`), and its shape-only SHA pin.
- Add a `### Workflow contract tests` subsection covering
  `tests/test_workflow_contract.py`: what it asserts (uses reference,
  `with:` block, permissions, concurrency, triggers) and how to run it
  locally.

## Review feedback addressed

- **Rebased onto `main` at `83cd8df2`.** The replay was clean (no conflicts);
  `git range-diff` shows the doc commit replayed identically. The branch's
  second commit — "Refresh the generated spelling config" — replayed empty and
  was dropped, because `main` has since absorbed it: `typos.toml` now carries
  both ignore patterns this branch added, and the generator itself was replaced
  by `typos-config-builder` (`a97d0a8b`), which is the new authority for that
  generated file. Dropping it is the correct resolution: committing it would
  have re-asserted a file whose contents and provenance `main` now owns.
- **This rebase also picks up the `coverage` fix.** The earlier `coverage`
  failure on this PR was repo-wide and environmental (the CodeScene CLI's
  `No matching field found: close for class java.io.InputStreamReader` parse
  error, affecting every `main`-targeting PR), not a defect in this branch.
  `main` fixed it in PR #411 ("Keep pull-request coverage local"), which is now
  in this branch's history.
- **Re-verified every factual claim** in the new section against the rebased
  tree and the pinned `shared-actions` revision, including the two inputs'
  defaults, the informational-only framing, the job-summary/artefact
  reporting, the missing-root-`Cargo.toml` rationale, and the
  `PYTEST_TARGETS`/`also_copy` claims below.

## Notes for reviewers

- **Permutation used**: C (Python/mutmut), per the standing template. Rust is
  deliberately not enrolled in this workflow (no repository-root
  `Cargo.toml`), and this doc change does not touch that.

- **Contract-test style**: shape-only. `USES_RE` in
  `tests/test_workflow_contract.py` matches
  `mutation-mutmut.yml@[0-9a-f]{40}` without asserting a specific SHA, so
  Dependabot bumps require no test edit.

- **Deviation from the standard template**: the test module has **no**
  `skipif` guard. `.github/` is listed in `[tool.mutmut].also_copy` in
  `pyproject.toml`, so the workflow file is copied into mutmut's sandbox and
  the contract test runs there rather than self-skipping. The section
  documents this explicitly instead of describing a guard that does not
  exist. The shared caller guide
  (`shared-actions` `docs/mutation-mutmut-workflow.md`) documents
  `skipif` / exclusion / `also_copy` as the three available answers, so
  choosing `also_copy` is the sanctioned route rather than an oversight.

- **Local command documented**:
  `uv run --with pytest --with pyyaml pytest tests/test_workflow_contract.py -q`
  (re-verified on the rebased tree: 6 passed). There is no dedicated Makefile
  target, and the test also falls outside `PYTEST_TARGETS` (the glob list
  `make test` uses), so this is the command a maintainer actually needs. The
  test does still run in CI: the `coverage` job invokes pytest with no path
  arguments, so bare collection picks up `tests/test_workflow_contract.py`.

- **TOC/cross-link**: `docs/developers-guide.md` has no per-section table of
  contents (only a flat ADR list at the top), so no TOC entry was added.
  `docs/contents.md` indexes whole documents, not sections, and its existing
  entry for the developers' guide already covers this addition — no change
  needed there.

- **Roadmap/execplan**: `docs/roadmap.md` has no mutation-testing or
  contract-test task; no roadmap/execplan tracking applies to this change.

- **Docs lint**: `markdownlint-cli2 docs/developers-guide.md` — 0 errors.
  `typos --config typos.toml docs/developers-guide.md` — 0 errors. Note the
  new prose uses "summarizing" and "serializes" (en-GB Oxford `-ize`), and the
  commit adds lines without deleting any, so no existing prose was respelled.

## Validation

- `make check-fmt` — passed.
- `make lint` — passed.
- `make typecheck` — passed.
- `make test` — passed (Python 1744 passed / 60 skipped; behavioural 125; cargo-nextest 112 passed).

Edited files: `docs/developers-guide.md`

## References

- [Lody session](https://lody.ai/leynos/sessions/5cf9ec9f-88bc-40f0-af99-7f7b3872f5e8)

## Summary by Sourcery

Document the mutation-testing workflow contract and keep generated lint configuration up to date.

Enhancements:
- Document the mutation-testing workflow, its configuration contract, informational execution modes, and workflow contract tests in the developers guide.

Documentation:
- Add maintainer documentation for the mutation-testing workflow contract and the command used to run its tests locally.

Chores:
- Refresh the generated typos configuration to keep lint runs clean.