### PR TITLE
Pin dev pytest below 9.1 until pytest-bdd supports its fixture API (#208)

### DIFF
--- a/.rules/python-pyproject.md
+++ b/.rules/python-pyproject.md
@@ -79,6 +79,8 @@ ______________________________________________________________________
 right one decides whether a dependency ships to every end user or only ever
 exists on a contributor's machine.
 
+Table 1. Dependency field selection.
+
 | Field | Installed for | Use it for |
 | --- | --- | --- |
 | `project.dependencies` | Everyone who installs the package | Libraries the shipped code imports at runtime |
@@ -108,8 +110,8 @@ tooling. Add them with `uv add --optional <extra>`:
 
 ```toml
 [project.optional-dependencies]
-# Opt-in feature: end users request it with cuprum[<extra>].
-<extra> = [
+# Opt-in feature: end users request it with cuprum[feature].
+feature = [
   "some-runtime-lib>=1.2,<2",
 ]
 ```
@@ -118,8 +120,8 @@ tooling. Add them with `uv add --optional <extra>`:
 
 Tooling only contributors need: test frameworks, linters, type checkers,
 documentation builders, and property or mutation testers. These are
-**local-only** — PEP 735 dependency groups are *not* published in the wheel
-metadata and are never installed for end users, so they must live here rather
+**local-only** — PEP 735 dependency groups are *not* included in published
+package metadata (they are not part of the wheel), so they must live here rather
 than in `project.optional-dependencies`. Add them with `uv add --dev` (the
 `dev` group) or `uv add --group <name>`:
 
@@ -147,9 +149,11 @@ gives a contributor the full toolchain. Adjust this with:
 default-groups = ["dev", "docs"]  # or "all"
 ```
 
-Groups may nest via `{ include-group = "..." }`, and `uv` resolves every group
-together into a single `uv.lock`, so all groups must be mutually compatible.
-(Astral Docs[^9])
+Groups may nest via `{ include-group = "..." }`, and by default `uv` resolves
+every group together into a single `uv.lock`, so groups must be mutually
+compatible unless you declare incompatible sets explicitly under
+`[tool.uv].conflicts`.
+(Astral Docs[^6])
 
 > **Rule of thumb:** if an end user needs it to *run* the code, it belongs
 > in `project.dependencies` (always) or `project.optional-dependencies`
@@ -174,12 +178,12 @@ mygui = "my_project.gui:start"
 ```
 
 - **`[project.scripts]`:** Defines console scripts. When you run `uv run mycli`,
-  `uv` will invoke the `main` function in `my_project/cli.py`. (Astral Docs[^8])
+  `uv` will invoke the `main` function in `my_project/cli.py`. (Astral Docs[^7])
 - **`[project.gui-scripts]`:** On Windows, `uv` will wrap these in a GUI
   executable; on Unix-like systems, they behave like normal console scripts.
-  (Astral Docs[^8])
+  (Astral Docs[^7])
 - **Plugin Entry Points:** If your project supports plugins, use
-  `[project.entry-points.'group.name']` to register them. (Astral Docs[^8])
+  `[project.entry-points.'group.name']` to register them. (Astral Docs[^7])
 
 ______________________________________________________________________
 
@@ -198,14 +202,14 @@ build-backend = "setuptools.build_meta"
 
 - **`requires`:** A list of packages needed at build time. For editable installs
   in `uv`, you need at least `setuptools>=61.0` and `wheel`. (Python
-  Packaging[^4], Astral Docs[^8])
+  Packaging[^4], Astral Docs[^7])
 - **`build-backend`:** The entry point for your build backend.
   `setuptools.build_meta` is the PEP 517-compliant backend for setuptools.
-  (Python Packaging[^4], Astral Docs[^8])
+  (Python Packaging[^4], Astral Docs[^7])
 - **Note:** If you omit `[build-system]`, `uv` will assume
   `setuptools.build_meta:__legacy__` and still install dependencies, but it
   won't editably install your own project unless you set
-  `tool.uv.package = true` (see next section). (Astral Docs[^8])
+  `tool.uv.package = true` (see next section). (Astral Docs[^7])
 
 ______________________________________________________________________
 
