### PR TITLE
Add tar default-path coverage and Compression migration note (#119)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -8,6 +8,7 @@
       "tables": false,
       "headings": false
     },
+    "MD024": { "siblings_only": true },
     "MD029": { "style": "ordered" }
   },
   "ignores": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Tar compression options (breaking):** `tar_create` now selects compression
+  through a single `Compression` enum instead of mutually-exclusive boolean
+  flags. Replace `TarCreateOptions(gzip=True)` with
+  `TarCreateOptions(compression=Compression.GZIP)`; likewise `bzip2=True`
+  becomes `Compression.BZIP2` and `xz=True` becomes `Compression.XZ`. Omitting
+  compression now maps to `Compression.NONE` and emits no tar compression flag
+  ([#119](https://github.com/leynos/cuprum/issues/119)).
+
 ## [0.2.0] - 2026-06-21
 
 ### Changed

--- a/cuprum/unittests/test_builder_library.py
+++ b/cuprum/unittests/test_builder_library.py
@@ -176,6 +176,21 @@ def test_tar_create_builder_outputs_args(tmp_path: Path) -> None:
     ), "tar_create argv mismatch"
 
 
+def test_tar_create_defaults_to_no_compression(tmp_path: Path) -> None:
+    """tar_create emits no compression flag when options are omitted."""
+    archive = tmp_path / "archive.tar"
+    source = tmp_path / "source"
+
+    cmd = tar_create(archive, [source])
+
+    assert cmd.argv == (
+        "-c",
+        "-f",
+        archive.as_posix(),
+        source.as_posix(),
+    )
+
+
 @pytest.mark.parametrize(
     ("compression", "expected_flag"),
     [

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -172,6 +172,12 @@ restore_cmd = tar_extract(
 )
 ```
 
+> **Migration note (breaking):** `tar_create` compression moved from boolean
+> flags to the `Compression` enum. Replace `TarCreateOptions(gzip=True)` with
+> `TarCreateOptions(compression=Compression.GZIP)` (and `bzip2`/`xz`
+> likewise); omitting compression maps to `Compression.NONE`. See the
+> [changelog](../CHANGELOG.md) for the full migration note.
+
 Relative paths require `allow_relative=True` on the relevant option objects
 (for example, `RsyncOptions`) or using `safe_path(..., allow_relative=True)`
 before passing the result into a builder.


### PR DESCRIPTION
## Summary

Follow-up to the tar `Compression` enum API ([#119](https://github.com/leynos/cuprum/issues/119)).
The enum itself already landed on `main`; this PR adds the remaining public
default-path coverage and the breaking-change migration documentation.

## Changes

- **Test:** Add `test_tar_create_defaults_to_no_compression`, which calls
  `tar_create(archive, [source])` with options omitted and asserts the argv
  carries no compression flag. This exercises the public default path
  directly, rather than via `_tar_create_argv` or an equality check on
  `TarCreateOptions()`.
- **Changelog:** Add an `[Unreleased]` breaking-change entry mapping the old
  boolean flags to the enum — `TarCreateOptions(gzip=True)` becomes
  `TarCreateOptions(compression=Compression.GZIP)`, and `bzip2`/`xz` become
  `Compression.BZIP2`/`Compression.XZ` — noting omitted compression maps to
  `Compression.NONE`.
- **Users' guide:** Add a migration callout in the tar-builder section linking
  to the changelog note.
- **Tooling:** Enable markdownlint `MD024: siblings_only` so the conventional
  repeated `### Changed` changelog headings across versions are permitted.

## Validation

- `make check-fmt` — pass
- `make lint` — pass
- `make typecheck` — pass
- `make test` — all Python suites pass, including the new test. One Rust
  trybuild UI snapshot fails only under the local toolchain (rustc 1.97.1); the
  committed snapshot matches the CI-pinned 1.92.0 diagnostic, so it passes on
  CI.
- `make markdownlint` — pass

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
