### PR TITLE
Bump the remaining setup-rust pin to 18bed1ca

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
 
       - name: Install Rust toolchain
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: '1.92.0'
 


### PR DESCRIPTION
## Summary
One `setup-rust` reference in ci.yml (line 162) was still on `927edd45` after the estate-wide pin bump — a concurrent merge reintroduced it. This moves it to `18bed1ca` to match every other shared-actions reference.

## Validation
CI on this pull request exercises the bumped reference.

## Summary by Sourcery

CI:
- Update the remaining setup-rust action reference in the CI workflow to use the new shared-actions commit hash.