### PR TITLE
Skip the maturin wheel build when its script is unreachable (#211)

### DIFF
--- a/cuprum/unittests/test_maturin_build.py
+++ b/cuprum/unittests/test_maturin_build.py
@@ -70,7 +70,9 @@ def test_maturin_script_locatable_true_when_script_present(
         "tests.helpers.maturin.sysconfig.get_path", lambda *_a, **_k: str(scripts_dir)
     )
 
-    assert maturin_script_locatable()
+    assert maturin_script_locatable(), (
+        "a maturin script in a scheme's scripts directory must be discovered"
+    )
 
 
 def test_maturin_script_locatable_false_when_script_absent(
@@ -95,7 +97,9 @@ def test_maturin_script_locatable_false_when_script_absent(
         "tests.helpers.maturin.sysconfig.get_path", lambda *_a, **_k: str(scripts_dir)
     )
 
-    assert not maturin_script_locatable()
+    assert not maturin_script_locatable(), (
+        "no maturin script is present, so discovery must report unavailable"
+    )
 
 
 def test_maturin_script_locatable_matches_windows_exe_launcher(

--- a/cuprum/unittests/test_maturin_build.py
+++ b/cuprum/unittests/test_maturin_build.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess  # noqa: S404 - tests assert trusted maturin command handling.
 import sys
 import typing as typ
+import zipfile
 
 import pytest
 
@@ -264,6 +265,27 @@ def test_build_native_wheel_artifact_reports_maturin_stderr(
     assert "cargo fetch failed" in error_text, (
         "maturin failure diagnostics should include captured stderr"
     )
+
+
+def test_wheel_build_snapshot_rejects_wheel_without_metadata(
+    tmp_path: pth.Path,
+) -> None:
+    """A wheel with WHEEL but no METADATA raises the documented error.
+
+    ``metadata_name`` is derived from the WHEEL entry by string
+    substitution rather than looked up in the archive, so without an
+    explicit membership check ``ZipFile.read`` would surface a ``KeyError``
+    that the helper's documented ``Raises`` contract does not advertise.
+    """
+    whl_path = tmp_path / "cuprum-0.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(whl_path, "w") as archive:
+        archive.writestr(
+            "cuprum-0.0.0.dist-info/WHEEL",
+            "Wheel-Version: 1.0\nGenerator: maturin (1.0.0)\nRoot-Is-Purelib: false\n",
+        )
+
+    with pytest.raises(AssertionError, match=r"missing \.dist-info/METADATA"):
+        wheel_build_snapshot(whl_path)
 
 
 @pytest.mark.timeout(0)

--- a/cuprum/unittests/test_maturin_build.py
+++ b/cuprum/unittests/test_maturin_build.py
@@ -98,6 +98,35 @@ def test_maturin_script_locatable_false_when_script_absent(
     assert not maturin_script_locatable()
 
 
+def test_maturin_script_locatable_matches_windows_exe_launcher(
+    tmp_path: pth.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detection accepts ``maturin.exe``, the real launcher on Windows.
+
+    Matching is stem-based on purpose: maturin's own ``get_maturin_path``
+    compares ``os.path.splitext(f)[0]`` against ``"maturin"``, so it accepts
+    any extension. On the ``windows-2022`` wheel target in
+    ``.github/workflows/build-wheels.yml`` the installed launcher *is*
+    ``maturin.exe``. Narrowing this to an exact ``maturin`` filename would
+    make the probe report unavailable on Windows and silently skip the
+    native-wheel contract there, so this test pins the mirrored behaviour.
+    """
+    scripts_dir = tmp_path / "Scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "maturin.exe").write_bytes(b"MZ")
+    monkeypatch.setattr(
+        "tests.helpers.maturin.sysconfig.get_scheme_names", lambda: ("nt",)
+    )
+    monkeypatch.setattr(
+        "tests.helpers.maturin.sysconfig.get_path", lambda *_a, **_k: str(scripts_dir)
+    )
+
+    assert maturin_script_locatable(), (
+        "stem-based matching must accept maturin.exe, the Windows launcher"
+    )
+
+
 def test_manylinux_aarch64_container_is_pinned_to_sha256() -> None:
     """Aarch64 manylinux container pin must be immutable."""
     container_ref = read_manylinux_aarch64_container_ref(repo_root())

--- a/cuprum/unittests/test_maturin_build.py
+++ b/cuprum/unittests/test_maturin_build.py
@@ -6,6 +6,7 @@ import importlib.metadata as im
 import re
 import shutil
 import subprocess  # noqa: S404 - tests assert trusted maturin command handling.
+import sys
 import typing as typ
 
 import pytest
@@ -16,6 +17,7 @@ from tests.helpers.maturin import (
     _AARCH64_CONTAINER_USAGE_RE,
     MaturinBuildError,
     build_native_wheel_artifact,
+    maturin_script_locatable,
     read_expected_maturin_version,
     read_manylinux_aarch64_container_ref,
     read_maturin_pins,
@@ -51,6 +53,49 @@ def test_installed_maturin_matches_expected_pin() -> None:
     assert installed == expected, (
         f"Expected maturin {expected}, but {installed} is installed"
     )
+
+
+def test_maturin_script_locatable_true_when_script_present(
+    tmp_path: pth.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detection succeeds when a ``maturin`` script sits in a scheme's dir."""
+    scripts_dir = tmp_path / "bin"
+    scripts_dir.mkdir()
+    (scripts_dir / "maturin").write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "tests.helpers.maturin.sysconfig.get_scheme_names", lambda: ("posix_prefix",)
+    )
+    monkeypatch.setattr(
+        "tests.helpers.maturin.sysconfig.get_path", lambda *_a, **_k: str(scripts_dir)
+    )
+
+    assert maturin_script_locatable()
+
+
+def test_maturin_script_locatable_false_when_script_absent(
+    tmp_path: pth.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detection reports unavailable when no scheme dir has the script.
+
+    This reproduces the layered ``uv run --with ...`` overlay from issue
+    #211: the scripts directory exists (populated with unrelated tools such
+    as mutmut itself) but contains no file named ``maturin``, which is
+    exactly the condition under which maturin's own ``python -m maturin``
+    entry point fails with "Unable to find `maturin` script".
+    """
+    scripts_dir = tmp_path / "bin"
+    scripts_dir.mkdir()
+    (scripts_dir / "mutmut").write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "tests.helpers.maturin.sysconfig.get_scheme_names", lambda: ("posix_prefix",)
+    )
+    monkeypatch.setattr(
+        "tests.helpers.maturin.sysconfig.get_path", lambda *_a, **_k: str(scripts_dir)
+    )
+
+    assert not maturin_script_locatable()
 
 
 def test_manylinux_aarch64_container_is_pinned_to_sha256() -> None:
@@ -198,6 +243,21 @@ def test_maturin_wheel_build_snapshot(
     expected = read_expected_maturin_version(root)
     if not toolchain_available():
         pytest.skip("Rust toolchain unavailable.")
+    if not maturin_script_locatable():
+        # A layered/ephemeral interpreter (for example, a `uv run --with
+        # ...` overlay, as used by the mutmut mutation-testing workflow)
+        # can import the maturin module via sys.path while sys.prefix
+        # points at a temporary environment that never received maturin's
+        # own compiled script. maturin's `python -m maturin` entry point
+        # then fails with "Unable to find `maturin` script" before it can
+        # invoke cargo. See tests.helpers.maturin.maturin_script_locatable
+        # for the detection logic, which mirrors maturin's own lookup.
+        pytest.skip(
+            "maturin's compiled script is not locatable via this "
+            "interpreter's sysconfig scripts directories (sys.prefix="
+            f"{sys.prefix!r}); this is expected in layered/ephemeral "
+            "interpreters such as a `uv run --with ...` overlay."
+        )
 
     wheel_path = build_native_wheel_artifact(root, tmp_path / "wheelhouse")
     snapshot_payload = wheel_build_snapshot(wheel_path)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1487,7 +1487,12 @@ change alters the architecture of the lint gate, update
 ## Maturin pin synchronization and native wheel tests
 
 The `tests/helpers/maturin.py` module provides shared helpers for tests that
-validate the maturin version pin contract and native wheel build output.
+validate the maturin version pin contract and native wheel build output. The
+wheel-artefact snapshot parsers (`wheel_build_snapshot` and its private
+helpers) live in the sibling module `tests/helpers/maturin_wheel.py` to keep
+each module below the Pylint module-length limit; `tests/helpers/maturin.py`
+re-exports `wheel_build_snapshot`, so import sites use
+`from tests.helpers.maturin import wheel_build_snapshot` unchanged.
 
 **Pin synchronization** (`test_maturin_pins_are_synchronized`) Asserts that the
 maturin version declared in `pyproject.toml`,
@@ -1540,6 +1545,47 @@ To update the snapshot after a maturin or PyO3 bump, run:
 uv run pytest cuprum/unittests/test_maturin_build.py \
     --snapshot-update -k test_maturin_wheel_build_snapshot
 ```
+
+### `maturin_script_locatable()` — native-wheel skip boundary
+
+`maturin_script_locatable()` (in `tests/helpers/maturin.py`) is the shared
+probe that decides whether the native-wheel build contract can actually run.
+It mirrors `maturin.__main__.get_maturin_path`: maturin resolves its bundled
+binary by scanning each `sysconfig` scheme's `scripts` directory for a file
+named `maturin`, keyed off the running interpreter's `sys.prefix` — **not**
+`sys.path` or `PATH`.
+
+This is deliberately narrower than `toolchain_available()`, and the two answer
+different questions:
+
+- `toolchain_available()` — is the `maturin` module importable and are `cargo`
+  and `rustc` on `PATH`? It uses `importlib.util.find_spec`, which succeeds
+  whenever the module is reachable via `sys.path`.
+- `maturin_script_locatable()` — can maturin find its own compiled script the
+  way `python -m maturin build` will at runtime?
+
+The two disagree in layered or ephemeral interpreters — most importantly the
+`uv run --with mutmut==3.6.0` overlay used by the mutation-testing workflow.
+There, the project virtualenv is on `sys.path` (so the module imports and
+`toolchain_available()` returns `True`), but `sys.prefix` points at a
+temporary environment that never received maturin's script, so
+`python -m maturin build` fails with ``Unable to find `maturin` script``
+before it can invoke `cargo`. This previously aborted the whole mutmut
+baseline. In a
+normal virtualenv (CI, `build-wheels.yml`, local `uv run pytest`) `sys.prefix`
+matches the install location, the probe returns `True`, and the real build
+runs — so the skip never masks a genuine regression.
+
+**Reuse policy.** Any test that shells out to `python -m maturin build` (or
+otherwise depends on maturin locating its own binary) — for example a new
+wheel-layout, packaging, or reproducibility test — should gate on **both**
+`toolchain_available()` and `maturin_script_locatable()`, skipping with a
+reason that names `sys.prefix` when the script is unreachable. Tests that only
+import the `maturin` Python module, or that inspect pins/metadata without
+building, need only the checks they already use and should **not** adopt this
+probe. Reuse the existing helper rather than re-deriving the `sysconfig` scan;
+extend `maturin_script_locatable()` in place if maturin changes how it locates
+its binary.
 
 ## Rust stream buffer-size validation
 

--- a/tests/helpers/maturin.py
+++ b/tests/helpers/maturin.py
@@ -7,11 +7,10 @@ import re
 import shutil
 import subprocess  # noqa: S404 - tests invoke pinned maturin build commands.
 import sys
-import typing as typ
-import zipfile
+import sysconfig
+from pathlib import Path
 
-if typ.TYPE_CHECKING:
-    from pathlib import Path
+from tests.helpers import maturin_wheel as _maturin_wheel
 
 _MATURIN_PIN_RE = re.compile(r"maturin==(\d+\.\d+\.\d+)")
 _WORKFLOW_PIN_RE = re.compile(r'MATURIN_VERSION:\s*"(\d+\.\d+\.\d+)"')
@@ -24,16 +23,6 @@ _AARCH64_CONTAINER_USAGE_RE = re.compile(
     r"^\s*container:\s*\$\{\{\s*env\.MANYLINUX_AARCH64_CONTAINER\s*\}\}\s*$",
     re.MULTILINE,
 )
-_GENERATOR_RE = re.compile(r"^Generator:\s*maturin\s*\(([^)]+)\)\s*$", re.MULTILINE)
-_EXTENSION_MODULE_RE = re.compile(
-    r"^cuprum/_rust_backend_native\.cpython-[^/]+\.so$",
-)
-_DIST_INFO_SUFFIXES: dict[str, str] = {
-    ".dist-info/RECORD": "cuprum-<version>.dist-info/RECORD",
-    ".dist-info/METADATA": "cuprum-<version>.dist-info/METADATA",
-    ".dist-info/WHEEL": "cuprum-<version>.dist-info/WHEEL",
-    ".dist-info/licenses/LICENSE": "cuprum-<version>.dist-info/licenses/LICENSE",
-}
 
 
 class MaturinBuildError(subprocess.CalledProcessError):
@@ -218,6 +207,47 @@ def toolchain_available() -> bool:
     )
 
 
+def _script_named_maturin_exists(directory: Path) -> bool:
+    """Return whether ``directory`` contains a file stem named ``maturin``."""
+    return any(
+        entry.is_file() and entry.stem == "maturin" for entry in directory.rglob("*")
+    )
+
+
+def maturin_script_locatable() -> bool:
+    """Return whether maturin's own lookup can find its compiled script.
+
+    Mirrors ``maturin.__main__.get_maturin_path``: the ``maturin`` PyPI
+    package resolves its bundled binary by walking each ``sysconfig``
+    scheme's ``scripts`` directory for a file named ``maturin``, keyed off
+    ``sys.prefix``/``sys.exec_prefix`` of the *running* interpreter — not
+    ``sys.path`` or ``PATH``. This diverges from :func:`toolchain_available`,
+    whose ``importlib.util.find_spec`` check only confirms the ``maturin``
+    module is importable.
+
+    The two checks disagree in layered/ephemeral interpreters such as a
+    ``uv run --with ...`` overlay: the overlay's ``sys.path`` includes the
+    project's own virtual environment (so the module imports fine and
+    :func:`toolchain_available` reports ``True``), but ``sys.prefix`` points
+    at a temporary environment that never received maturin's script, so
+    ``python -m maturin`` fails with ``Unable to find `maturin` script``
+    even though a real build would succeed in the project's own virtualenv.
+    Checking this separately lets callers skip precisely where the build is
+    genuinely unreachable, without masking a regression in normal CI or
+    local-development environments, where ``sys.prefix`` matches the
+    virtualenv that installed maturin's script.
+    """
+    script_dirs = (
+        Path(sysconfig.get_path("scripts", scheme))
+        for scheme in sysconfig.get_scheme_names()
+    )
+    return any(
+        _script_named_maturin_exists(directory)
+        for directory in script_dirs
+        if directory.exists()
+    )
+
+
 def build_native_wheel_artifact(root: Path, out_dir: Path) -> Path:
     """Build a native wheel with the pinned maturin version.
 
@@ -260,135 +290,6 @@ def build_native_wheel_artifact(root: Path, out_dir: Path) -> Path:
     return wheels[0]
 
 
-def _header_value(headers: dict[str, list[str]], key: str) -> str | None:
-    """Return the first header value for the given key, or None if absent."""
-    values = headers.get(key)
-    if not values:
-        return None
-    return values[0]
-
-
-def _parse_metadata(raw_metadata: str) -> dict[str, typ.Any]:
-    """Parse RFC 2822-style metadata headers into a normalised dict."""
-    headers: dict[str, list[str]] = {}
-    current_key: str | None = None
-    for line in raw_metadata.splitlines():
-        if line.startswith((" ", "\t")) and current_key is not None:
-            headers[current_key][-1] = f"{headers[current_key][-1]} {line.strip()}"
-            continue
-        if ":" not in line:
-            break
-        key, value = line.split(":", 1)
-        current_key = key.strip()
-        headers.setdefault(current_key, []).append(value.strip())
-
-    return {
-        "name": _header_value(headers, "Name"),
-        "version": _header_value(headers, "Version"),
-        "requires_python": _header_value(headers, "Requires-Python"),
-        "requires_dist": sorted(headers.get("Requires-Dist", [])),
-        "classifiers": sorted(headers.get("Classifier", [])),
-    }
-
-
-def _normalise_wheel_entry(name: str) -> str:
-    """Normalize platform/version wheel entry names to stable placeholders."""
-    if _EXTENSION_MODULE_RE.match(name):
-        return "cuprum/_rust_backend_native.cpython-<platform>.so"
-    if "/sboms/" in name:
-        return "cuprum-<version>.dist-info/sboms/<sbom>.cyclonedx.json"
-    for suffix, normalised in _DIST_INFO_SUFFIXES.items():
-        if name.endswith(suffix):
-            return normalised
-    return name
-
-
-def _locate_dist_info_wheel(entry_names: list[str]) -> str:
-    """Return the .dist-info/WHEEL entry name from a wheel archive's namelist.
-
-    Parameters
-    ----------
-    entry_names:
-        All entry names returned by ``zipfile.ZipFile.namelist()``.
-
-    Raises
-    ------
-    AssertionError
-        If no ``.dist-info/WHEEL`` entry is present.
-    """
-    wheel_name = next(
-        (name for name in entry_names if name.endswith(".dist-info/WHEEL")),
-        None,
-    )
-    if wheel_name is None:
-        msg = "wheel is missing .dist-info/WHEEL metadata"
-        raise AssertionError(msg)
-    return wheel_name
-
-
-def _parse_wheel_header(wheel_payload: str, whl_path: Path) -> tuple[str, str]:
-    """Extract the maturin generator string and Root-Is-Purelib value.
-
-    Parameters
-    ----------
-    wheel_payload:
-        Decoded text content of the ``.dist-info/WHEEL`` file.
-    whl_path:
-        Path to the wheel archive; used only in error messages.
-
-    Returns
-    -------
-    tuple[str, str]
-        ``(generator, root_is_purelib)`` extracted from the WHEEL headers.
-
-    Raises
-    ------
-    AssertionError
-        If either field cannot be parsed.
-    """
-    generator_match = _GENERATOR_RE.search(wheel_payload)
-    if generator_match is None:
-        msg = f"Could not parse maturin generator from WHEEL metadata: {whl_path}"
-        raise AssertionError(msg)
-    root_is_purelib = next(
-        (
-            line.removeprefix("Root-Is-Purelib: ")
-            for line in wheel_payload.splitlines()
-            if line.startswith("Root-Is-Purelib:")
-        ),
-        None,
-    )
-    if root_is_purelib is None:
-        msg = "wheel is missing Root-Is-Purelib metadata"
-        raise AssertionError(msg)
-    return generator_match.group(1), root_is_purelib
-
-
-def wheel_build_snapshot(whl_path: Path) -> dict[str, typ.Any]:
-    """Return a normalised snapshot of wheel metadata and layout.
-
-    Raises
-    ------
-    AssertionError
-        If the wheel metadata is missing expected maturin fields.
-    OSError
-        If the wheel file cannot be opened or read.
-    zipfile.BadZipFile
-        If the wheel file is not a valid zip archive.
-    """
-    with zipfile.ZipFile(whl_path) as archive:
-        entry_names = archive.namelist()
-        wheel_name = _locate_dist_info_wheel(entry_names)
-        metadata_name = wheel_name.replace("/WHEEL", "/METADATA")
-        wheel_payload = archive.read(wheel_name).decode("utf-8")
-        metadata_payload = archive.read(metadata_name).decode("utf-8")
-    generator, root_is_purelib = _parse_wheel_header(wheel_payload, whl_path)
-    return {
-        "generator": generator,
-        "metadata": _parse_metadata(metadata_payload),
-        "wheel": {
-            "root_is_purelib": root_is_purelib,
-            "tag": "<platform-tag>",
-        },
-        "entries": sorted(_normalise_wheel_entry(name) for name in entry_names),
-    }
+# The wheel-artifact snapshot helpers live in a sibling module to keep this
+# module focused; re-exported here so existing import sites keep working.
+wheel_build_snapshot = _maturin_wheel.wheel_build_snapshot

--- a/tests/helpers/maturin.py
+++ b/tests/helpers/maturin.py
@@ -236,6 +236,12 @@ def maturin_script_locatable() -> bool:
     genuinely unreachable, without masking a regression in normal CI or
     local-development environments, where ``sys.prefix`` matches the
     virtualenv that installed maturin's script.
+
+    Returns
+    -------
+    bool
+        Whether maturin's own lookup can locate its compiled script in this
+        interpreter.
     """
     script_dirs = (
         Path(sysconfig.get_path("scripts", scheme))

--- a/tests/helpers/maturin_wheel.py
+++ b/tests/helpers/maturin_wheel.py
@@ -30,7 +30,21 @@ _DIST_INFO_SUFFIXES: dict[str, str] = {
 
 
 class WheelMetadata(typ.TypedDict):
-    """Normalized ``.dist-info/METADATA`` fields captured in the snapshot."""
+    """Normalized ``.dist-info/METADATA`` fields captured in the snapshot.
+
+    Attributes
+    ----------
+    name : str | None
+        Value of the ``Name`` metadata header, or ``None`` if absent.
+    version : str | None
+        Value of the ``Version`` metadata header, or ``None`` if absent.
+    requires_python : str | None
+        Value of the ``Requires-Python`` header, or ``None`` if absent.
+    requires_dist : list[str]
+        Sorted values of the ``Requires-Dist`` headers.
+    classifiers : list[str]
+        Sorted values of the ``Classifier`` headers.
+    """
 
     name: str | None
     version: str | None
@@ -40,14 +54,35 @@ class WheelMetadata(typ.TypedDict):
 
 
 class WheelHeaders(typ.TypedDict):
-    """Normalized ``.dist-info/WHEEL`` fields captured in the snapshot."""
+    """Normalized ``.dist-info/WHEEL`` fields captured in the snapshot.
+
+    Attributes
+    ----------
+    root_is_purelib : str
+        Raw value of the ``Root-Is-Purelib`` header.
+    tag : str
+        Always the literal placeholder ``"<platform-tag>"``, normalized so
+        snapshots stay platform-independent.
+    """
 
     root_is_purelib: str
     tag: str
 
 
 class WheelBuildSnapshot(typ.TypedDict):
-    """Stable snapshot of a built wheel's metadata and layout."""
+    """Stable snapshot of a built wheel's metadata and layout.
+
+    Attributes
+    ----------
+    generator : str
+        Maturin version parsed from the WHEEL ``Generator`` header.
+    metadata : WheelMetadata
+        Normalized ``.dist-info/METADATA`` fields.
+    wheel : WheelHeaders
+        Normalized ``.dist-info/WHEEL`` fields.
+    entries : list[str]
+        Sorted, normalized archive entry names.
+    """
 
     generator: str
     metadata: WheelMetadata
@@ -99,18 +134,7 @@ def _normalise_wheel_entry(name: str) -> str:
 
 
 def _locate_dist_info_wheel(entry_names: list[str]) -> str:
-    """Return the .dist-info/WHEEL entry name from a wheel archive's namelist.
-
-    Parameters
-    ----------
-    entry_names:
-        All entry names returned by ``zipfile.ZipFile.namelist()``.
-
-    Raises
-    ------
-    AssertionError
-        If no ``.dist-info/WHEEL`` entry is present.
-    """
+    """Return the .dist-info/WHEEL entry name from a wheel archive's namelist."""
     wheel_name = next(
         (name for name in entry_names if name.endswith(".dist-info/WHEEL")),
         None,
@@ -122,25 +146,7 @@ def _locate_dist_info_wheel(entry_names: list[str]) -> str:
 
 
 def _parse_wheel_header(wheel_payload: str, whl_path: Path) -> tuple[str, str]:
-    """Extract the maturin generator string and Root-Is-Purelib value.
-
-    Parameters
-    ----------
-    wheel_payload:
-        Decoded text content of the ``.dist-info/WHEEL`` file.
-    whl_path:
-        Path to the wheel archive; used only in error messages.
-
-    Returns
-    -------
-    tuple[str, str]
-        ``(generator, root_is_purelib)`` extracted from the WHEEL headers.
-
-    Raises
-    ------
-    AssertionError
-        If either field cannot be parsed.
-    """
+    """Extract the maturin generator string and Root-Is-Purelib value."""
     generator_match = _GENERATOR_RE.search(wheel_payload)
     if generator_match is None:
         msg = f"Could not parse maturin generator from WHEEL metadata: {whl_path}"
@@ -162,10 +168,22 @@ def _parse_wheel_header(wheel_payload: str, whl_path: Path) -> tuple[str, str]:
 def wheel_build_snapshot(whl_path: Path) -> WheelBuildSnapshot:
     """Return a normalized snapshot of wheel metadata and layout.
 
+    Parameters
+    ----------
+    whl_path : Path
+        Path to the built wheel archive to inspect.
+
+    Returns
+    -------
+    WheelBuildSnapshot
+        The normalized snapshot (generator string, parsed metadata, wheel
+        headers, and normalized entry list).
+
     Raises
     ------
     AssertionError
-        If the wheel metadata is missing expected maturin fields.
+        If the wheel is missing its ``.dist-info/METADATA`` member or the
+        expected maturin metadata fields.
     OSError
         If the wheel file cannot be opened or read.
     zipfile.BadZipFile
@@ -175,6 +193,9 @@ def wheel_build_snapshot(whl_path: Path) -> WheelBuildSnapshot:
         entry_names = archive.namelist()
         wheel_name = _locate_dist_info_wheel(entry_names)
         metadata_name = wheel_name.replace("/WHEEL", "/METADATA")
+        if metadata_name not in entry_names:
+            msg = "wheel is missing .dist-info/METADATA metadata"
+            raise AssertionError(msg)
         wheel_payload = archive.read(wheel_name).decode("utf-8")
         metadata_payload = archive.read(metadata_name).decode("utf-8")
     generator, root_is_purelib = _parse_wheel_header(wheel_payload, whl_path)

--- a/tests/helpers/maturin_wheel.py
+++ b/tests/helpers/maturin_wheel.py
@@ -29,6 +29,32 @@ _DIST_INFO_SUFFIXES: dict[str, str] = {
 }
 
 
+class WheelMetadata(typ.TypedDict):
+    """Normalised ``.dist-info/METADATA`` fields captured in the snapshot."""
+
+    name: str | None
+    version: str | None
+    requires_python: str | None
+    requires_dist: list[str]
+    classifiers: list[str]
+
+
+class WheelHeaders(typ.TypedDict):
+    """Normalised ``.dist-info/WHEEL`` fields captured in the snapshot."""
+
+    root_is_purelib: str
+    tag: str
+
+
+class WheelBuildSnapshot(typ.TypedDict):
+    """Stable snapshot of a built wheel's metadata and layout."""
+
+    generator: str
+    metadata: WheelMetadata
+    wheel: WheelHeaders
+    entries: list[str]
+
+
 def _header_value(headers: dict[str, list[str]], key: str) -> str | None:
     """Return the first header value for the given key, or None if absent."""
     values = headers.get(key)
@@ -37,7 +63,7 @@ def _header_value(headers: dict[str, list[str]], key: str) -> str | None:
     return values[0]
 
 
-def _parse_metadata(raw_metadata: str) -> dict[str, typ.Any]:
+def _parse_metadata(raw_metadata: str) -> WheelMetadata:
     """Parse RFC 2822-style metadata headers into a normalised dict."""
     headers: dict[str, list[str]] = {}
     current_key: str | None = None
@@ -133,7 +159,7 @@ def _parse_wheel_header(wheel_payload: str, whl_path: Path) -> tuple[str, str]:
     return generator_match.group(1), root_is_purelib
 
 
-def wheel_build_snapshot(whl_path: Path) -> dict[str, typ.Any]:
+def wheel_build_snapshot(whl_path: Path) -> WheelBuildSnapshot:
     """Return a normalised snapshot of wheel metadata and layout.
 
     Raises

--- a/tests/helpers/maturin_wheel.py
+++ b/tests/helpers/maturin_wheel.py
@@ -1,0 +1,163 @@
+"""Wheel-artifact inspection helpers for maturin build contract tests.
+
+Split out of :mod:`tests.helpers.maturin` to keep each module focused: the
+parent module owns pin/version parsing, toolchain probing, and the wheel
+*build* invocation, while this module owns parsing a *built* wheel archive
+into the stable snapshot consumed by ``test_maturin_wheel_build_snapshot``.
+``tests.helpers.maturin`` re-exports :func:`wheel_build_snapshot` so existing
+import sites remain unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+import typing as typ
+import zipfile
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+_GENERATOR_RE = re.compile(r"^Generator:\s*maturin\s*\(([^)]+)\)\s*$", re.MULTILINE)
+_EXTENSION_MODULE_RE = re.compile(
+    r"^cuprum/_rust_backend_native\.cpython-[^/]+\.so$",
+)
+_DIST_INFO_SUFFIXES: dict[str, str] = {
+    ".dist-info/RECORD": "cuprum-<version>.dist-info/RECORD",
+    ".dist-info/METADATA": "cuprum-<version>.dist-info/METADATA",
+    ".dist-info/WHEEL": "cuprum-<version>.dist-info/WHEEL",
+    ".dist-info/licenses/LICENSE": "cuprum-<version>.dist-info/licenses/LICENSE",
+}
+
+
+def _header_value(headers: dict[str, list[str]], key: str) -> str | None:
+    """Return the first header value for the given key, or None if absent."""
+    values = headers.get(key)
+    if not values:
+        return None
+    return values[0]
+
+
+def _parse_metadata(raw_metadata: str) -> dict[str, typ.Any]:
+    """Parse RFC 2822-style metadata headers into a normalised dict."""
+    headers: dict[str, list[str]] = {}
+    current_key: str | None = None
+    for line in raw_metadata.splitlines():
+        if line.startswith((" ", "\t")) and current_key is not None:
+            headers[current_key][-1] = f"{headers[current_key][-1]} {line.strip()}"
+            continue
+        if ":" not in line:
+            break
+        key, value = line.split(":", 1)
+        current_key = key.strip()
+        headers.setdefault(current_key, []).append(value.strip())
+
+    return {
+        "name": _header_value(headers, "Name"),
+        "version": _header_value(headers, "Version"),
+        "requires_python": _header_value(headers, "Requires-Python"),
+        "requires_dist": sorted(headers.get("Requires-Dist", [])),
+        "classifiers": sorted(headers.get("Classifier", [])),
+    }
+
+
+def _normalise_wheel_entry(name: str) -> str:
+    """Normalize platform/version wheel entry names to stable placeholders."""
+    if _EXTENSION_MODULE_RE.match(name):
+        return "cuprum/_rust_backend_native.cpython-<platform>.so"
+    if "/sboms/" in name:
+        return "cuprum-<version>.dist-info/sboms/<sbom>.cyclonedx.json"
+    for suffix, normalised in _DIST_INFO_SUFFIXES.items():
+        if name.endswith(suffix):
+            return normalised
+    return name
+
+
+def _locate_dist_info_wheel(entry_names: list[str]) -> str:
+    """Return the .dist-info/WHEEL entry name from a wheel archive's namelist.
+
+    Parameters
+    ----------
+    entry_names:
+        All entry names returned by ``zipfile.ZipFile.namelist()``.
+
+    Raises
+    ------
+    AssertionError
+        If no ``.dist-info/WHEEL`` entry is present.
+    """
+    wheel_name = next(
+        (name for name in entry_names if name.endswith(".dist-info/WHEEL")),
+        None,
+    )
+    if wheel_name is None:
+        msg = "wheel is missing .dist-info/WHEEL metadata"
+        raise AssertionError(msg)
+    return wheel_name
+
+
+def _parse_wheel_header(wheel_payload: str, whl_path: Path) -> tuple[str, str]:
+    """Extract the maturin generator string and Root-Is-Purelib value.
+
+    Parameters
+    ----------
+    wheel_payload:
+        Decoded text content of the ``.dist-info/WHEEL`` file.
+    whl_path:
+        Path to the wheel archive; used only in error messages.
+
+    Returns
+    -------
+    tuple[str, str]
+        ``(generator, root_is_purelib)`` extracted from the WHEEL headers.
+
+    Raises
+    ------
+    AssertionError
+        If either field cannot be parsed.
+    """
+    generator_match = _GENERATOR_RE.search(wheel_payload)
+    if generator_match is None:
+        msg = f"Could not parse maturin generator from WHEEL metadata: {whl_path}"
+        raise AssertionError(msg)
+    root_is_purelib = next(
+        (
+            line.removeprefix("Root-Is-Purelib: ")
+            for line in wheel_payload.splitlines()
+            if line.startswith("Root-Is-Purelib:")
+        ),
+        None,
+    )
+    if root_is_purelib is None:
+        msg = "wheel is missing Root-Is-Purelib metadata"
+        raise AssertionError(msg)
+    return generator_match.group(1), root_is_purelib
+
+
+def wheel_build_snapshot(whl_path: Path) -> dict[str, typ.Any]:
+    """Return a normalised snapshot of wheel metadata and layout.
+
+    Raises
+    ------
+    AssertionError
+        If the wheel metadata is missing expected maturin fields.
+    OSError
+        If the wheel file cannot be opened or read.
+    zipfile.BadZipFile
+        If the wheel file is not a valid zip archive.
+    """
+    with zipfile.ZipFile(whl_path) as archive:
+        entry_names = archive.namelist()
+        wheel_name = _locate_dist_info_wheel(entry_names)
+        metadata_name = wheel_name.replace("/WHEEL", "/METADATA")
+        wheel_payload = archive.read(wheel_name).decode("utf-8")
+        metadata_payload = archive.read(metadata_name).decode("utf-8")
+    generator, root_is_purelib = _parse_wheel_header(wheel_payload, whl_path)
+    return {
+        "generator": generator,
+        "metadata": _parse_metadata(metadata_payload),
+        "wheel": {
+            "root_is_purelib": root_is_purelib,
+            "tag": "<platform-tag>",
+        },
+        "entries": sorted(_normalise_wheel_entry(name) for name in entry_names),
+    }

--- a/tests/helpers/maturin_wheel.py
+++ b/tests/helpers/maturin_wheel.py
@@ -30,7 +30,7 @@ _DIST_INFO_SUFFIXES: dict[str, str] = {
 
 
 class WheelMetadata(typ.TypedDict):
-    """Normalised ``.dist-info/METADATA`` fields captured in the snapshot."""
+    """Normalized ``.dist-info/METADATA`` fields captured in the snapshot."""
 
     name: str | None
     version: str | None
@@ -40,7 +40,7 @@ class WheelMetadata(typ.TypedDict):
 
 
 class WheelHeaders(typ.TypedDict):
-    """Normalised ``.dist-info/WHEEL`` fields captured in the snapshot."""
+    """Normalized ``.dist-info/WHEEL`` fields captured in the snapshot."""
 
     root_is_purelib: str
     tag: str
@@ -64,7 +64,7 @@ def _header_value(headers: dict[str, list[str]], key: str) -> str | None:
 
 
 def _parse_metadata(raw_metadata: str) -> WheelMetadata:
-    """Parse RFC 2822-style metadata headers into a normalised dict."""
+    """Parse RFC 2822-style metadata headers into a normalized dict."""
     headers: dict[str, list[str]] = {}
     current_key: str | None = None
     for line in raw_metadata.splitlines():
@@ -160,7 +160,7 @@ def _parse_wheel_header(wheel_payload: str, whl_path: Path) -> tuple[str, str]:
 
 
 def wheel_build_snapshot(whl_path: Path) -> WheelBuildSnapshot:
-    """Return a normalised snapshot of wheel metadata and layout.
+    """Return a normalized snapshot of wheel metadata and layout.
 
     Raises
     ------


### PR DESCRIPTION
## Summary

- Every scheduled mutation-testing run for `cuprum` has failed at the
  baseline since 2026-07-14: `test_maturin_wheel_build_snapshot` dies
  with `Unable to find `maturin` script` before mutmut generates any
  mutants, so no mutation testing has actually happened.
- Root cause: the `maturin` PyPI package locates its own compiled
  binary by walking each `sysconfig` scheme's `scripts` directory keyed
  off the *running interpreter's* `sys.prefix` — not `sys.path`/`PATH`.
  Under mutmut's `uv run --with mutmut==3.6.0` overlay, `sys.prefix`
  points at a temporary environment layered on top of the project's own
  virtualenv: the `maturin` module still imports fine (via `sys.path`,
  so `cargo`/`rustc` and the existing `toolchain_available()` check all
  report success), but the overlay never received maturin's script, so
  the lookup comes up empty and the build subprocess exits 1.
- Fix: add `maturin_script_locatable()` to `tests/helpers/maturin.py`,
  mirroring maturin's own lookup exactly, and skip
  `test_maturin_wheel_build_snapshot` with a precise reason when it
  reports the script unreachable. In every normal environment (CI,
  `build-wheels.yml`, local `uv run pytest`) `sys.prefix` matches the
  virtualenv that installed the script, so the real native build still
  runs unchanged — only the layered mutmut overlay skips.

Closes #211

### Why this design over the alternatives

The issue proposed two paths: exclude the test from mutmut's baseline
selection, or make the test locate maturin robustly and skip only when
genuinely unavailable. This PR takes the second path because it is the
more precise fix for the actual root cause:

- The maturin binary genuinely *is* unreachable in mutmut's layered
  overlay (confirmed empirically below), so a `pytest.skip` with an
  exact reason is not a workaround — it is accurate diagnosis.
- Excluding the test from mutmut's test selection would need a new
  `[tool.mutmut]` section in `pyproject.toml` (there currently is none;
  mutmut runs on defaults) and would silence the test everywhere
  mutmut runs, even in environments where the build would actually
  succeed.
- This keeps the wheel-build snapshot test exercising the real
  `maturin build` path in every environment that can actually complete
  it, per the issue's stated preference.

## Review walkthrough

- [`tests/helpers/maturin.py`](https://github.com/leynos/cuprum/blob/fix/mutmut-baseline-maturin/tests/helpers/maturin.py):
  adds `_script_named_maturin_exists()` and `maturin_script_locatable()`,
  which reproduce `maturin.__main__.get_maturin_path()`'s own
  `sysconfig`-based scan for a file named `maturin` under each scheme's
  `scripts` directory.
- [`cuprum/unittests/test_maturin_build.py`](https://github.com/leynos/cuprum/blob/fix/mutmut-baseline-maturin/cuprum/unittests/test_maturin_build.py):
  `test_maturin_wheel_build_snapshot` now skips with a reason naming
  `sys.prefix` when the script can't be found, alongside the existing
  Rust-toolchain skip. Two new unit tests
  (`test_maturin_script_locatable_true_when_script_present` /
  `_false_when_script_absent`) pin the detector's behaviour by faking
  the `sysconfig` scheme lookup, independent of the real environment.
- [`tests/helpers/maturin_wheel.py`](https://github.com/leynos/cuprum/blob/fix/mutmut-baseline-maturin/tests/helpers/maturin_wheel.py):
  new module. Rebasing onto `main` pulled in `MaturinBuildError` (#144),
  which together with the new detector pushed `tests/helpers/maturin.py`
  past pylint's 400-line module limit. The wheel-artifact snapshot parsers
  (`wheel_build_snapshot` and its private helpers) move here;
  `tests/helpers/maturin.py` re-exports `wheel_build_snapshot`, so all
  import sites are unchanged.
- [`docs/developers-guide.md`](https://github.com/leynos/cuprum/blob/fix/mutmut-baseline-maturin/docs/developers-guide.md): documents `maturin_script_locatable()`'s scope, how it differs from `toolchain_available()`, the native-wheel skip boundary, and the reuse policy (which tests should gate on it), per the AGENTS.md abstraction/helper policy.

## Validation evidence

Reproduced the exact CI failure locally, then confirmed the fix:

```console
$ uv run --with mutmut==3.6.0 python -m pytest -x cuprum/unittests/test_maturin_build.py::test_maturin_wheel_build_snapshot
# before the fix:
subprocess.CalledProcessError: Command '[...python', '-m', 'maturin', 'build', ...]' returned non-zero exit status 1.
Unable to find `maturin` script
1 failed in 0.14s

# after the fix:
cuprum/unittests/test_maturin_build.py::test_maturin_wheel_build_snapshot SKIPPED
SKIPPED [1] ...: maturin's compiled script is not locatable via this interpreter's
sysconfig scripts directories (sys.prefix='/home/leynos/.cache/uv/builds-v0/.tmp...');
this is expected in layered/ephemeral interpreters such as a `uv run --with ...` overlay.
```

Confirmed the fix does **not** mask a real build in normal environments:

```console
$ uv run pytest -rs cuprum/unittests/test_maturin_build.py::test_maturin_wheel_build_snapshot -v
cuprum/unittests/test_maturin_build.py::test_maturin_wheel_build_snapshot PASSED
1 passed in 9.80s
```

Gates run against the two changed files (`make build`, `make check-fmt`,
`make lint`, `make typecheck`, `make test`):

- `build`, `check-fmt`, `lint`, `typecheck`: pass.
- `test`: all Python suites pass, including the full
  `cuprum/unittests/test_maturin_build.py` file (14 passed). One
  pre-existing Rust `trybuild` UI fixture
  (`cuprum-rust::compile_tests::compile_time_ui`,
  `tests/ui/fail/const_availability_export.rs`) fails on a rustc
  diagnostic-wording drift unrelated to this change; confirmed it also
  fails identically on an unmodified `origin/main` checkout.

## Test plan

- [x] `uv run --with mutmut==3.6.0 python -m pytest -x
      cuprum/unittests/test_maturin_build.py` — reproduced the failure,
      then confirmed the skip.
- [x] `uv run pytest cuprum/unittests/test_maturin_build.py` — full
      file green, real build still exercised in a normal virtualenv.
- [x] `make check-fmt`, `make lint`, `make typecheck` — pass.
- [ ] CI: watch the PR checks and the next scheduled mutation-testing
      run.

## References

- Issue [#211](https://github.com/leynos/cuprum/issues/211): Mutation-testing
  baseline fails: maturin wheel build cannot find its own script.
- Lody session: https://lody.ai/leynos/sessions/97806670-b92d-419e-9ceb-ddd870848ec4

## Summary by Sourcery

Skip the maturin wheel-build snapshot test when maturin’s compiled script is not locatable by the running interpreter, while keeping normal builds exercised and reorganising wheel snapshot helpers into a dedicated module.

Bug Fixes:
- Prevent mutation-testing runs from failing early by conditionally skipping the maturin wheel-build snapshot test when maturin’s script cannot be found in the current interpreter’s sysconfig scripts directories.

Enhancements:
- Add a helper to detect whether maturin’s compiled script is discoverable in the current environment, mirroring maturin’s own lookup.
- Refactor wheel artifact snapshot logic into a dedicated helper module and re-export its main entry point to preserve existing imports.

Tests:
- Add unit tests covering maturin script discoverability in environments where the script is present or absent.