@@ -222,10 +226,10 @@ package = true
 - **`tool.uv.package = true`:** Forces `uv` to build and install your project
   into its virtual environment every time you run `uv sync` or `uv run`.
   Without this, `uv` only installs dependencies (not your own package) if
-  `[build-system]` is missing. (Astral Docs[^8])
+  `[build-system]` is missing. (Astral Docs[^7])
 - You may also set other `uv`-specific keys (e.g., custom indexes, resolver
   policies) under `[tool.uv]`, but `package` is the most common. (Python
-  Packaging[^4], Astral Docs[^8])
+  Packaging[^4], Astral Docs[^7])
 
 ______________________________________________________________________
 
@@ -305,26 +309,26 @@ package = true
      Packaging[^4])
    - `[dependency-groups]` (PEP 735) holds development-only tooling (`dev`,
      `docs`) that is never published; `uv sync` installs the `dev` group by
-     default. (Astral Docs[^9])
+     default. (Astral Docs[^6])
 
 3. **Entry Points (`[project.scripts]`):**
 
    - Defines a console command `mycli` that maps to `my_project/cli.py:main`.
-     Invoking `uv run mycli` will run the `main()` function. (Astral Docs[^8])
+     Invoking `uv run mycli` will run the `main()` function. (Astral Docs[^7])
 
 4. **Build System:**
 
    - `setuptools>=61.0` plus `wheel` ensures both legacy and editable installs
      work. ✱ Newer versions of setuptools support PEP 660 editable installs
-     without a `setup.py` stub. (Python Packaging[^4], Astral Docs[^8])
+     without a `setup.py` stub. (Python Packaging[^4], Astral Docs[^7])
    - `build-backend = "setuptools.build_meta"` tells `uv` how to compile your
-     package. (Python Packaging[^4], Astral Docs[^8])
+     package. (Python Packaging[^4], Astral Docs[^7])
 
 5. **`[tool.uv]`:**
 
    - `package = true` ensures that `uv sync` will build and install your own
      project (in editable mode) every time dependencies change. Otherwise, `uv`
-     treats your project as a collection of scripts only (no package). (Astral Docs[^8])
+     treats your project as a collection of scripts only (no package). (Astral Docs[^7])
 
 ______________________________________________________________________
 
@@ -346,10 +350,10 @@ ______________________________________________________________________
 4. **Keep Build Constraints Minimal:** If you don't need editable installs, you
    can omit `[build-system]` (but then `uv` won't build your package; it will
    only install dependencies). To override, set `tool.uv.package = true`.
-   (Astral Docs[^8])
+   (Astral Docs[^7])
 
 5. **Use Exact or Bounded Ranges for Dependencies:** Rather than `requests`, use
