### PR TITLE
Drain subprocess stream consumers once and harden test synchronisation

### DIFF
--- a/cuprum/_subprocess_execution.py
+++ b/cuprum/_subprocess_execution.py
@@ -53,9 +53,14 @@ async def _wait_for_exit_code(
     ctx: ExecutionContext,
     *,
     timeout: float | None = None,
-    consumers: tuple[asyncio.Task[str | None], ...] = (),
 ) -> tuple[int, float]:
-    """Wait for a subprocess, handling cancellation and capturing exit time."""
+    """Wait for a subprocess exit code, terminating it on timeout or cancel.
+
+    Waiting for the exit code is this helper's sole responsibility. Any stream
+    consumers belong to the caller, which drains them exactly once when the wait
+    fails (see :func:`_run_subprocess_with_streams`); terminating the process
+    here lets those consumers reach EOF during that drain.
+    """
     try:
         if timeout is None:
             exit_code = await process.wait()
@@ -63,16 +68,30 @@ async def _wait_for_exit_code(
             exit_code = await asyncio.wait_for(process.wait(), timeout)
     except (TimeoutError, asyncio.CancelledError):
         # asyncio.wait_for raises TimeoutError on expiry; the surrounding task
-        # may also be cancelled. Both need the same teardown: terminate the
-        # process, then cancel and drain any still-pending consumers before
-        # re-raising the original exception.
+        # may also be cancelled. Both tear the process down before re-raising
+        # the original exception.
         await _terminate_process(process, ctx.cancel_grace)
-        if consumers:
-            _cancel_pending_consumers(consumers)
-            await asyncio.gather(*consumers, return_exceptions=True)
         raise
     exited_at = time.perf_counter()
     return exit_code, exited_at
+
+
+async def _drain_stream_consumers(
+    consumers: tuple[asyncio.Task[str | None], asyncio.Task[str | None]],
+) -> tuple[str | None, str | None]:
+    """Cancel pending consumers, drain them once, and decode their output.
+
+    A consumer that failed or was cancelled maps to ``None`` so a broken reader
+    cannot mask the surrounding failure. Draining here exactly once keeps the
+    timeout and cancellation paths from reconciling the same tasks twice.
+    """
+    _cancel_pending_consumers(consumers)
+    stdout_result, stderr_result = await asyncio.gather(
+        *consumers, return_exceptions=True
+    )
+    stdout_text = None if isinstance(stdout_result, BaseException) else stdout_result
+    stderr_text = None if isinstance(stderr_result, BaseException) else stderr_result
+    return stdout_text, stderr_text
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -190,14 +209,22 @@ async def _run_subprocess_with_streams(
             process,
             execution.ctx,
             timeout=timeout,
-            consumers=consumers,
         )
     except TimeoutError as exc:
-        await _handle_stream_timeout(
-            exc, stdin_task=stdin_task, consumers=consumers, timeout=timeout
+        # The process has been terminated; cancel the stdin writer and drain the
+        # stream consumers exactly once here, then hand the decoded output to the
+        # timeout handler so it survives on the resulting TimeoutExpired.
+        await _cancel_stdin_writer(stdin_task)
+        stdout_text, stderr_text = await _drain_stream_consumers(consumers)
+        _handle_stream_timeout(
+            exc,
+            stdout_text=stdout_text,
+            stderr_text=stderr_text,
+            timeout=timeout,
         )
     except asyncio.CancelledError:
         await _cancel_stdin_writer(stdin_task)
+        await _drain_stream_consumers(consumers)
         raise
     if stdin_task is not None:
         try:
@@ -292,6 +319,7 @@ __all__ = [
     "_build_stream_config",
     "_cancel_pending_consumers",
     "_create_stream_callback",
+    "_drain_stream_consumers",
     "_execute_subprocess",
     "_run_subprocess_with_streams",
     "_spawn_stream_consumers",

--- a/cuprum/_subprocess_execution.py
+++ b/cuprum/_subprocess_execution.py
@@ -234,8 +234,7 @@ async def _run_subprocess_with_streams(
             # this await) must still reconcile the stdout/stderr consumers,
             # mirroring the timeout and cancellation paths above, so those tasks
             # are cancelled and drained before the error propagates.
-            _cancel_pending_consumers(consumers)
-            await asyncio.gather(*consumers, return_exceptions=True)
+            await _drain_stream_consumers(consumers)
             raise
     stdout_text, stderr_text = await asyncio.gather(*consumers)
     return exit_code, exited_at, stdout_text, stderr_text

--- a/cuprum/_subprocess_timeout.py
+++ b/cuprum/_subprocess_timeout.py
@@ -7,16 +7,16 @@ exit-event helpers shared by the timeout and normal completion paths.
 
 from __future__ import annotations
 
-import asyncio
 import dataclasses as dc
 import time
 import typing as typ
 
 from cuprum._pipeline_internals import _EventDetails
 from cuprum._subprocess_context import _sh_module
-from cuprum._subprocess_stdin import _cancel_stdin_writer
 
 if typ.TYPE_CHECKING:
+    import asyncio
+
     from cuprum._pipeline_internals import _StageObservation
     from cuprum._subprocess_execution import _SubprocessExecution
 
@@ -170,20 +170,19 @@ def _handle_subprocess_timeout(
     )
 
 
-async def _handle_stream_timeout(
+def _handle_stream_timeout(
     exc: TimeoutError,
     *,
-    stdin_task: asyncio.Task[None] | None,
-    consumers: tuple[asyncio.Task[str | None], asyncio.Task[str | None]],
+    stdout_text: str | None,
+    stderr_text: str | None,
     timeout: float | None,
 ) -> typ.NoReturn:
-    """Clean up stdin/stream tasks on timeout and raise _SubprocessTimeoutError."""
-    await _cancel_stdin_writer(stdin_task)
-    stdout_result, stderr_result = await asyncio.gather(
-        *consumers, return_exceptions=True
-    )
-    stdout_text = None if isinstance(stdout_result, BaseException) else stdout_result
-    stderr_text = None if isinstance(stderr_result, BaseException) else stderr_result
+    """Raise ``_SubprocessTimeoutError`` carrying pre-drained stream output.
+
+    The caller drains the stream consumers exactly once and passes the decoded
+    stdout/stderr here, so a timeout preserves whatever output was captured
+    before it fired.
+    """
     raise _SubprocessTimeoutError(
         _SubprocessTimeoutDetails(
             timeout=_require_timeout(timeout, exc),

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -96,6 +96,7 @@
       'cuprum/unittests/test_maturin_build.py',
       'cuprum/unittests/test_metrics_adapter.py',
       'cuprum/unittests/test_observe.py',
+      'cuprum/unittests/test_observe_stdin_early_close.py',
       'cuprum/unittests/test_performance_guidance_docs.py',
       'cuprum/unittests/test_pipeline.py',
       'cuprum/unittests/test_pipeline_output_options.py',

--- a/cuprum/unittests/test_observe.py
+++ b/cuprum/unittests/test_observe.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
-import tempfile
 import typing as typ
 from pathlib import Path
 
@@ -17,8 +16,7 @@ from cuprum._subprocess_stdin import _write_stdin
 from cuprum.catalogue import ProgramCatalogue, ProjectSettings
 from cuprum.context import ScopeConfig, current_context, scoped
 from cuprum.program import Program
-from cuprum.sh import ExecutionContext, RunOutputOptions, StdinInput
-from tests.helpers.stream_pipes import drain_blocking_payload_size
+from cuprum.sh import ExecutionContext, RunOutputOptions
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -309,129 +307,6 @@ def test_pipeline_observe_emits_stage_tags_and_env_overlay() -> None:
         if ev.phase == "stdout"
         and typ.cast("int", ev.tags["pipeline_stage_index"]) == 1
     ]
-
-
-# Child script for the early-close test. The child waits for the parent's
-# ``go`` marker (written only once the writer is confirmed wedged in drain),
-# closes its stdin, then writes a ``closed`` marker to signal it has done so.
-_STDIN_EARLY_CLOSE_CHILD = "\n".join((
-    "import os, sys, time",
-    'go = os.environ["CUPRUM_STDIN_CLOSE_GO"]',
-    'closed = os.environ["CUPRUM_STDIN_CLOSED"]',
-    "while not os.path.exists(go):",
-    "    time.sleep(0.005)",
-    "sys.stdin.close()",
-    'with open(closed, "w") as marker:',
-    '    marker.write("closed")',
-    'print("done")',
-))
-
-
-async def _wait_for_path(path: Path, *, timeout: float) -> None:
-    """Poll until ``path`` exists, bounding the wait with ``timeout``.
-
-    Awaiting a marker file that a child writes keeps the coordination
-    deterministic rather than guessing readiness with a fixed sleep.
-    """
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while not path.exists():
-        if loop.time() >= deadline:
-            msg = f"timed out waiting for marker {path}"
-            raise TimeoutError(msg)
-        await asyncio.sleep(0.005)
-
-
-def _patch_writer_wedge_signal(monkeypatch: pytest.MonkeyPatch) -> asyncio.Event:
-    """Patch the stdin writer to flag when it engages; return that flag.
-
-    The event is set synchronously before delegating to the real writer, which
-    then buffers the oversized payload and suspends on ``drain()`` before
-    control returns to the awaiting orchestrator, so the writer is genuinely
-    wedged once the flag is observed.
-    """
-    writer_wedged = asyncio.Event()
-
-    async def _coordinated_write_stdin(
-        process: asyncio.subprocess.Process,
-        stdin_data: bytes,
-        observation: _StageObservation,
-    ) -> None:
-        """Signal the writer is running, then write stdin as usual."""
-        writer_wedged.set()
-        await _write_stdin(process, stdin_data, observation)
-
-    monkeypatch.setattr(
-        "cuprum._subprocess_stdin._write_stdin", _coordinated_write_stdin
-    )
-    return writer_wedged
-
-
-def test_observe_emits_stdin_error_event_when_process_closes_stdin_early(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Emit a real ``stdin_error`` event when the subprocess closes stdin early.
-
-    The runner writes a payload larger than the OS pipe buffer, so the real
-    writer wedges in ``drain()``. Only once that writer is confirmed wedged is
-    the child released to close its stdin, driving the wedged ``drain()`` into a
-    broken-pipe (EPIPE) failure. The runner must surface that as an observable
-    ``stdin_error`` event rather than propagating or swallowing it silently.
-
-    A go/closed marker handshake replaces reliance on payload-size timing: the
-    child closes stdin only after the writer is confirmed wedged, and signals
-    back once it has, so the early-close path is coordinated deterministically.
-    """
-    builder, catalogue = _python_builder(project_name="observe-stdin-error")
-    writer_wedged = _patch_writer_wedge_signal(monkeypatch)
-    events: list[ExecEvent] = []
-
-    def hook(ev: ExecEvent) -> None:
-        """Record an emitted execution event."""
-        events.append(ev)
-
-    async def _orchestrate(go_path: Path, closed_path: Path) -> sh.CommandResult:
-        """Run the command, releasing the child only once the writer wedges."""
-        cmd = builder("-c", _STDIN_EARLY_CLOSE_CHILD)
-        context = ExecutionContext(
-            env={
-                "CUPRUM_STDIN_CLOSE_GO": str(go_path),
-                "CUPRUM_STDIN_CLOSED": str(closed_path),
-            },
-        )
-        with scoped(ScopeConfig(allowlist=catalogue.allowlist)), sh.observe(hook):
-            task = asyncio.create_task(
-                cmd.run(
-                    stdin=StdinInput(data=b"x" * drain_blocking_payload_size()),
-                    output=RunOutputOptions(capture=True),
-                    context=context,
-                )
-            )
-            # Release the child only after the writer is confirmed wedged in
-            # drain(): deterministic ordering rather than racing the close.
-            await asyncio.wait_for(writer_wedged.wait(), timeout=5.0)
-            go_path.write_text("go")
-            # Confirm the child's post-close signal before finishing, so the
-            # close is observed rather than merely inferred from timing.
-            await _wait_for_path(closed_path, timeout=10.0)
-            return await asyncio.wait_for(task, timeout=10.0)
-
-    with tempfile.TemporaryDirectory() as tmp:
-        result = asyncio.run(_orchestrate(Path(tmp) / "go", Path(tmp) / "closed"))
-
-    assert result.exit_code == 0, (
-        f"subprocess exited with non-zero code: {result.exit_code}"
-    )
-    stdin_error_events = [ev for ev in events if ev.phase == "stdin_error"]
-    assert stdin_error_events, (
-        "expected at least one stdin_error event when subprocess closes stdin early"
-    )
-    assert stdin_error_events[0].pid is not None, (
-        "expected pid to be present on first stdin_error event"
-    )
-    assert stdin_error_events[0].note is not None, (
-        "expected error note/detail to be present on first stdin_error event"
-    )
 
 
 @pytest.mark.parametrize(

--- a/cuprum/unittests/test_observe.py
+++ b/cuprum/unittests/test_observe.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import fcntl
 import logging
-import os
 import sys
+import tempfile
 import typing as typ
 from pathlib import Path
 
@@ -19,6 +18,7 @@ from cuprum.catalogue import ProgramCatalogue, ProjectSettings
 from cuprum.context import ScopeConfig, current_context, scoped
 from cuprum.program import Program
 from cuprum.sh import ExecutionContext, RunOutputOptions, StdinInput
+from tests.helpers.stream_pipes import drain_blocking_payload_size
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -311,54 +311,113 @@ def test_pipeline_observe_emits_stage_tags_and_env_overlay() -> None:
     ]
 
 
-def _drain_blocking_payload_size() -> int:
-    """Return a stdin payload size that reliably blocks the writer's drain().
+# Child script for the early-close test. The child waits for the parent's
+# ``go`` marker (written only once the writer is confirmed wedged in drain),
+# closes its stdin, then writes a ``closed`` marker to signal it has done so.
+_STDIN_EARLY_CLOSE_CHILD = "\n".join((
+    "import os, sys, time",
+    'go = os.environ["CUPRUM_STDIN_CLOSE_GO"]',
+    'closed = os.environ["CUPRUM_STDIN_CLOSED"]',
+    "while not os.path.exists(go):",
+    "    time.sleep(0.005)",
+    "sys.stdin.close()",
+    'with open(closed, "w") as marker:',
+    '    marker.write("closed")',
+    'print("done")',
+))
 
-    The early-close ``stdin_error`` only surfaces when ``drain()`` actually
-    blocks, which requires a payload larger than the OS pipe buffer plus the
-    asyncio transport write high-water mark. Probe the real pipe capacity so
-    the assertion does not rely on an assumed ~64 KiB buffer.
+
+async def _wait_for_path(path: Path, *, timeout: float) -> None:
+    """Poll until ``path`` exists, bounding the wait with ``timeout``.
+
+    Awaiting a marker file that a child writes keeps the coordination
+    deterministic rather than guessing readiness with a fixed sleep.
     """
-    read_fd, write_fd = os.pipe()
-    try:
-        pipe_capacity = fcntl.fcntl(write_fd, fcntl.F_GETPIPE_SZ)
-    finally:
-        os.close(read_fd)
-        os.close(write_fd)
-    # Exceed the probed pipe capacity and the default 64 KiB transport
-    # high-water mark with a full extra MiB of headroom.
-    return pipe_capacity + (1 << 20)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not path.exists():
+        if loop.time() >= deadline:
+            msg = f"timed out waiting for marker {path}"
+            raise TimeoutError(msg)
+        await asyncio.sleep(0.005)
 
 
-def test_observe_emits_stdin_error_event_when_process_closes_stdin_early() -> None:
+def _patch_writer_wedge_signal(monkeypatch: pytest.MonkeyPatch) -> asyncio.Event:
+    """Patch the stdin writer to flag when it engages; return that flag.
+
+    The event is set synchronously before delegating to the real writer, which
+    then buffers the oversized payload and suspends on ``drain()`` before
+    control returns to the awaiting orchestrator, so the writer is genuinely
+    wedged once the flag is observed.
+    """
+    writer_wedged = asyncio.Event()
+
+    async def _coordinated_write_stdin(
+        process: asyncio.subprocess.Process,
+        stdin_data: bytes,
+        observation: _StageObservation,
+    ) -> None:
+        """Signal the writer is running, then write stdin as usual."""
+        writer_wedged.set()
+        await _write_stdin(process, stdin_data, observation)
+
+    monkeypatch.setattr(
+        "cuprum._subprocess_stdin._write_stdin", _coordinated_write_stdin
+    )
+    return writer_wedged
+
+
+def test_observe_emits_stdin_error_event_when_process_closes_stdin_early(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Emit a real ``stdin_error`` event when the subprocess closes stdin early.
 
-    The child closes its stdin immediately, so writing a payload larger than
-    the OS pipe buffer drives the real writer's ``drain()`` into a broken-pipe
-    (EPIPE) failure. The runner must surface that as an observable
+    The runner writes a payload larger than the OS pipe buffer, so the real
+    writer wedges in ``drain()``. Only once that writer is confirmed wedged is
+    the child released to close its stdin, driving the wedged ``drain()`` into a
+    broken-pipe (EPIPE) failure. The runner must surface that as an observable
     ``stdin_error`` event rather than propagating or swallowing it silently.
+
+    A go/closed marker handshake replaces reliance on payload-size timing: the
+    child closes stdin only after the writer is confirmed wedged, and signals
+    back once it has, so the early-close path is coordinated deterministically.
     """
     builder, catalogue = _python_builder(project_name="observe-stdin-error")
-    cmd = builder(
-        "-c",
-        "import sys; sys.stdin.close(); print('done')",
-    )
-
+    writer_wedged = _patch_writer_wedge_signal(monkeypatch)
     events: list[ExecEvent] = []
 
     def hook(ev: ExecEvent) -> None:
         """Record an emitted execution event."""
         events.append(ev)
 
-    # Size the payload from the real pipe capacity so the writer is guaranteed
-    # to block in drain() until the child closes the read end, forcing a
-    # deterministic EPIPE rather than assuming a ~64 KiB buffer.
-    payload = b"x" * _drain_blocking_payload_size()
-    with scoped(ScopeConfig(allowlist=catalogue.allowlist)), sh.observe(hook):
-        result = cmd.run_sync(
-            stdin=StdinInput(data=payload),
-            output=RunOutputOptions(capture=True),
+    async def _orchestrate(go_path: Path, closed_path: Path) -> sh.CommandResult:
+        """Run the command, releasing the child only once the writer wedges."""
+        cmd = builder("-c", _STDIN_EARLY_CLOSE_CHILD)
+        context = ExecutionContext(
+            env={
+                "CUPRUM_STDIN_CLOSE_GO": str(go_path),
+                "CUPRUM_STDIN_CLOSED": str(closed_path),
+            },
         )
+        with scoped(ScopeConfig(allowlist=catalogue.allowlist)), sh.observe(hook):
+            task = asyncio.create_task(
+                cmd.run(
+                    stdin=StdinInput(data=b"x" * drain_blocking_payload_size()),
+                    output=RunOutputOptions(capture=True),
+                    context=context,
+                )
+            )
+            # Release the child only after the writer is confirmed wedged in
+            # drain(): deterministic ordering rather than racing the close.
+            await asyncio.wait_for(writer_wedged.wait(), timeout=5.0)
+            go_path.write_text("go")
+            # Confirm the child's post-close signal before finishing, so the
+            # close is observed rather than merely inferred from timing.
+            await _wait_for_path(closed_path, timeout=10.0)
+            return await asyncio.wait_for(task, timeout=10.0)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        result = asyncio.run(_orchestrate(Path(tmp) / "go", Path(tmp) / "closed"))
 
     assert result.exit_code == 0, (
         f"subprocess exited with non-zero code: {result.exit_code}"
@@ -367,11 +426,10 @@ def test_observe_emits_stdin_error_event_when_process_closes_stdin_early() -> No
     assert stdin_error_events, (
         "expected at least one stdin_error event when subprocess closes stdin early"
     )
-    first = stdin_error_events[0]
-    assert first.pid is not None, (
+    assert stdin_error_events[0].pid is not None, (
         "expected pid to be present on first stdin_error event"
     )
-    assert first.note is not None, (
+    assert stdin_error_events[0].note is not None, (
         "expected error note/detail to be present on first stdin_error event"
     )
 

--- a/cuprum/unittests/test_observe_stdin_early_close.py
+++ b/cuprum/unittests/test_observe_stdin_early_close.py
@@ -1,0 +1,157 @@
+"""Deterministic early-close coordination test for stdin observe events.
+
+Extracted from ``test_observe`` to keep that module within the repository's
+file-size budget. This file owns the go/closed marker handshake that drives a
+subprocess into a broken-pipe (EPIPE) failure and asserts the runner surfaces it
+as an observable ``stdin_error`` event.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import typing as typ
+from pathlib import Path
+
+from cuprum import sh
+from cuprum._subprocess_stdin import _write_stdin
+from cuprum.context import ScopeConfig, scoped
+from cuprum.sh import ExecutionContext, RunOutputOptions, StdinInput
+from tests.helpers.catalogue import python_catalogue
+from tests.helpers.stream_pipes import drain_blocking_payload_size
+
+if typ.TYPE_CHECKING:
+    import pytest
+
+    from cuprum._pipeline_types import _StageObservation
+    from cuprum.events import ExecEvent
+
+
+# Child script for the early-close test. The child waits — with a finite
+# deadline — for the parent's ``go`` marker (written only once the writer is
+# confirmed wedged in drain), closes its stdin, then writes a ``closed`` marker
+# to signal it has done so. If the marker never arrives (for example, the parent
+# aborts before writing it) the child exits non-zero rather than spinning
+# forever and orphaning the process.
+_STDIN_EARLY_CLOSE_CHILD = "\n".join((
+    "import os, sys, time",
+    'go = os.environ["CUPRUM_STDIN_CLOSE_GO"]',
+    'closed = os.environ["CUPRUM_STDIN_CLOSED"]',
+    "deadline = time.monotonic() + 15.0",
+    "while not os.path.exists(go):",
+    "    if time.monotonic() >= deadline:",
+    '        sys.exit("cuprum early-close child timed out waiting for go marker")',
+    "    time.sleep(0.005)",
+    "sys.stdin.close()",
+    'with open(closed, "w") as marker:',
+    '    marker.write("closed")',
+    'print("done")',
+))
+
+
+async def _wait_for_path(path: Path, *, timeout: float) -> None:
+    """Poll until ``path`` exists, bounding the wait with ``timeout``.
+
+    Awaiting a marker file that a child writes keeps the coordination
+    deterministic rather than guessing readiness with a fixed sleep.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not path.exists():
+        if loop.time() >= deadline:
+            msg = f"timed out waiting for marker {path}"
+            raise TimeoutError(msg)
+        await asyncio.sleep(0.005)
+
+
+def _patch_writer_wedge_signal(monkeypatch: pytest.MonkeyPatch) -> asyncio.Event:
+    """Patch the stdin writer to flag when it engages; return that flag.
+
+    The event is set synchronously before delegating to the real writer, which
+    then buffers the oversized payload and suspends on ``drain()`` before
+    control returns to the awaiting orchestrator, so the writer is genuinely
+    wedged once the flag is observed.
+    """
+    writer_wedged = asyncio.Event()
+
+    async def _coordinated_write_stdin(
+        process: asyncio.subprocess.Process,
+        stdin_data: bytes,
+        observation: _StageObservation,
+    ) -> None:
+        """Signal the writer is running, then write stdin as usual."""
+        writer_wedged.set()
+        await _write_stdin(process, stdin_data, observation)
+
+    monkeypatch.setattr(
+        "cuprum._subprocess_stdin._write_stdin", _coordinated_write_stdin
+    )
+    return writer_wedged
+
+
+def test_observe_emits_stdin_error_event_when_process_closes_stdin_early(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Emit a real ``stdin_error`` event when the subprocess closes stdin early.
+
+    The runner writes a payload larger than the OS pipe buffer, so the real
+    writer wedges in ``drain()``. Only once that writer is confirmed wedged is
+    the child released to close its stdin, driving the wedged ``drain()`` into a
+    broken-pipe (EPIPE) failure. The runner must surface that as an observable
+    ``stdin_error`` event rather than propagating or swallowing it silently.
+
+    A go/closed marker handshake replaces reliance on payload-size timing: the
+    child closes stdin only after the writer is confirmed wedged, and signals
+    back once it has, so the early-close path is coordinated deterministically.
+    """
+    catalogue, program = python_catalogue()
+    builder = sh.make(program, catalogue=catalogue)
+    writer_wedged = _patch_writer_wedge_signal(monkeypatch)
+    events: list[ExecEvent] = []
+
+    def hook(ev: ExecEvent) -> None:
+        """Record an emitted execution event."""
+        events.append(ev)
+
+    async def _orchestrate(go_path: Path, closed_path: Path) -> sh.CommandResult:
+        """Run the command, releasing the child only once the writer wedges."""
+        cmd = builder("-c", _STDIN_EARLY_CLOSE_CHILD)
+        context = ExecutionContext(
+            env={
+                "CUPRUM_STDIN_CLOSE_GO": str(go_path),
+                "CUPRUM_STDIN_CLOSED": str(closed_path),
+            },
+        )
+        with scoped(ScopeConfig(allowlist=catalogue.allowlist)), sh.observe(hook):
+            task = asyncio.create_task(
+                cmd.run(
+                    stdin=StdinInput(data=b"x" * drain_blocking_payload_size()),
+                    output=RunOutputOptions(capture=True),
+                    context=context,
+                )
+            )
+            # Release the child only after the writer is confirmed wedged in
+            # drain(): deterministic ordering rather than racing the close.
+            await asyncio.wait_for(writer_wedged.wait(), timeout=5.0)
+            go_path.write_text("go")
+            # Confirm the child's post-close signal before finishing, so the
+            # close is observed rather than merely inferred from timing.
+            await _wait_for_path(closed_path, timeout=10.0)
+            return await asyncio.wait_for(task, timeout=10.0)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        result = asyncio.run(_orchestrate(Path(tmp) / "go", Path(tmp) / "closed"))
+
+    assert result.exit_code == 0, (
+        f"subprocess exited with non-zero code: {result.exit_code}"
+    )
+    stdin_error_events = [ev for ev in events if ev.phase == "stdin_error"]
+    assert stdin_error_events, (
+        "expected at least one stdin_error event when subprocess closes stdin early"
+    )
+    assert stdin_error_events[0].pid is not None, (
+        "expected pid to be present on first stdin_error event"
+    )
+    assert stdin_error_events[0].note is not None, (
+        "expected error note/detail to be present on first stdin_error event"
+    )

--- a/cuprum/unittests/test_observe_stdin_early_close.py
+++ b/cuprum/unittests/test_observe_stdin_early_close.py
@@ -35,16 +35,16 @@ if typ.TYPE_CHECKING:
 # forever and orphaning the process.
 _STDIN_EARLY_CLOSE_CHILD = "\n".join((
     "import os, sys, time",
-    'go = os.environ["CUPRUM_STDIN_CLOSE_GO"]',
-    'closed = os.environ["CUPRUM_STDIN_CLOSED"]',
+    "from pathlib import Path",
+    'go = Path(os.environ["CUPRUM_STDIN_CLOSE_GO"])',
+    'closed = Path(os.environ["CUPRUM_STDIN_CLOSED"])',
     "deadline = time.monotonic() + 15.0",
-    "while not os.path.exists(go):",
+    "while not go.exists():",
     "    if time.monotonic() >= deadline:",
     '        sys.exit("cuprum early-close child timed out waiting for go marker")',
     "    time.sleep(0.005)",
     "sys.stdin.close()",
-    'with open(closed, "w") as marker:',
-    '    marker.write("closed")',
+    'closed.write_text("closed")',
     'print("done")',
 ))
 

--- a/cuprum/unittests/test_observe_stdin_early_close.py
+++ b/cuprum/unittests/test_observe_stdin_early_close.py
@@ -9,9 +9,7 @@ as an observable ``stdin_error`` event.
 from __future__ import annotations
 
 import asyncio
-import tempfile
 import typing as typ
-from pathlib import Path
 
 from cuprum import sh
 from cuprum._subprocess_stdin import _write_stdin
@@ -21,6 +19,8 @@ from tests.helpers.catalogue import python_catalogue
 from tests.helpers.stream_pipes import drain_blocking_payload_size
 
 if typ.TYPE_CHECKING:
+    from pathlib import Path
+
     import pytest
 
     from cuprum._pipeline_types import _StageObservation
@@ -91,6 +91,7 @@ def _patch_writer_wedge_signal(monkeypatch: pytest.MonkeyPatch) -> asyncio.Event
 
 def test_observe_emits_stdin_error_event_when_process_closes_stdin_early(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Emit a real ``stdin_error`` event when the subprocess closes stdin early.
 
@@ -139,8 +140,7 @@ def test_observe_emits_stdin_error_event_when_process_closes_stdin_early(
             await _wait_for_path(closed_path, timeout=10.0)
             return await asyncio.wait_for(task, timeout=10.0)
 
-    with tempfile.TemporaryDirectory() as tmp:
-        result = asyncio.run(_orchestrate(Path(tmp) / "go", Path(tmp) / "closed"))
+    result = asyncio.run(_orchestrate(tmp_path / "go", tmp_path / "closed"))
 
     assert result.exit_code == 0, (
         f"subprocess exited with non-zero code: {result.exit_code}"

--- a/cuprum/unittests/test_safe_cmd_context.py
+++ b/cuprum/unittests/test_safe_cmd_context.py
@@ -20,6 +20,7 @@ from tests.helpers.catalogue import python_builder as build_python_builder
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
 
+    from cuprum.events import ExecEvent
     from cuprum.sh import CommandResult, SafeCmd
     from tests.helpers.execution import ExecuteFn, _RunKwargs
 
@@ -206,11 +207,21 @@ def test_run_does_not_invoke_after_hooks_on_cancellation(
     command = python_builder("-c", "import time; time.sleep(10)")
 
     async def orchestrate() -> None:
-        """Start the command under a scope, then cancel it."""
-        with scoped(
-            ScopeConfig(
-                allowlist=frozenset([command.program]), after_hooks=(after_hook,)
-            )
+        """Start the command under a scope, then cancel it once it starts."""
+        started = asyncio.Event()
+
+        def on_event(ev: ExecEvent) -> None:
+            """Signal once the subprocess has actually started."""
+            if ev.phase == "start":
+                started.set()
+
+        with (
+            scoped(
+                ScopeConfig(
+                    allowlist=frozenset([command.program]), after_hooks=(after_hook,)
+                )
+            ),
+            sh.observe(on_event),
         ):
             task = asyncio.create_task(
                 command.run(
@@ -218,7 +229,9 @@ def test_run_does_not_invoke_after_hooks_on_cancellation(
                     context=ExecutionContext(cancel_grace=0.1),
                 ),
             )
-            await asyncio.sleep(0.1)  # Let the process start
+            # Cancel only after the subprocess has actually started: a
+            # deterministic readiness signal rather than a fixed sleep.
+            await asyncio.wait_for(started.wait(), timeout=2.0)
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task

--- a/cuprum/unittests/test_safe_cmd_stdin.py
+++ b/cuprum/unittests/test_safe_cmd_stdin.py
@@ -22,6 +22,7 @@ from cuprum import ECHO, ForbiddenProgramError, ScopeConfig, TimeoutExpired, sco
 from cuprum._subprocess_stdin import _write_stdin as _real_write_stdin
 from cuprum.sh import ExecutionContext, RunOutputOptions, StdinInput
 from tests.helpers.catalogue import python_builder as build_python_builder
+from tests.helpers.stream_pipes import drain_blocking_payload_size
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -271,7 +272,9 @@ def test_direct_timeout_with_blocked_stdin_writer_does_not_hang(
     """
     _, execute = execution_strategy
     command = python_builder("-c", "import time; time.sleep(3600)")
-    payload = b"x" * (1024 * 1024)  # 1 MiB dwarfs the ~64 KiB pipe buffer
+    # Probe the real pipe capacity so the writer is guaranteed to stall in
+    # drain() rather than assuming a ~64 KiB buffer.
+    payload = b"x" * drain_blocking_payload_size()
     started = time.perf_counter()
     with pytest.raises(TimeoutExpired):
         execute(
@@ -285,6 +288,38 @@ def test_direct_timeout_with_blocked_stdin_writer_does_not_hang(
     elapsed = time.perf_counter() - started
     assert elapsed < 10.0, (
         "direct-mode timeout with a blocked stdin writer must not hang; "
+        f"took {elapsed:.2f}s"
+    )
+
+
+def test_capture_timeout_with_blocked_stdin_writer_does_not_hang(
+    python_builder: cabc.Callable[..., SafeCmd],
+    execution_strategy: tuple[str, ExecuteFn],
+) -> None:
+    """Capture-mode timeout cancels a stdin writer wedged on an unread pipe.
+
+    The child never reads its stdin, so an oversized payload stalls the
+    writer's ``drain()``. Unlike the direct-mode case this drives the stream
+    path: on timeout the runner must cancel that writer while draining the
+    stdout/stderr consumers, raising ``TimeoutExpired`` promptly instead of
+    blocking on the stalled drain (regression for #117 on the capture path).
+    """
+    _, execute = execution_strategy
+    command = python_builder("-c", "import time; time.sleep(3600)")
+    payload = b"x" * drain_blocking_payload_size()
+    started = time.perf_counter()
+    with pytest.raises(TimeoutExpired):
+        execute(
+            command,
+            {
+                "stdin": StdinInput(data=payload),
+                "timeout": 0.2,
+                "output": RunOutputOptions(capture=True),
+            },
+        )
+    elapsed = time.perf_counter() - started
+    assert elapsed < 10.0, (
+        "capture-mode timeout with a blocked stdin writer must not hang; "
         f"took {elapsed:.2f}s"
     )
 
@@ -304,7 +339,9 @@ def test_stdin_input_cancellation_cleans_up_task(
     async def _orchestrate() -> None:
         """Start a blocked-writer command and cancel it once it is wedged."""
         command = python_builder("-c", "import time; time.sleep(30)")
-        payload = b"x" * (1024 * 1024)  # 1 MiB wedges the writer's drain()
+        # Probe the real pipe capacity so the writer wedges in drain() rather
+        # than assuming a ~64 KiB buffer.
+        payload = b"x" * drain_blocking_payload_size()
         writer_wedged = asyncio.Event()
 
         async def _tracked_write_stdin(

--- a/cuprum/unittests/test_safe_cmd_stdin.py
+++ b/cuprum/unittests/test_safe_cmd_stdin.py
@@ -282,7 +282,7 @@ def test_timeout_with_blocked_stdin_writer_does_not_hang(
     drains the stdout/stderr consumers) keeps this a regression for #117 across
     both branches.
     """
-    _, execute = execution_strategy
+    label, execute = execution_strategy
     command = python_builder("-c", "import time; time.sleep(3600)")
     # Probe the real pipe capacity so the writer is guaranteed to stall in
     # drain() rather than assuming a ~64 KiB buffer.
@@ -299,8 +299,8 @@ def test_timeout_with_blocked_stdin_writer_does_not_hang(
         )
     elapsed = time.perf_counter() - started
     assert elapsed < 10.0, (
-        f"{mode}-mode timeout with a blocked stdin writer must not hang; "
-        f"took {elapsed:.2f}s"
+        f"{mode}-mode timeout with a blocked stdin writer must not hang under "
+        f"{label} execution; took {elapsed:.2f}s"
     )
 
 

--- a/cuprum/unittests/test_safe_cmd_stdin.py
+++ b/cuprum/unittests/test_safe_cmd_stdin.py
@@ -259,16 +259,28 @@ def test_stdin_input_with_timeout_escalation(
         )
 
 
-def test_direct_timeout_with_blocked_stdin_writer_does_not_hang(
+@pytest.mark.parametrize(
+    ("capture", "mode"),
+    [
+        pytest.param(False, "direct", id="direct"),
+        pytest.param(True, "capture", id="capture"),
+    ],
+)
+def test_timeout_with_blocked_stdin_writer_does_not_hang(
+    capture: bool,  # noqa: FBT001 - pytest parametrises this value.
+    mode: str,
     python_builder: cabc.Callable[..., SafeCmd],
     execution_strategy: tuple[str, ExecuteFn],
 ) -> None:
-    """Direct-mode timeout cancels a stdin writer wedged on an unread pipe.
+    """Timeout cancels a stdin writer wedged on an unread pipe, on both paths.
 
     The child never reads its stdin, so a payload larger than the OS pipe
     buffer stalls the writer's ``drain()``. On timeout the runner must cancel
     that writer rather than wait on it, raising ``TimeoutExpired`` promptly
-    instead of blocking on the stalled drain (regression for #117).
+    instead of blocking on the stalled drain. Exercising both the direct output
+    path (``capture=False``) and the capture path (``capture=True``, which also
+    drains the stdout/stderr consumers) keeps this a regression for #117 across
+    both branches.
     """
     _, execute = execution_strategy
     command = python_builder("-c", "import time; time.sleep(3600)")
@@ -282,44 +294,12 @@ def test_direct_timeout_with_blocked_stdin_writer_does_not_hang(
             {
                 "stdin": StdinInput(data=payload),
                 "timeout": 0.2,
-                "output": RunOutputOptions(capture=False),
+                "output": RunOutputOptions(capture=capture),
             },
         )
     elapsed = time.perf_counter() - started
     assert elapsed < 10.0, (
-        "direct-mode timeout with a blocked stdin writer must not hang; "
-        f"took {elapsed:.2f}s"
-    )
-
-
-def test_capture_timeout_with_blocked_stdin_writer_does_not_hang(
-    python_builder: cabc.Callable[..., SafeCmd],
-    execution_strategy: tuple[str, ExecuteFn],
-) -> None:
-    """Capture-mode timeout cancels a stdin writer wedged on an unread pipe.
-
-    The child never reads its stdin, so an oversized payload stalls the
-    writer's ``drain()``. Unlike the direct-mode case this drives the stream
-    path: on timeout the runner must cancel that writer while draining the
-    stdout/stderr consumers, raising ``TimeoutExpired`` promptly instead of
-    blocking on the stalled drain (regression for #117 on the capture path).
-    """
-    _, execute = execution_strategy
-    command = python_builder("-c", "import time; time.sleep(3600)")
-    payload = b"x" * drain_blocking_payload_size()
-    started = time.perf_counter()
-    with pytest.raises(TimeoutExpired):
-        execute(
-            command,
-            {
-                "stdin": StdinInput(data=payload),
-                "timeout": 0.2,
-                "output": RunOutputOptions(capture=True),
-            },
-        )
-    elapsed = time.perf_counter() - started
-    assert elapsed < 10.0, (
-        "capture-mode timeout with a blocked stdin writer must not hang; "
+        f"{mode}-mode timeout with a blocked stdin writer must not hang; "
         f"took {elapsed:.2f}s"
     )
 

--- a/cuprum/unittests/test_subprocess_timeout.py
+++ b/cuprum/unittests/test_subprocess_timeout.py
@@ -10,9 +10,10 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from cuprum._subprocess_execution import _wait_for_exit_code
+from cuprum._subprocess_execution import _drain_stream_consumers, _wait_for_exit_code
 from cuprum._subprocess_timeout import (
     _handle_stream_timeout,
+    _SubprocessInvariantError,
     _SubprocessTimeoutError,
 )
 from cuprum.sh import ExecutionContext
@@ -25,136 +26,93 @@ _CONSUMER_OUTCOME = st.one_of(
 
 
 @dc.dataclass(frozen=True, slots=True)
-class _StreamTimeoutCase:
-    """Generated scheduling and outcome configuration for timeout cleanup."""
+class _DrainCase:
+    """Generated scheduling and outcome configuration for a consumer drain."""
 
     stdout: tuple[str, str | None]
     stdout_delay: int
     stderr: tuple[str, str | None]
     stderr_delay: int
-    stdin_delay: int
-    timeout: float
 
 
-_STREAM_TIMEOUT_CASE = st.builds(
-    _StreamTimeoutCase,
+_DRAIN_CASE = st.builds(
+    _DrainCase,
     stdout=_CONSUMER_OUTCOME,
     stdout_delay=st.integers(min_value=0, max_value=3),
     stderr=_CONSUMER_OUTCOME,
     stderr_delay=st.integers(min_value=0, max_value=3),
-    stdin_delay=st.integers(min_value=0, max_value=3),
-    timeout=st.floats(min_value=0.001, max_value=3600.0, allow_nan=False),
 )
 
 
-def test_stream_timeout_preserves_timeout_when_consumer_fails() -> None:
-    """A stream-consumer failure cannot mask a timeout during cleanup."""
-
-    async def block_stdin() -> None:
-        """Remain pending until timeout cleanup cancels the task."""
-        await asyncio.Event().wait()
-
-    async def fail_consumer() -> str | None:
-        """Yield once, then raise the stream-consumer failure."""
+async def _consumer(outcome: tuple[str, str | None], delay: int) -> str | None:
+    """Yield ``delay`` times, then either return text or fail."""
+    for _ in range(delay):
         await asyncio.sleep(0)
+    kind, value = outcome
+    if kind == "raise":
         msg = "consumer failed"
         raise ValueError(msg)
-
-    async def handle_timeout() -> None:
-        """Run the timeout handler and assert its cleanup outcome."""
-        stdin_task = asyncio.create_task(block_stdin())
-        consumers = (
-            asyncio.create_task(fail_consumer()),
-            asyncio.create_task(asyncio.sleep(0, result="stderr")),
-        )
-
-        with pytest.raises(_SubprocessTimeoutError) as exc_info:
-            await _handle_stream_timeout(
-                TimeoutError(),
-                stdin_task=stdin_task,
-                consumers=consumers,
-                timeout=1.0,
-            )
-
-        assert stdin_task.cancelled(), (
-            "timeout cleanup must cancel the pending stdin writer, "
-            f"but stdin_task.done()={stdin_task.done()} and it was not cancelled"
-        )
-        assert exc_info.value.stdout is None, (
-            "a failed stdout consumer must surface as None, "
-            f"not {exc_info.value.stdout!r}"
-        )
-        assert exc_info.value.stderr == "stderr", (
-            "a successful stderr consumer must be preserved through timeout "
-            f"cleanup, but got {exc_info.value.stderr!r}"
-        )
-
-    asyncio.run(handle_timeout())
+    return value
 
 
-@settings(max_examples=75, deadline=None, derandomize=True)
-@given(case=_STREAM_TIMEOUT_CASE)
-def test_handle_stream_timeout_upholds_invariants_across_orderings(
-    case: _StreamTimeoutCase,
-) -> None:
-    """_handle_stream_timeout keeps its cleanup contract for any task ordering.
+def test_drain_stream_consumers_cancels_pending_and_decodes() -> None:
+    """Draining cancels a still-pending consumer and preserves a completed one."""
 
-    Across arbitrary interleavings of consumer completion, consumer failure,
-    and a stdin writer that blocks until cancelled, the handler must always:
-
-    - raise ``_SubprocessTimeoutError`` carrying the configured timeout,
-    - cancel and drain the pending stdin writer, and
-    - surface each successful consumer's text while mapping a failed consumer
-      to ``None``.
-    """
-
-    async def consumer(outcome: tuple[str, str | None], delay: int) -> str | None:
-        """Yield ``delay`` times, then either return text or fail."""
-        for _ in range(delay):
-            await asyncio.sleep(0)
-        kind, value = outcome
-        if kind == "raise":
-            msg = "consumer failed"
-            raise ValueError(msg)
-        return value
-
-    async def block_stdin() -> None:
-        """Yield ``case.stdin_delay`` times, then block until cancelled."""
-        for _ in range(case.stdin_delay):
-            await asyncio.sleep(0)
+    async def block() -> str | None:
+        """Remain pending until the drain cancels this task."""
         await asyncio.Event().wait()
 
     async def run_case() -> None:
-        """Drive the handler once and assert its cleanup invariants."""
-        stdin_task = asyncio.create_task(block_stdin())
+        """Drain a still-pending consumer alongside an already-completed one."""
+        pending = asyncio.create_task(block())
+        completed = asyncio.create_task(asyncio.sleep(0, result="stderr"))
+        await completed  # the completed consumer must be genuinely done
+
+        stdout_text, stderr_text = await _drain_stream_consumers((pending, completed))
+
+        assert pending.cancelled(), (
+            "a consumer left pending at drain must be cancelled, "
+            f"but pending.done()={pending.done()}"
+        )
+        assert stdout_text is None, (
+            f"a cancelled consumer must decode to None, not {stdout_text!r}"
+        )
+        assert stderr_text == "stderr", (
+            f"a completed consumer's text must be preserved, got {stderr_text!r}"
+        )
+
+    asyncio.run(run_case())
+
+
+@settings(max_examples=75, deadline=None, derandomize=True)
+@given(case=_DRAIN_CASE)
+def test_drain_stream_consumers_decodes_across_orderings(case: _DrainCase) -> None:
+    """_drain_stream_consumers drains once and decodes each consumer outcome.
+
+    Across arbitrary interleavings of consumer completion and failure, the
+    helper must drain every consumer and surface each successful consumer's
+    text while mapping a failed consumer to ``None``.
+    """
+
+    async def run_case() -> None:
+        """Drive the drain once and assert its decoding invariants."""
         consumers = (
-            asyncio.create_task(consumer(case.stdout, case.stdout_delay)),
-            asyncio.create_task(consumer(case.stderr, case.stderr_delay)),
+            asyncio.create_task(_consumer(case.stdout, case.stdout_delay)),
+            asyncio.create_task(_consumer(case.stderr, case.stderr_delay)),
         )
+        # Let every consumer reach its outcome before draining, so the decode
+        # path (text preserved, failure -> None) is exercised rather than the
+        # cancellation of a reader that never got to run.
+        await asyncio.gather(*consumers, return_exceptions=True)
 
-        with pytest.raises(_SubprocessTimeoutError) as exc_info:
-            await _handle_stream_timeout(
-                TimeoutError(),
-                stdin_task=stdin_task,
-                consumers=consumers,
-                timeout=case.timeout,
-            )
+        stdout_text, stderr_text = await _drain_stream_consumers(consumers)
 
-        exc = exc_info.value
-        assert exc.timeout == case.timeout, (
-            f"timeout must survive cleanup unchanged: got {exc.timeout} "
-            f"for configured {case.timeout}"
-        )
-        assert stdin_task.cancelled(), (
-            "the blocked stdin writer must be cancelled during cleanup, "
-            f"but stdin_task.done()={stdin_task.done()}"
-        )
         assert all(task.done() for task in consumers), (
-            "every consumer task must be drained before the handler returns"
+            "every consumer task must be drained before the helper returns"
         )
         for label, captured, outcome in (
-            ("stdout", exc.stdout, case.stdout),
-            ("stderr", exc.stderr, case.stderr),
+            ("stdout", stdout_text, case.stdout),
+            ("stderr", stderr_text, case.stderr),
         ):
             kind, value = outcome
             expected = None if kind == "raise" else value
@@ -164,6 +122,39 @@ def test_handle_stream_timeout_upholds_invariants_across_orderings(
             )
 
     asyncio.run(run_case())
+
+
+def test_handle_stream_timeout_preserves_timeout_and_output() -> None:
+    """The handler raises with the configured timeout and pre-drained output."""
+    with pytest.raises(_SubprocessTimeoutError) as exc_info:
+        _handle_stream_timeout(
+            TimeoutError(),
+            stdout_text="captured-out",
+            stderr_text=None,
+            timeout=1.5,
+        )
+
+    assert exc_info.value.timeout == 1.5, (
+        f"the configured timeout must survive unchanged: got {exc_info.value.timeout}"
+    )
+    assert exc_info.value.stdout == "captured-out", (
+        "pre-drained stdout must be preserved on the timeout error, "
+        f"got {exc_info.value.stdout!r}"
+    )
+    assert exc_info.value.stderr is None, (
+        f"pre-drained stderr must be preserved, got {exc_info.value.stderr!r}"
+    )
+
+
+def test_handle_stream_timeout_requires_configured_timeout() -> None:
+    """A timeout handler reached without a configured timeout fails loudly."""
+    with pytest.raises(_SubprocessInvariantError):
+        _handle_stream_timeout(
+            TimeoutError(),
+            stdout_text=None,
+            stderr_text=None,
+            timeout=None,
+        )
 
 
 class _TimeoutWaitProcess:
@@ -199,23 +190,17 @@ class _TimeoutWaitProcess:
         self._exited.set()
 
 
-def test_wait_for_exit_code_cancels_pending_consumers_on_timeout() -> None:
-    """A timed-out wait cancels and drains consumers still pending after kill.
+def test_wait_for_exit_code_terminates_process_on_timeout() -> None:
+    """A timed-out wait terminates the process before propagating TimeoutError.
 
-    The stream path hands its stdout/stderr tasks to ``_wait_for_exit_code`` as
-    ``consumers``. When ``process.wait()`` times out and a consumer remains
-    blocked after termination, cleanup must cancel and drain it so timeout
-    handling cannot hang, while the original ``TimeoutError`` still propagates.
+    ``_wait_for_exit_code`` waits only for the exit code now; on expiry it must
+    still tear the process down so the caller's stream consumers can reach EOF,
+    while the original ``TimeoutError`` propagates unchanged.
     """
-
-    async def blocking_consumer() -> str | None:
-        """Block until timeout cleanup cancels this task."""
-        await asyncio.Event().wait()
 
     async def run_case() -> None:
         """Drive ``_wait_for_exit_code`` through its timeout-cleanup branch."""
         process = _TimeoutWaitProcess()
-        consumer = asyncio.create_task(blocking_consumer())
         ctx = ExecutionContext(cancel_grace=0.1)
 
         with pytest.raises(TimeoutError):
@@ -223,44 +208,34 @@ def test_wait_for_exit_code_cancels_pending_consumers_on_timeout() -> None:
                 typ.cast("asyncio.subprocess.Process", process),
                 ctx,
                 timeout=0.05,
-                consumers=(consumer,),
             )
 
-        assert consumer.cancelled(), (
-            "a consumer left pending at timeout must be cancelled during "
-            f"cleanup, but consumer.done()={consumer.done()}"
-        )
-        assert consumer.done(), (
-            "the cancelled consumer must be drained before the timeout propagates"
+        assert process.returncode == -15, (
+            "the process must be terminated during timeout cleanup, "
+            f"but returncode={process.returncode}"
         )
 
     asyncio.run(run_case())
 
 
-def test_wait_for_exit_code_cancels_pending_consumers_on_cancellation() -> None:
-    """Cancelling the waiter cancels and drains consumers still pending.
+def test_wait_for_exit_code_terminates_process_on_cancellation() -> None:
+    """Cancelling the waiter terminates the process before CancelledError propagates.
 
     This covers the distinct ``asyncio.CancelledError`` cleanup path (not the
     timeout path): when the task running ``_wait_for_exit_code`` is cancelled
-    while a consumer is still blocked, cleanup must cancel and drain that
-    consumer and let the ``CancelledError`` propagate.
+    mid-wait, cleanup must terminate the process and let ``CancelledError``
+    propagate.
     """
-
-    async def blocking_consumer() -> str | None:
-        """Block until cancellation cleanup cancels this task."""
-        await asyncio.Event().wait()
 
     async def run_case() -> None:
         """Cancel ``_wait_for_exit_code`` mid-wait and assert its cleanup."""
         process = _TimeoutWaitProcess()
-        consumer = asyncio.create_task(blocking_consumer())
         ctx = ExecutionContext(cancel_grace=0.1)
 
         task = asyncio.create_task(
             _wait_for_exit_code(
                 typ.cast("asyncio.subprocess.Process", process),
                 ctx,
-                consumers=(consumer,),
             )
         )
         # Wait until the task has actually entered process.wait() before
@@ -272,12 +247,9 @@ def test_wait_for_exit_code_cancels_pending_consumers_on_cancellation() -> None:
         with pytest.raises(asyncio.CancelledError):
             await task
 
-        assert consumer.cancelled(), (
-            "a consumer left pending at cancellation must be cancelled during "
-            f"cleanup, but consumer.done()={consumer.done()}"
-        )
-        assert consumer.done(), (
-            "the cancelled consumer must be drained before cancellation propagates"
+        assert process.returncode == -15, (
+            "the process must be terminated during cancellation cleanup, "
+            f"but returncode={process.returncode}"
         )
 
     asyncio.run(run_case())

--- a/cuprum/unittests/test_subprocess_timeout.py
+++ b/cuprum/unittests/test_subprocess_timeout.py
@@ -84,14 +84,24 @@ def test_drain_stream_consumers_cancels_pending_and_decodes() -> None:
     asyncio.run(run_case())
 
 
+# Number of event-loop turns the harness lets consumers settle before draining.
+# ``_consumer`` needs ``delay + 1`` turns to reach its outcome, and each consumer
+# is scheduled exactly once per turn, so a consumer whose ``delay`` is at least
+# ``_SETTLE_TURNS`` is still pending when the drain runs (and must be cancelled
+# and decoded to ``None``); one with a smaller delay has completed and keeps its
+# outcome.
+_SETTLE_TURNS = 2
+
+
 @settings(max_examples=75, deadline=None, derandomize=True)
 @given(case=_DRAIN_CASE)
 def test_drain_stream_consumers_decodes_across_orderings(case: _DrainCase) -> None:
-    """_drain_stream_consumers drains once and decodes each consumer outcome.
+    """_drain_stream_consumers drains once, decoding completed and pending readers.
 
-    Across arbitrary interleavings of consumer completion and failure, the
-    helper must drain every consumer and surface each successful consumer's
-    text while mapping a failed consumer to ``None``.
+    Consumers settle for a fixed number of event-loop turns before the drain, so
+    those whose delay fits the window complete (their text preserved, a failure
+    mapping to ``None``) while those whose delay exceeds it are still pending at
+    drain time and must be cancelled and decoded to ``None``.
     """
 
     async def run_case() -> None:
@@ -100,22 +110,34 @@ def test_drain_stream_consumers_decodes_across_orderings(case: _DrainCase) -> No
             asyncio.create_task(_consumer(case.stdout, case.stdout_delay)),
             asyncio.create_task(_consumer(case.stderr, case.stderr_delay)),
         )
-        # Let every consumer reach its outcome before draining, so the decode
-        # path (text preserved, failure -> None) is exercised rather than the
-        # cancellation of a reader that never got to run.
-        await asyncio.gather(*consumers, return_exceptions=True)
+        # Let consumers settle for a bounded number of turns rather than awaiting
+        # every one to completion, so readers slower than the window remain
+        # pending when the drain runs and exercise its cancellation path.
+        for _ in range(_SETTLE_TURNS):
+            await asyncio.sleep(0)
 
         stdout_text, stderr_text = await _drain_stream_consumers(consumers)
 
         assert all(task.done() for task in consumers), (
             "every consumer task must be drained before the helper returns"
         )
-        for label, captured, outcome in (
-            ("stdout", stdout_text, case.stdout),
-            ("stderr", stderr_text, case.stderr),
+        for label, task, captured, outcome, delay in (
+            ("stdout", consumers[0], stdout_text, case.stdout, case.stdout_delay),
+            ("stderr", consumers[1], stderr_text, case.stderr, case.stderr_delay),
         ):
             kind, value = outcome
-            expected = None if kind == "raise" else value
+            if delay >= _SETTLE_TURNS:
+                assert task.cancelled(), (
+                    f"{label} consumer with delay {delay} must still be pending at "
+                    f"drain and be cancelled, but cancelled()={task.cancelled()}"
+                )
+                expected = None
+            else:
+                assert not task.cancelled(), (
+                    f"{label} consumer with delay {delay} must complete within the "
+                    "settling window rather than being cancelled"
+                )
+                expected = None if kind == "raise" else value
             assert captured == expected, (
                 f"{label} capture must reflect its consumer outcome: "
                 f"expected {expected!r}, got {captured!r}"

--- a/docs/debugging/debugging-plan-2026-07-18-hypothesis-too-slow.md
+++ b/docs/debugging/debugging-plan-2026-07-18-hypothesis-too-slow.md
@@ -34,7 +34,7 @@ examples in 1.94 seconds. Health check: too_slow.
 ### Investigation outcome
 
 Wyvern replayed the supplied seed five times; every replay passed in 0.18–0.19
-seconds. Sampling 100 `_TAGS` examples took 0.098 seconds and 100 fixed-tag
+seconds. Sampling 100 `_TAGS` examples took 0.098 seconds, and 100 fixed-tag
 observation constructions took 0.001 seconds. Both hypotheses were falsified,
 so no correction or health-check suppression is justified.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1669,11 +1669,26 @@ executes:
    successful writes and `cuprum_stdin_errors_total` for failure events.
 5. In the streaming path (`_run_subprocess_with_streams`), the stdin writer
    task runs concurrently with the stdout/stderr consumer tasks.  On
-   `TimeoutError`, `_handle_stream_timeout` cancels/gathers the stdin task
-   before raising `_SubprocessTimeoutError`.  On `asyncio.CancelledError`, the
-   task is explicitly cancelled and gathered before re-raising.
+   `TimeoutError` or `asyncio.CancelledError`, `_run_subprocess_with_streams`
+   itself cancels and gathers the stdin writer via `_cancel_stdin_writer`,
+   then drains the stdout/stderr consumers exactly once via
+   `_drain_stream_consumers`.  `_wait_for_exit_code` has already terminated
+   the process, so the drain reaches EOF.  Only after that draining does it
+   call `_handle_stream_timeout`, which merely raises
+   `_SubprocessTimeoutError` carrying the pre-drained stdout/stderr; on the
+   cancellation path `CancelledError` is re-raised directly.
 6. In the non-streaming path (`_execute_subprocess`), the same writer task is
    created and awaited after `_wait_for_exit_code` completes.
+
+The `tests/helpers/stream_pipes.py` module provides
+`drain_blocking_payload_size()`, a shared helper returning a stdin payload
+size that reliably wedges the writer's `drain()`.  It probes the real OS
+pipe capacity (via `fcntl(F_GETPIPE_SZ)` on Linux) and adds a mebibyte of
+headroom, falling back to a conservative default on platforms that cannot
+probe it so callers need no platform guard.  It exists solely to make
+blocked-`drain()` regression tests deterministic and is shared by
+`test_safe_cmd_stdin.py` and `test_observe_stdin_early_close.py`; new
+blocked-writer tests should reuse it rather than hardcoding a payload size.
 
 `_execute_with_hooks(cmd, execution, tracking)` is the single site that runs
 `_execute_subprocess`, iterates after-hooks, and co-ordinates cancellation-safe

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1678,7 +1678,12 @@ executes:
    `_SubprocessTimeoutError` carrying the pre-drained stdout/stderr; on the
    cancellation path `CancelledError` is re-raised directly.
 6. In the non-streaming path (`_execute_subprocess`), the same writer task is
-   created and awaited after `_wait_for_exit_code` completes.
+   created and awaited after `_wait_for_exit_code` completes.  On
+   `TimeoutError` or `asyncio.CancelledError` from `_wait_for_exit_code`,
+   `_execute_subprocess` itself cancels and drains the writer task via
+   `_cancel_stdin_writer` before the timeout is translated or the
+   cancellation propagates, so a stdin drain blocked on an unread pipe cannot
+   delay completion.
 
 The `tests/helpers/stream_pipes.py` module provides
 `drain_blocking_payload_size()`, a shared helper returning a stdin payload

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -365,6 +365,11 @@ enforced. When a timeout expires, Cuprum terminates the subprocess, waits for
 `cancel_grace`, escalates to `SIGKILL` if needed, and raises `TimeoutExpired`
 (mirroring `subprocess.TimeoutExpired`).
 
+Any output already captured before the timeout fired is preserved on the
+exception: `exc.output` / `exc.stderr` hold the partial stdout/stderr (or
+`None` when `capture=False`), so callers can inspect what the command
+produced before it was killed.
+
 Timeout resolution order:
 
 - Explicit `timeout` argument on `run()` / `run_sync` when not `None`.

--- a/tests/helpers/stream_pipes.py
+++ b/tests/helpers/stream_pipes.py
@@ -29,6 +29,35 @@ def _read_all(fd: int, *, chunk_size: int = 4096) -> bytes:
     return b"".join(chunks)
 
 
+def drain_blocking_payload_size() -> int:
+    """Return a stdin payload size that reliably blocks the writer's ``drain()``.
+
+    A blocked-``drain()`` regression only surfaces when the writer's ``drain()``
+    actually blocks, which requires a payload larger than the OS pipe buffer
+    plus the asyncio transport write high-water mark. Probe the real pipe
+    capacity so callers do not rely on an assumed ~64 KiB buffer.
+
+    ``fcntl`` is imported lazily so importing this module — and collecting the
+    tests that use it — still succeeds on platforms without ``fcntl``; the
+    helper itself is only ever executed on POSIX hosts.
+
+    Returns
+    -------
+    int
+        A payload size exceeding the probed pipe capacity, with a full extra
+        mebibyte of headroom above the default transport high-water mark.
+    """
+    import fcntl
+
+    read_fd, write_fd = os.pipe()
+    try:
+        pipe_capacity = fcntl.fcntl(write_fd, fcntl.F_GETPIPE_SZ)
+    finally:
+        _safe_close(read_fd)
+        _safe_close(write_fd)
+    return pipe_capacity + (1 << 20)
+
+
 @contextlib.contextmanager
 def _pipe_pair() -> cabc.Iterator[tuple[int, int, int, int]]:
     """Manage pipe creation and cleanup for stream tests."""

--- a/tests/helpers/stream_pipes.py
+++ b/tests/helpers/stream_pipes.py
@@ -29,33 +29,60 @@ def _read_all(fd: int, *, chunk_size: int = 4096) -> bytes:
     return b"".join(chunks)
 
 
+# Conservative pipe-buffer estimate for hosts that cannot probe the real
+# capacity: Windows lacks ``fcntl`` entirely, while macOS and other POSIX
+# systems lack Linux's ``F_GETPIPE_SZ``. One mebibyte comfortably exceeds the
+# default pipe buffers seen on those platforms, so the payload still blocks the
+# writer's ``drain()`` without a real probe.
+_FALLBACK_PIPE_CAPACITY = 1 << 20
+
+
+def _probe_pipe_capacity() -> int:
+    """Return the real OS pipe capacity, or a conservative fallback.
+
+    Linux exposes the pipe buffer size through ``fcntl(F_GETPIPE_SZ)``. Hosts
+    without the ``fcntl`` module (Windows) or without that constant (macOS,
+    BSD) cannot probe it, so this returns :data:`_FALLBACK_PIPE_CAPACITY`
+    instead of raising. The ``fcntl`` import stays local so importing this
+    module — and collecting the tests that use it — succeeds everywhere.
+
+    Returns
+    -------
+    int
+        The probed pipe capacity in bytes on Linux, otherwise the conservative
+        fallback capacity.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        return _FALLBACK_PIPE_CAPACITY
+    if not hasattr(fcntl, "F_GETPIPE_SZ"):
+        return _FALLBACK_PIPE_CAPACITY
+    read_fd, write_fd = os.pipe()
+    try:
+        return fcntl.fcntl(write_fd, fcntl.F_GETPIPE_SZ)
+    finally:
+        _safe_close(read_fd)
+        _safe_close(write_fd)
+
+
 def drain_blocking_payload_size() -> int:
     """Return a stdin payload size that reliably blocks the writer's ``drain()``.
 
     A blocked-``drain()`` regression only surfaces when the writer's ``drain()``
     actually blocks, which requires a payload larger than the OS pipe buffer
-    plus the asyncio transport write high-water mark. Probe the real pipe
-    capacity so callers do not rely on an assumed ~64 KiB buffer.
-
-    ``fcntl`` is imported lazily so importing this module — and collecting the
-    tests that use it — still succeeds on platforms without ``fcntl``; the
-    helper itself is only ever executed on POSIX hosts.
+    plus the asyncio transport write high-water mark. The capacity is probed via
+    :func:`_probe_pipe_capacity`, which falls back to a conservative default on
+    platforms that cannot probe it, so callers need no platform guard.
 
     Returns
     -------
     int
-        A payload size exceeding the probed pipe capacity, with a full extra
-        mebibyte of headroom above the default transport high-water mark.
+        A payload size exceeding the probed (or fallback) pipe capacity, with a
+        full extra mebibyte of headroom above the default transport high-water
+        mark.
     """
-    import fcntl
-
-    read_fd, write_fd = os.pipe()
-    try:
-        pipe_capacity = fcntl.fcntl(write_fd, fcntl.F_GETPIPE_SZ)
-    finally:
-        _safe_close(read_fd)
-        _safe_close(write_fd)
-    return pipe_capacity + (1 << 20)
+    return _probe_pipe_capacity() + (1 << 20)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Summary

This branch actions a batch of code-review findings on the subprocess
execution machinery and its tests. Each finding was first verified against the
current code; all six proved still valid, and every one has been fixed with
minimal changes. The substantive change is that stream-consumer draining on
timeout now happens exactly once rather than twice, with captured output
preserved on `TimeoutExpired`; the remainder replace timing-based test
coordination with deterministic synchronisation seams and move a shared helper
into the test-helper package.

No issue or roadmap task governs this branch, and there is no execplan; the
work originates from inline and out-of-diff review comments.

## Review walkthrough

- Start with [cuprum/_subprocess_execution.py](https://github.com/leynos/cuprum/blob/12a9296a897ff65cc25732ce3618fa921d17667c/cuprum/_subprocess_execution.py) — `_wait_for_exit_code` now waits only for the exit code (still terminating the process on timeout or cancellation), and a new `_drain_stream_consumers` helper cancels, drains, and decodes the stdout/stderr consumers exactly once in the timeout and cancellation branches of `_run_subprocess_with_streams`.
- Then review [cuprum/_subprocess_timeout.py](https://github.com/leynos/cuprum/blob/12a9296a897ff65cc25732ce3618fa921d17667c/cuprum/_subprocess_timeout.py) — `_handle_stream_timeout` is now synchronous and simply raises `_SubprocessTimeoutError` from the caller-supplied, already-decoded stdout/stderr, so captured output survives onto the public `TimeoutExpired`.
- Review the moved helper in [tests/helpers/stream_pipes.py](https://github.com/leynos/cuprum/blob/12a9296a897ff65cc25732ce3618fa921d17667c/tests/helpers/stream_pipes.py) — `drain_blocking_payload_size` probes the real pipe capacity and imports `fcntl` lazily so off-POSIX collection still succeeds.
- Review the reworked observe tests in [cuprum/unittests/test_observe.py](https://github.com/leynos/cuprum/blob/12a9296a897ff65cc25732ce3618fa921d17667c/cuprum/unittests/test_observe.py) — the early-close stdin test replaces payload-size timing with a deterministic go/closed marker handshake: the child closes stdin only once the writer is confirmed wedged in `drain()`, then signals back.
- Review [cuprum/unittests/test_safe_cmd_context.py](https://github.com/leynos/cuprum/blob/12a9296a897ff65cc25732ce3618fa921d17667c/cuprum/unittests/test_safe_cmd_context.py) — the cancellation test replaces a fixed `asyncio.sleep` readiness guess with an `sh.observe` `start`-phase hook and an `asyncio.Event`.
- Review [cuprum/unittests/test_safe_cmd_stdin.py](https://github.com/leynos/cuprum/blob/12a9296a897ff65cc25732ce3618fa921d17667c/cuprum/unittests/test_safe_cmd_stdin.py) — the two blocked-stdin tests now use the shared `drain_blocking_payload_size` helper instead of hardcoded 1 MiB payloads, and a capture-mode blocked-stdin timeout regression test exercises the stream path.
- Finish with [cuprum/unittests/test_subprocess_timeout.py](https://github.com/leynos/cuprum/blob/12a9296a897ff65cc25732ce3618fa921d17667c/cuprum/unittests/test_subprocess_timeout.py) — the unit tests are re-pointed at the new decomposition: `_drain_stream_consumers` decoding, the synchronous `_handle_stream_timeout`, and `_wait_for_exit_code`'s process teardown.
- The documentation fix is a single clause-separating comma in [docs/debugging/debugging-plan-2026-07-18-hypothesis-too-slow.md](https://github.com/leynos/cuprum/blob/12a9296a897ff65cc25732ce3618fa921d17667c/docs/debugging/debugging-plan-2026-07-18-hypothesis-too-slow.md).

## Validation

- `uv run ruff format --check`: pass (all files formatted)
- `make lint`: pass (ruff clean, typos gate clean)
- `make typecheck`: pass (`ty check`, all checks passed)
- `make markdownlint`: pass (exit 0)
- `make nixie`: pass (all diagrams validated)
- `uv run pytest -n0 test_observe.py test_safe_cmd_context.py test_safe_cmd_stdin.py test_subprocess_timeout.py`: 57 passed

## Notes

- The consumer-drain relocation preserves existing behaviour: the previous code
  drained the consumers twice (discarding the first pass, keeping the second),
  so collapsing to a single drain does not change observable output. A consumer
  still blocked on `read()` at drain time is cancelled and decodes to `None`, as
  before.
- The full `make test` suite, including the Rust `nextest` portion, was not run
  to completion locally; the changes are Python-only and do not touch the Rust
  crate. The known trybuild snapshot drift against the CI-pinned toolchain is
  unrelated to this branch.
