### PR TITLE
Clarify R503 requires terminal returns only when another branch returns a value (#197)

### DIFF
--- a/.rules/python-return.md
+++ b/.rules/python-return.md
@@ -43,14 +43,14 @@ Ensure all branches explicitly return a value if any branch does.
 
 ______________________________________________________________________
 
-## R503 — Add an Explicit Return at the End
+## R503 — Add an Explicit Return at the End When a Function May Return a Value
 
 ```python
 # BAD:
 def func(x):
     if x > 0:
         return x
-    # no return (bad)
+    # missing terminal return (bad)
 
 
 # GOOD:
@@ -60,7 +60,17 @@ def func(x):
     return -1
 ```
 
-Don't rely on implicit `None`—always return something at the end.
+Don't rely on implicit `None` if the function may return a value elsewhere—always
+return something at the end.
+
+Functions whose only possible result is `None` do not need a final bare `return`:
+
+```python
+# GOOD:
+def func():
+    do_something()
+    # implicit None is fine here
+```
 
 ______________________________________________________________________
 


### PR DESCRIPTION
Closes #197

R503 currently says "Don't rely on implicit `None`—always return something at the end." This conflicts with the narrower intent expressed by R502 and led to an invalid request to add `return` to an all-`None` helper.

State the rule as:

> Don't rely on implicit `None` if the function may return a value elsewhere—always return something at the end.

This retains the safeguard for mixed value/`None` control-flow while avoiding redundant bare returns for procedures.