-   `requests>=2.25, <3.0` to avoid unexpected major bumps. (DevsJC[^6])
+   `requests>=2.25, <3.0` to avoid unexpected major bumps. (DevsJC[^8])
 
 6. **Consider Dynamic Fields Sparingly:** You can declare fields like
    `dynamic = ["version"]` if your version is computed at build time (e.g. via
@@ -382,6 +386,6 @@ easy to maintain, and integrates seamlessly with Astral `uv`.
 [^3]: [Modern Python Development with pyproject.toml and UV](https://levelup.gitconnected.com/modern-python-development-with-pyproject-toml-and-uv-405dfb8b6ec8)
 [^4]: [Writing your pyproject.toml – Python Packaging User Guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/)
 [^5]: [Anyone used UV package manager in production? (Reddit)](https://www.reddit.com/r/Python/comments/1ixryec/anyone_used_uv_package_manager_in_production/)
-[^6]: [The Complete Guide to pyproject.toml – devsjc blogs](https://devsjc.github.io/blog/20240627-the-complete-guide-to-pyproject-toml/)
-[^8]: [Configuring projects | uv - Astral Docs](https://docs.astral.sh/uv/concepts/projects/config/)
-[^9]: [Managing dependencies | uv - Astral Docs](https://docs.astral.sh/uv/concepts/projects/dependencies/)
+[^6]: [Managing dependencies | uv - Astral Docs](https://docs.astral.sh/uv/concepts/projects/dependencies/)
+[^7]: [Configuring projects | uv - Astral Docs](https://docs.astral.sh/uv/concepts/projects/config/)
+[^8]: [The Complete Guide to pyproject.toml – devsjc blogs](https://devsjc.github.io/blog/20240627-the-complete-guide-to-pyproject-toml/)

--- a/.rules/python-pyproject.md
+++ b/.rules/python-pyproject.md
@@ -73,31 +73,89 @@ dependencies = [
 
 ______________________________________________________________________
 
-## 3. Optional and Development Dependencies
+## 3. Runtime vs. development dependencies
 
-Modern projects typically distinguish between "production" dependencies (those
-needed at runtime) and "development" dependencies (linters, test frameworks,
-etc.). In PEP 621, you use `[project.optional-dependencies]` for this:
+`uv` (via PEP 621 and PEP 735) exposes three dependency fields. Choosing the
+right one decides whether a dependency ships to every end user or only ever
+exists on a contributor's machine.
+
+| Field | Installed for | Use it for |
+| --- | --- | --- |
+| `project.dependencies` | Everyone who installs the package | Libraries the shipped code imports at runtime |
+| `project.optional-dependencies` | End users who opt into an *extra* | Optional runtime *features* (`package[extra]`) |
+| `dependency-groups` | Local development only | Test, lint, type-check, docs, and other tooling |
+
+### Required runtime dependencies — `project.dependencies`
+
+Packages the shipped code imports unconditionally. They are published in the
+wheel metadata and installed for every consumer. Use PEP 508 specifiers with
+bounded ranges, and add them with `uv add <name>`:
 
 ```toml
-[project.optional-dependencies]
-dev = [
-  "pytest>=7.0",        # Testing framework
-  "black",              # Code formatter
-  "flake8>=4.0"         # Linter
-]
-docs = [
-  "sphinx>=5.0",        # Documentation builder
-  "sphinx-rtd-theme"
+[project]
+dependencies = [
+  "httpx>=0.27,<1",
 ]
 ```
 
-- **`[project.optional-dependencies]`:** Each table key (e.g. `dev`, `docs`)
-  defines a "dependency group." You can install a group via
-  `uv add --group dev` or `uv sync --include dev`. (Python Packaging[^4],
-  DevsJC[^6])
-- **Why use groups?** You keep the lockfile deterministic (via `uv.lock`) while
-  still separating concerns (test‐only vs. production). (Medium[^7], DevsJC[^6])
+### Optional runtime features — `project.optional-dependencies`
+
+Published "extras" that an *end user* opts into to enable an optional feature
+of the package, requested with `package[extra]` syntax (for example,
+`pandas[excel]`). Reach for this only when the extra dependency powers
+user-facing functionality that not everyone needs — never for development
+tooling. Add them with `uv add --optional <extra>`:
+
+```toml
+[project.optional-dependencies]
+# Opt-in feature: end users request it with cuprum[<extra>].
+<extra> = [
+  "some-runtime-lib>=1.2,<2",
+]
+```
+
+### Development-time dependencies — `dependency-groups`
+
+Tooling only contributors need: test frameworks, linters, type checkers,
+documentation builders, and property or mutation testers. These are
+**local-only** — PEP 735 dependency groups are *not* published in the wheel
+metadata and are never installed for end users, so they must live here rather
+than in `project.optional-dependencies`. Add them with `uv add --dev` (the
+`dev` group) or `uv add --group <name>`:
+
+```toml
+[dependency-groups]
+dev = [
+  "pytest<9.1",
+  "ruff",
+  "ty",
+]
+```
+
+**`uv` installs the `dev` group automatically by default.** `uv run` and
+`uv sync` include the `dev` group with no extra flags, so a bare `uv sync`
+gives a contributor the full toolchain. Adjust this with:
+
+- `--no-dev` or `--no-default-groups` to exclude development dependencies (for
+  example, when building a wheel or a production install).
+- `--group <name>` or `--only-group <name>` to include or isolate a
+  non-default group.
+- `[tool.uv].default-groups` to change which groups sync by default:
+
+```toml
+[tool.uv]
+default-groups = ["dev", "docs"]  # or "all"
+```
+
+Groups may nest via `{ include-group = "..." }`, and `uv` resolves every group
+together into a single `uv.lock`, so all groups must be mutually compatible.
+(Astral Docs[^9])
+
+> **Rule of thumb:** if an end user needs it to *run* the code, it belongs
+> in `project.dependencies` (always) or `project.optional-dependencies`
+> (an opt-in feature). If only a contributor needs it to *develop, test,
+> lint, type-check, or document* the code, it belongs in
+> `dependency-groups`.
 
 ______________________________________________________________________
 
@@ -198,11 +256,18 @@ dependencies = [
   "numpy>=1.23"
 ]
 
+# Opt-in runtime feature; end users install it with my_project[fast].
 [project.optional-dependencies]
+fast = [
+  "orjson>=3.9"
+]
+
+# Development-only tooling (PEP 735); never shipped to end users.
+[dependency-groups]
 dev = [
   "pytest>=7.0",
-  "black",
-  "flake8>=4.0"
+  "ruff",
+  "mypy>=1.0"
 ]
 docs = [
   "sphinx>=5.0",
@@ -233,11 +298,14 @@ package = true
    - `dependencies`: runtime requirements, expressed in PEP 508 syntax.
      (Astral Docs[^1], RidgeRun.ai[^2])
 
-2. **Optional Dependencies (`[project.optional-dependencies]`):**
+2. **Optional features vs. development tooling:**
 
-   - Grouped as `dev` (for testing + linting) and `docs` (for documentation).
-     Installing them is as simple as `uv add --group dev` or
-     `uv sync --include dev`. (Python Packaging[^4], DevsJC[^6])
+   - `[project.optional-dependencies]` declares an opt-in runtime *extra*
+     (`fast`), installed by end users via `my_project[fast]`. (Python
+     Packaging[^4])
+   - `[dependency-groups]` (PEP 735) holds development-only tooling (`dev`,
+     `docs`) that is never published; `uv sync` installs the `dev` group by
+     default. (Astral Docs[^9])
 
 3. **Entry Points (`[project.scripts]`):**
 
@@ -294,8 +362,10 @@ ______________________________________________________________________
 
 A "modern" `pyproject.toml` for an Astral `uv` project should:
 
-- Use the PEP 621 `[project]` table for metadata and `dependencies`.
-- Distinguish optional dependencies under `[project.optional-dependencies]`.
+- Use the PEP 621 `[project]` table for metadata and runtime `dependencies`.
+- Declare opt-in runtime *features* as extras under
+  `[project.optional-dependencies]`, and development-only tooling under
+  `[dependency-groups]` (the `dev` group installs by default).
 - Define any CLI or GUI entry points under `[project.scripts]` or
   `[project.gui-scripts]`.
 - Declare a PEP 517 `[build-system]` (e.g. `setuptools>=61.0`, `wheel`,
@@ -313,5 +383,5 @@ easy to maintain, and integrates seamlessly with Astral `uv`.
 [^4]: [Writing your pyproject.toml – Python Packaging User Guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/)
 [^5]: [Anyone used UV package manager in production? (Reddit)](https://www.reddit.com/r/Python/comments/1ixryec/anyone_used_uv_package_manager_in_production/)
 [^6]: [The Complete Guide to pyproject.toml – devsjc blogs](https://devsjc.github.io/blog/20240627-the-complete-guide-to-pyproject-toml/)
-[^7]: [Start Using UV Python Package Manager for Better Dependency Management](https://medium.com/%40gnetkov/start-using-uv-python-package-manager-for-better-dependency-management-183e7e428760)
 [^8]: [Configuring projects | uv - Astral Docs](https://docs.astral.sh/uv/concepts/projects/config/)
+[^9]: [Managing dependencies | uv - Astral Docs](https://docs.astral.sh/uv/concepts/projects/dependencies/)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1437,6 +1437,21 @@ exercised in `cuprum/unittests/test_rust_streams_boundary_property.py`. Keep the
 `_streams_rs.py` wrapper docstrings, `docs/cuprum-design.md`, and the
 users' guide aligned with this contract when the cap changes.
 
+## Development dependency pins
+
+Test tooling occasionally needs a temporary upper bound while an upstream
+project catches up with a newer release. These pins live in `pyproject.toml`'s
+`[dependency-groups]` `dev` group — dev-only, never in the runtime
+`[project.optional-dependencies]` — each with an inline rationale and a tracking
+link, and are lifted once the upstream fix lands.
+
+- `pytest<9.1` — pytest 9.1 deprecates the nodeid/baseid path that `pytest-bdd`
+  8.1.0 relies on for fixture registration, raising `PytestRemovedIn10Warning`
+  under the behavioural suite. The constraint holds the dev environment on
+  pytest 9.0.x until `pytest-bdd` migrates to the node-based fixture API. Track
+  [pytest-bdd#823](https://github.com/pytest-dev/pytest-bdd/issues/823); remove
+  the pin and this note once a released `pytest-bdd` supports pytest 9.1.
+
 ## Workflow pins and Dependabot
 
 Dependabot owns the upgrade of GitHub Actions and reusable workflows, including

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ dev = [
     "hypothesis",
     "hypothesis-crosshair",
     "interrogate",
-    "pytest",
+    # Constrained below pytest 9.1 until pytest-bdd supports its node-based
+    # fixture-registration API; 9.1 deprecates the nodeid/baseid path that
+    # pytest-bdd 8.1.0 uses, raising PytestRemovedIn10Warning.
+    # Track: https://github.com/pytest-dev/pytest-bdd/issues/823
+    "pytest<9.1",
     "pytest-benchmark",
     "pytest-bdd",
     "ruff",

--- a/uv.lock
+++ b/uv.lock
@@ -117,7 +117,7 @@ dev = [
     { name = "interrogate" },
     { name = "maturin", specifier = "==1.13.3" },
     { name = "pyright" },
-    { name = "pytest" },
+    { name = "pytest", specifier = "<9.1" },
     { name = "pytest-bdd" },
     { name = "pytest-benchmark" },
     { name = "pytest-timeout" },
@@ -440,7 +440,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.1.1"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -449,9 +449,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Constrains the development `pytest` dependency to `pytest<9.1` so the resolver selects a 9.0.x release while `pytest-bdd` stays at 8.1.0. pytest 9.1 deprecates the `nodeid`/`baseid` fixture-registration path that `pytest-bdd==8.1.0` uses, which surfaced `PytestRemovedIn10Warning` from `pytest_bdd.compat` and `_pytest.fixtures` during the behaviour suites.

The warnings originate in the dependency, not in Cuprum's tests or application code. This pin is temporary and should be removed once pytest-bdd ships support for pytest 9.1's node-based fixture-registration API (upstream: pytest-dev/pytest-bdd#823).

## Changes

- `pyproject.toml`: `pytest` -> `pytest<9.1` in `[dependency-groups].dev`, with an inline comment documenting the rationale and upstream tracking link.
- `uv.lock`: regenerated — `pytest` resolves to 9.0.3, `pytest-bdd` retained at 8.1.0.

## Verification

- `make test` green (Python + Rust); test log confirms `pytest-9.0.3` / `pytest-bdd-8.1.0`.
- No `PytestRemovedIn10Warning` (or any `DeprecationWarning`) in the test output.
- Did not modify `cuprum/**` or `tests/behaviour/**`, add `filterwarnings`, patch pytest-bdd, or change CI.

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin the development pytest dependency below 9.1 to avoid incompatibilities with pytest-bdd until upstream adds support for the newer fixture API.

Build:
- Constrain the dev dependency on pytest to pytest<9.1 with inline documentation of the compatibility rationale and upstream tracking issue.
- Regenerate the uv.lock file to reflect the updated pytest constraint while keeping pytest-bdd at a compatible version.