### PR TITLE
Bump whitaker-installer to 0.2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       MBAKE_VERSION: '1.4.6'
       TY_VERSION: '0.0.8'
-      WHITAKER_INSTALLER_VERSION: '0.2.6'
+      WHITAKER_INSTALLER_VERSION: '0.2.7'
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -48,7 +48,7 @@ jobs:
             ~/.local/bin/whitaker
             ~/.dylint_drivers
             ~/.local/share/whitaker
-          key: whitaker-v4-${{ runner.os }}-${{ env.WHITAKER_INSTALLER_VERSION }}
+          key: whitaker-v5-${{ runner.os }}-${{ env.WHITAKER_INSTALLER_VERSION }}
 
       - name: Install Whitaker
         run: |


### PR DESCRIPTION
## Summary

This branch bumps the Whitaker installer pin to the released `0.2.7`, which fixes the CI lint-gate failure caused by the installer rejecting a valid `dylint-link` release artefact.

Under Rust 1.85.0, installer 0.2.6 downloaded the correct, checksummed `dylint-link` 6.0.1 artefact but then executed it as a `--help` health check. `dylint-link` is a linker wrapper with no reliable self-reporting subcommand, so that probe failed and verification fell back to `cargo install --locked --version 6.0.1 dylint-link`, which cannot compile on Rust 1.85.0 (its resolved dependencies require Rust 1.86–1.91). Installer 0.2.7 ([leynos/whitaker#300](https://github.com/leynos/whitaker/pull/300), closing [#299](https://github.com/leynos/whitaker/issues/299)) trusts the download, checksum, extraction, and permission pipeline instead of executing the wrapper, so the artefact is accepted and no source build is attempted.

## Changes

- Set `WHITAKER_INSTALLER_VERSION` from `0.2.6` to `0.2.7` in [.github/workflows/ci.yml](https://github.com/leynos/cuprum/blob/bump-whitaker-installer-0.2.7/.github/workflows/ci.yml).
- Bump the Whitaker cache-key namespace from `whitaker-v4-` to `whitaker-v5-` so a cache populated by installer 0.2.6 cannot mask the upgrade.

## Validation

- The `lint-test` job under Rust 1.85.0 should now clear `whitaker-installer --cranelift` without any Cargo source installation of `dylint-link`; CI on this PR exercises that path.

## Notes

No Rust toolchain pin is changed and the Whitaker lint gate is not weakened.
