### PR TITLE
Rust: pure pump state machine with proptest + Kani (#84)

### DIFF
--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -2238,6 +2238,34 @@ operation-scoped thread-local counters that the
 loops reset at operation start (keeping the seams parameter-free). See the
 developers' guide for the full contract.
 
+#### Read/write fallback state machine
+
+The non-splice read/write loop keeps its control flow — how each read and write
+outcome moves the running byte total and the latched writer state — in a pure,
+`io::Error`-free state machine in `rust/cuprum-rust/src/pump_machine.rs`,
+separate from the descriptor I/O that feeds it.
+
+`step` advances a `PumpState` given a `ReadEvent` (`Chunk`/`Eof`) and, when a
+write was performed, a `WriteEvent` (`Complete`/`Closed`). `drive_step` wraps it
+with the loop's write precondition — the write runs only for a chunk read while
+the writer is still open — so `pump_stream_files_readwrite` and the property
+tests drive the machine through one definition of that rule rather than a
+runtime copy and a test copy.
+
+`io_utils::classify_write` is the adapter between the two halves. It collapses
+`WriteOutcome` and the non-fatal error partition into the machine's two-variant
+`WriteEvent`, so a broken pipe or connection reset latches the writer closed
+carrying the bytes accepted before the failure, while genuinely fatal failures
+propagate as `PumpError` and never reach the machine at all.
+
+Keeping the decision `io::Error`-free is what makes it verifiable: proptests
+fold random event scripts through `drive_step`, and Kani proves the same
+invariants — the total is monotonic, the writer never reopens once latched, a
+closed writer drains without accruing bytes, and the loop stops exactly on
+`Eof` — over unbounded byte counts and arbitrary starting states. That is
+deliberately unlike the splice path, whose `io::Error` values are not
+Kani-tractable; the developers' guide records the commands and the bounds.
+
 ### 13.8 Build and Distribution
 
 The Rust extension is built using maturin and distributed as platform-specific

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -2245,25 +2245,43 @@ outcome moves the running byte total and the latched writer state — in a pure,
 `io::Error`-free state machine in `rust/cuprum-rust/src/pump_machine.rs`,
 separate from the descriptor I/O that feeds it.
 
-`step` advances a `PumpState` given a `ReadEvent` (`Chunk`/`Eof`) and, when a
-write was performed, a `WriteEvent` (`Complete`/`Closed`). `drive_step` wraps it
-with the loop's write precondition — the write runs only for a chunk read while
-the writer is still open — so `pump_stream_files_readwrite` and the property
-tests drive the machine through one definition of that rule rather than a
-runtime copy and a test copy.
+`advance` is the whole public surface. It takes a `PumpState`, the length just
+read, and a closure that performs one write, and it returns a `Flow`
+(`Continue`/`Stop`):
+
+```rust,ignore
+pub(crate) fn advance<E>(
+    state: &mut PumpState,
+    read_len: usize,
+    write_once: impl FnOnce() -> Result<WriteEvent, E>,
+) -> Result<Flow, E>;
+```
+
+Taking the *raw read length* rather than a pre-built read event is what puts
+the loop's write precondition inside the machine: `advance` calls `write_once`
+only for a non-zero read while the writer is still open, and otherwise drains
+or stops without calling it at all. So `pump_stream_files_readwrite` and the
+property tests cannot disagree about that rule — neither one gets to decide it.
+
+The precondition is then encoded in the type system rather than re-checked. A
+private `Transition` (`Wrote`/`Drained`/`Eof`) is constructed only by
+`advance`, so "wrote a chunk after the writer latched closed" is not a
+representable state and the internal `step` needs no defensive `writer_open`
+check — a second check would only mask a caller that got it wrong.
 
 `io_utils::classify_write` is the adapter between the two halves. It collapses
 `WriteOutcome` and the non-fatal error partition into the machine's two-variant
-`WriteEvent`, so a broken pipe or connection reset latches the writer closed
-carrying the bytes accepted before the failure, while genuinely fatal failures
-propagate as `PumpError` and never reach the machine at all.
+`WriteEvent` (`Complete { bytes }` / `Closed { bytes }`), so a broken pipe or
+connection reset latches the writer closed carrying the bytes accepted before
+the failure, while genuinely fatal failures propagate as `PumpError` and never
+reach the machine at all.
 
 Keeping the decision `io::Error`-free is what makes it verifiable: proptests
-fold random event scripts through `drive_step`, and Kani proves the same
+fold random event scripts through `advance`, and Kani proves the same
 invariants — the total is monotonic, the writer never reopens once latched, a
-closed writer drains without accruing bytes, and the loop stops exactly on
-`Eof` — over unbounded byte counts and arbitrary starting states. That is
-deliberately unlike the splice path, whose `io::Error` values are not
+closed writer drains without accruing bytes, and the loop stops exactly on a
+zero-length read — over unbounded byte counts and arbitrary starting states.
+That is deliberately unlike the splice path, whose `io::Error` values are not
 Kani-tractable; the developers' guide records the commands and the bounds.
 
 ### 13.8 Build and Distribution

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -2267,7 +2267,10 @@ The precondition is then encoded in the type system rather than re-checked. A
 private `Transition` (`Wrote`/`Drained`/`Eof`) is constructed only by
 `advance`, so "wrote a chunk after the writer latched closed" is not a
 representable state and the internal `step` needs no defensive `writer_open`
-check — a second check would only mask a caller that got it wrong.
+check — a second check would only mask a caller that got it wrong. Because that
+argument rests on `Transition` and `step` remaining module-private, a
+compile-fail case (`tests/ui/fail/pump_transition_unreachable.rs`) holds the
+boundary: it fails if either is widened, even to `pub(crate)`.
 
 `io_utils::classify_write` is the adapter between the two halves. It collapses
 `WriteOutcome` and the non-fatal error partition into the machine's two-variant

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1276,6 +1276,21 @@ These raw-fd helpers live in the `io_utils` directory module (`io_utils/mod.rs`,
 with tests in `io_utils/tests.rs`), split from the former single file to stay
 within the per-module line cap.
 
+The read/write fallback's control flow — how each read and write outcome moves
+the running byte total and the latched `writer_open` flag — is factored into a
+pure, `io::Error`-free state machine in `src/pump_machine.rs`. `step` advances a
+`PumpState` given a `ReadEvent` (`Chunk`/`Eof`) and, when a write is performed,
+a `WriteEvent` (`Complete`/`Closed`); `pump_stream_files_readwrite` drives it,
+translating real descriptor I/O into those events and propagating fatal
+`PumpError`s out of band so they never reach the machine. Extracting the
+decision this way lets it be checked without descriptors: proptests fold random
+event scripts through `step` to assert the total is monotonic, the writer never
+reopens once a broken pipe latches it closed, a closed writer drains without
+accruing bytes, and the loop stops exactly on `Eof`. Kani proves the same
+invariants over unbounded byte counts and arbitrary starting states in
+`src/pump_machine_kani_proofs.rs` (`#[cfg(kani)]`, so outside the commit gate),
+closing the model-checking follow-up from issue `#84`.
+
 The path emits bounded `tracing` diagnostics at the three boundaries operators
 need visibility into: support detection logs a `debug` event when the
 descriptors cannot splice and the read/write fallback takes over; the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1298,6 +1298,16 @@ lived in a doc comment. Making those states unrepresentable also removed the
 defensive re-check inside `step`, which had been masking exactly the mistake it
 looked like it was guarding against.
 
+That encapsulation is what the proptests and Kani proofs assume rather than
+establish — neither can observe a transition it cannot spell — so it is pinned
+separately by the compile-fail case
+`rust/cuprum-rust/tests/ui/fail/pump_transition_unreachable.rs`. That case
+includes `src/pump_machine.rs` as a child module, reproducing the relationship
+`lib.rs` has with it, and asserts the compiler's refusal of an attempt to build
+a `Transition::Wrote` and pass it to `step` from the parent. Widening either
+item, even to `pub(crate)`, changes the diagnostic and fails the case, so the
+"`advance` is the only constructor" claim cannot quietly stop being true.
+
 Whether the write *ran* is what the tests assert, not merely its effect: a
 dropped precondition would leave the resulting state identical and differ only
 in having performed a spurious write, so the drivers report invocation.
@@ -1870,8 +1880,10 @@ as a test assertion on the SHA string.
 ## Compile-time UI tests (trybuild)
 
 The Rust crate at `rust/cuprum-rust/` uses
-[trybuild](https://github.com/dtolnay/trybuild) to validate PyO3 macro
-behaviour at compile time. Tests live under `rust/cuprum-rust/tests/ui/`:
+[trybuild](https://github.com/dtolnay/trybuild) to validate contracts that hold
+at compile time and so cannot be observed by a runtime test: PyO3 macro
+behaviour, and encapsulation boundaries such as the pump machine's private
+`Transition`. Tests live under `rust/cuprum-rust/tests/ui/`:
 
 - `tests/ui/pass/` — Rust files that **must compile** without error.
 - `tests/ui/fail/` — Rust files that **must fail** compilation with diagnostics
@@ -1893,6 +1905,15 @@ cd rust && TRYBUILD=overwrite cargo +1.85.0 test compile_time_ui
 
 Inspect the updated `.stderr` files before committing to confirm that each fail
 test still represents a genuine compile-time error.
+
+A fail case that pins an encapsulation boundary must include the real module
+under test with `#[path]` rather than restating its shape, because a
+hand-written copy would only prove the copy private. `#![allow]` at the top of
+such a fixture is legitimate for lints the throwaway crate trybuild builds
+cannot configure — it inherits no `[lints]` table, so the workspace's
+`check-cfg = ["cfg(kani)"]` does not apply — and keeps the expected diagnostic
+narrow. Before committing one, verify it is not vacuous: weaken the production
+item it guards, confirm the case then fails, and restore.
 
 ## Design decisions
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1331,6 +1331,16 @@ accumulated in operation-scoped thread-local counters that
 (right after entering the span, via `io_utils::reset_retry_counters`;
 `operation_span` itself does not touch the counters), so the seams stay
 parameter-free while the span still reports them.
+
+One event in that loop comes from the pump's own state rather than a seam.
+When the writer-close latch first closes — the downstream stage hung up and the
+remaining reads only drain the upstream, the `head`-style early exit — the loop
+emits a `debug` event carrying `bytes_transferred`, using the same field and
+message as the splice path's broken-pipe report so a hang-up looks identical
+whichever path handled it. It is observed in the loop rather than in
+`pump_machine`, which stays free of I/O and logging so its bounded proofs stay
+tractable.
+
 The span is created at `error` level so the `warn`/`error` events keep their
 operation context even under a `warn`/`error`-only production filter, where an
 `info` span would be disabled; it emits no log line of its own.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1278,29 +1278,41 @@ within the per-module line cap.
 
 The read/write fallback's control flow — how each read and write outcome moves
 the running byte total and the latched `writer_open` flag — is factored into a
-pure, `io::Error`-free state machine in `src/pump_machine.rs`. `step` advances a
-`PumpState` given a `ReadEvent` (`Chunk`/`Eof`) and, when a write is performed,
-a `WriteEvent` (`Complete`/`Closed`).
+pure, `io::Error`-free state machine in `src/pump_machine.rs`.
 
-`drive_step` wraps `step` with the loop's write precondition: it invokes the
-supplied write operation **only** for a chunk read while the writer is still
-open, so EOF and a latched-closed writer never attempt one.
-`pump_stream_files_readwrite` and the property tests both drive the machine
-through `drive_step`, so the precondition has a single definition rather than a
-runtime copy and a test copy that could drift apart. That distinction needs
-testing directly: `step` independently ignores a write it is handed, so a
-`drive_step` that dropped the precondition would leave the resulting state
-identical and only differ in having performed a spurious write. The tests
-therefore assert whether the write operation *ran*, not merely its effect.
+`advance` is the machine's only production entry point. It takes the raw read
+length and a write operation, and owns both decisions the loop would otherwise
+have to make for itself: a zero-length read is end of input, anything else is a
+chunk; and the write runs **only** for a chunk read while the writer is still
+open. `pump_stream_files_readwrite`, the property tests, and the bounded proofs
+all go through it, so there is one definition of that policy rather than three
+copies that could drift.
+
+The precondition is enforced by the type rather than by a check. Internally
+`advance` builds a private `Transition` — `Wrote(WriteEvent)`, `Drained`, or
+`Eof` — and `Wrote` is constructible only on the branch that has already
+established the writer is open. An earlier API took a read event and an
+`Option<WriteEvent>` independently, which let a caller pass a write for an EOF
+read or for a closed writer; both were silently ignored, so the precondition
+lived in a doc comment. Making those states unrepresentable also removed the
+defensive re-check inside `step`, which had been masking exactly the mistake it
+looked like it was guarding against.
+
+Whether the write *ran* is what the tests assert, not merely its effect: a
+dropped precondition would leave the resulting state identical and differ only
+in having performed a spurious write, so the drivers report invocation.
 
 Extracting the decision this way lets it be checked without descriptors:
-proptests fold random event scripts through `drive_step` to assert the total is
-monotonic, the writer never reopens once a broken pipe latches it closed, a
-closed writer drains without accruing bytes, the loop stops exactly on `Eof`,
-and the write runs exactly when the transition permits it. Kani proves the same
-invariants over unbounded byte counts and arbitrary starting states in
-`src/pump_machine_kani_proofs.rs` (`#[cfg(kani)]`, so outside the commit gate),
-closing the model-checking follow-up from issue `#84`.
+proptests fold random scripts of `(read_len, WriteEvent)` through `advance` to
+assert the total is monotonic, the writer never reopens once a broken pipe
+latches it closed, a closed writer drains without accruing bytes, the loop
+stops exactly on a zero-length read, and the write runs exactly when the
+transition permits it. Kani proves the same invariants over unbounded byte
+counts and arbitrary starting states in `src/pump_machine_kani_proofs.rs`
+(`#[cfg(kani)]`, so outside the commit gate), closing the model-checking
+follow-up from issue `#84`. Those proofs target `advance` rather than the
+private `step`, because `advance` is where the precondition lives — proving
+`step` in isolation would establish nothing about a closed writer.
 
 The path emits bounded `tracing` diagnostics at the three boundaries operators
 need visibility into: support detection logs a `debug` event when the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1280,13 +1280,39 @@ The read/write fallback's control flow — how each read and write outcome moves
 the running byte total and the latched `writer_open` flag — is factored into a
 pure, `io::Error`-free state machine in `src/pump_machine.rs`.
 
-`advance` is the machine's only production entry point. It takes the raw read
-length and a write operation, and owns both decisions the loop would otherwise
-have to make for itself: a zero-length read is end of input, anything else is a
-chunk; and the write runs **only** for a chunk read while the writer is still
-open. `pump_stream_files_readwrite`, the property tests, and the bounded proofs
-all go through it, so there is one definition of that policy rather than three
+[Cuprum design](cuprum-design.md) §13.7, "Read/write fallback state machine",
+is the normative reference for this API: it carries `advance`'s full signature
+and the reasoning behind its shape. The notes below record the conventions that
+govern using it, and name the types so a reader arriving from the `io_utils`
+sections above knows what to look for.
+
+`advance` is the machine's only production entry point. It takes a `PumpState`
+by mutable reference, the raw read length, and a closure that performs one
+write, and it returns a `Flow` — `Continue` to keep reading, or `Stop` on end
+of input. `PumpState` holds exactly the two values the loop must not get wrong,
+the running `total_written` total and the latched `writer_open` flag, exposed
+through `total_written()` and `writer_open()` accessors rather than as public
+fields, so only the machine may move them.
+
+`advance` owns both decisions the loop would otherwise have to make for itself:
+a zero-length read is end of input, anything else is a chunk; and the write
+runs **only** for a chunk read while the writer is still open.
+`pump_stream_files_readwrite`, the property tests, and the bounded proofs all
+go through it, so there is one definition of that policy rather than three
 copies that could drift.
+
+The write closure yields a `WriteEvent`, the machine's `io::Error`-free view of
+one write: `Complete { bytes }` accepted the whole chunk and leaves the writer
+open, while `Closed { bytes }` carries the bytes accepted before a broken pipe
+or connection reset and latches the writer shut for good. The sole production
+adapter that builds one is `io_utils::classify_write`, which collapses a
+`WriteOutcome` and the non-fatal error partition into those two variants; the
+test-only `classify_write_with` shares its mapping through a `write(2)` seam.
+Genuinely fatal failures never reach the machine at all — they propagate as
+`PumpError` — which is what keeps `pump_machine` free of `io::Error` and so
+tractable for Kani. Re-use policy: a new caller of the machine must classify
+its writes through `classify_write` rather than constructing a `WriteEvent`
+inline, otherwise "non-fatal" stops having one definition.
 
 The precondition is enforced by the type rather than by a check. Internally
 `advance` builds a private `Transition` — `Wrote(WriteEvent)`, `Drained`, or
@@ -1323,6 +1349,13 @@ counts and arbitrary starting states in `src/pump_machine_kani_proofs.rs`
 follow-up from issue `#84`. Those proofs target `advance` rather than the
 private `step`, because `advance` is where the precondition lives — proving
 `step` in isolation would establish nothing about a closed writer.
+
+Neither the proptests nor the proofs call `advance` directly. Both go through
+`drive`, a `#[cfg(any(test, kani))]` helper beside it that supplies the write
+closure and returns the `Flow` alongside whether the closure was invoked. That
+is deliberate: it keeps the two harnesses driving the machine identically, and
+it is where the "was the write attempted?" observable comes from. Add new
+harnesses through `drive` rather than reconstructing the closure in each one.
 
 The path emits bounded `tracing` diagnostics at the three boundaries operators
 need visibility into: support detection logs a `debug` event when the
@@ -1908,12 +1941,34 @@ test still represents a genuine compile-time error.
 
 A fail case that pins an encapsulation boundary must include the real module
 under test with `#[path]` rather than restating its shape, because a
-hand-written copy would only prove the copy private. `#![allow]` at the top of
-such a fixture is legitimate for lints the throwaway crate trybuild builds
-cannot configure — it inherits no `[lints]` table, so the workspace's
-`check-cfg = ["cfg(kani)"]` does not apply — and keeps the expected diagnostic
-narrow. Before committing one, verify it is not vacuous: weaken the production
-item it guards, confirm the case then fails, and restore.
+hand-written copy would only prove the copy private.
+
+Such a fixture may legitimately need to silence a lint the throwaway crate
+trybuild builds cannot configure — that crate inherits no `[lints]` table, so
+the workspace's `check-cfg = ["cfg(kani)"]` does not apply and the included
+module's `#[cfg(kani)]` gates would otherwise bury the expected diagnostic in
+`unexpected_cfgs` noise. Scope that suppression to the item that needs it:
+
+- Do not use a crate-level inner attribute (`#![allow(...)]` or
+  `#![expect(...)]`). It suppresses the lint for the probe code as well as the
+  included module, so a diagnostic the case ought to report can vanish
+  unnoticed. There are no crate-level `allow` or `expect` attributes anywhere in
+  `rust/`, and no fixture needs the first one.
+- Put an outer `#[expect(<lint>, reason = "...")]` on the `#[path]` module
+  declaration instead, next to the `#[path]` attribute itself. Prefer `expect`
+  over `allow`: if the production module later drops the gates that provoke the
+  lint, an unfulfilled expectation fails the build rather than leaving a stale
+  suppression behind.
+- Every suppression carries a `reason` string naming the constraint, per the
+  repository-wide rule that lint suppressions are tightly scoped and explained.
+
+`tests/ui/fail/pump_transition_unreachable.rs` is the worked example.
+
+Before committing one, verify it is not vacuous: weaken the production item it
+guards, confirm the case then fails, and restore. Re-run that check after any
+change to the fixture's attributes or structure, not only after a change to the
+item under test — narrowing a suppression can alter which diagnostics reach the
+`.stderr` fixture.
 
 ## Design decisions
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1280,13 +1280,24 @@ The read/write fallback's control flow — how each read and write outcome moves
 the running byte total and the latched `writer_open` flag — is factored into a
 pure, `io::Error`-free state machine in `src/pump_machine.rs`. `step` advances a
 `PumpState` given a `ReadEvent` (`Chunk`/`Eof`) and, when a write is performed,
-a `WriteEvent` (`Complete`/`Closed`); `pump_stream_files_readwrite` drives it,
-translating real descriptor I/O into those events and propagating fatal
-`PumpError`s out of band so they never reach the machine. Extracting the
-decision this way lets it be checked without descriptors: proptests fold random
-event scripts through `step` to assert the total is monotonic, the writer never
-reopens once a broken pipe latches it closed, a closed writer drains without
-accruing bytes, and the loop stops exactly on `Eof`. Kani proves the same
+a `WriteEvent` (`Complete`/`Closed`).
+
+`drive_step` wraps `step` with the loop's write precondition: it invokes the
+supplied write operation **only** for a chunk read while the writer is still
+open, so EOF and a latched-closed writer never attempt one.
+`pump_stream_files_readwrite` and the property tests both drive the machine
+through `drive_step`, so the precondition has a single definition rather than a
+runtime copy and a test copy that could drift apart. That distinction needs
+testing directly: `step` independently ignores a write it is handed, so a
+`drive_step` that dropped the precondition would leave the resulting state
+identical and only differ in having performed a spurious write. The tests
+therefore assert whether the write operation *ran*, not merely its effect.
+
+Extracting the decision this way lets it be checked without descriptors:
+proptests fold random event scripts through `drive_step` to assert the total is
+monotonic, the writer never reopens once a broken pipe latches it closed, a
+closed writer drains without accruing bytes, the loop stops exactly on `Eof`,
+and the write runs exactly when the transition permits it. Kani proves the same
 invariants over unbounded byte counts and arbitrary starting states in
 `src/pump_machine_kani_proofs.rs` (`#[cfg(kani)]`, so outside the commit gate),
 closing the model-checking follow-up from issue `#84`.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -243,8 +243,9 @@ Notes:
   discarded input stays bounded. On the Rust backend that drain is reported —
   see [Rust stream observability](#rust-stream-observability-internal) for the
   `broken pipe; draining reader` event and the `bytes_transferred` count, which
-  distinguish a consumer that finished early by design from one that failed
-  partway through.
+  record *that* the downstream stage stopped reading and how much it received
+  first. Neither says why it stopped; read them alongside that stage's exit
+  status.
 
 ## Execution runtime
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -240,7 +240,11 @@ Notes:
   `result.failure_index`.
 - When a downstream writer closes early, Cuprum drains the upstream reader
   until EOF or a short timeout elapses, even on a stalled upstream, so
-  discarded input stays bounded.
+  discarded input stays bounded. On the Rust backend that drain is reported —
+  see [Rust stream observability](#rust-stream-observability-internal) for the
+  `broken pipe; draining reader` event and the `bytes_transferred` count, which
+  distinguish a consumer that finished early by design from one that failed
+  partway through.
 
 ## Execution runtime
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1275,13 +1275,21 @@ broken pipe; draining reader    bytes_transferred=<count>
 `bytes_transferred` is the number of bytes that reached the downstream stage
 before it hung up, so `0` means it closed before receiving anything.
 
-This is not an error and the pipeline still succeeds: the drain is what stops a
-producer blocking forever on a pipe nobody is reading. The event is worth
-watching because it distinguishes "the consumer finished early by design", as
-`head` does, from a consumer crashing partway through — the exit codes look the
-same, but the byte total does not. Both the `splice` fast path and the
-read/write fallback emit it identically, so the message does not depend on
-which path handled the transfer.
+The event is not itself an error. It records that the pump classified the
+writer's closure as non-fatal and drained the rest of the input, which is what
+stops a producer blocking forever on a pipe nobody is reading — the pump
+returns success.
+
+It does not, on its own, say *why* the downstream stage stopped reading. A
+consumer that finished by design, as `head` does, and one that crashed partway
+through can both close the pipe after the same number of bytes. Read the event
+alongside that stage's exit status: a zero exit means the early stop was
+deliberate, and a non-zero exit means the stage failed — in which case the
+pipeline still fails through the usual fail-fast path, even though the pump
+itself succeeded.
+
+Both the `splice` fast path and the read/write fallback emit the event
+identically, so the message does not depend on which path handled the transfer.
 
 ### Choosing a stream backend
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1277,9 +1277,13 @@ broken pipe; draining reader    bytes_transferred=<count>
 before it hung up, so `0` means it closed before receiving anything.
 
 The event is not itself an error. It records that the pump classified the
-writer's closure as non-fatal and drained the rest of the input, which is what
-stops a producer blocking forever on a pipe nobody is reading — the pump
-returns success.
+writer's closure as non-fatal and *began* draining the rest of the input, which
+is what stops a producer blocking forever on a pipe nobody is reading.
+
+It is emitted the moment the writer latches closed, before the drain finishes,
+so it is not a report of success. The pump returns success only if the drain
+then reaches EOF; a read that fails fatally afterwards still propagates as an
+`OSError`, on a run where this event was already emitted.
 
 It does not, on its own, say *why* the downstream stage stopped reading. A
 consumer that finished by design, as `head` does, and one that crashed partway

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1258,6 +1258,27 @@ cumulative `EINTR` `read_retries`/`write_retries` counts. The span sits at
 `error` level so the `warn`/`error` events retain their operation context even
 when the subscriber is filtered to `warn`/`error`; it emits no log line itself.
 
+One further `debug` event reports the pump's own state rather than an
+individual read or write. When a downstream stage hangs up early — the
+`head`-style exit, where a consumer stops reading before the producer has
+finished — the pump latches its writer closed and keeps draining the upstream
+reader to EOF. That transition logs:
+
+```text
+broken pipe; draining reader    bytes_transferred=<count>
+```
+
+`bytes_transferred` is the number of bytes that reached the downstream stage
+before it hung up, so `0` means it closed before receiving anything.
+
+This is not an error and the pipeline still succeeds: the drain is what stops a
+producer blocking forever on a pipe nobody is reading. The event is worth
+watching because it distinguishes "the consumer finished early by design", as
+`head` does, from a consumer crashing partway through — the exit codes look the
+same, but the byte total does not. Both the `splice` fast path and the
+read/write fallback emit it identically, so the message does not depend on
+which path handled the transfer.
+
 ### Choosing a stream backend
 
 Most users should leave backend selection on `auto`. This uses the Rust pathway

--- a/rust/cuprum-rust/src/io_utils/mod.rs
+++ b/rust/cuprum-rust/src/io_utils/mod.rs
@@ -158,6 +158,29 @@ pub(crate) fn classify_write(
     classify_write_outcome(handle_write(writer, chunk))
 }
 
+/// Classify a write driven by an injectable single-write operation.
+///
+/// Substitutes only the `write(2)` syscall. Everything downstream of it — the
+/// partial-write loop in [`write_all_unix_with`], the non-fatal partitioning
+/// in [`map_short_write_error`], and the mapping in [`classify_write_outcome`]
+/// — is the same code [`classify_write`] reaches through [`handle_write`], in
+/// the same order. What this does *not* cover is the `write(2)` call inside
+/// [`write_all_unix`]; the descriptor-backed tests above exercise that.
+///
+/// The seam exists because the two non-fatal mappings cannot both be forced
+/// through a real descriptor. A broken pipe *before* any progress is easy —
+/// drop the read end and write — but a partial write *followed by* a broken
+/// pipe depends on when the peer closes relative to the kernel accepting
+/// bytes, which no test can schedule deterministically. Test-only, so
+/// production keeps exactly one write path.
+#[cfg(all(unix, test))]
+pub(crate) fn classify_write_with(
+    chunk: &[u8],
+    write_once: impl FnMut(&[u8]) -> Result<libc::ssize_t, io::Error>,
+) -> Result<WriteEvent, PumpError> {
+    classify_write_outcome(write_all_unix_with(chunk, write_once))
+}
+
 /// Map a completed write attempt onto the pure machine's `WriteEvent`.
 ///
 /// Split from [`classify_write`] so the mapping can be exercised for every

--- a/rust/cuprum-rust/src/io_utils/mod.rs
+++ b/rust/cuprum-rust/src/io_utils/mod.rs
@@ -9,6 +9,7 @@ use std::cell::Cell;
 use std::io;
 
 use crate::errors::PumpError;
+use crate::pump_machine::WriteEvent;
 
 thread_local! {
     /// EINTR retries observed on the read path of the current operation.
@@ -126,6 +127,40 @@ pub(crate) fn handle_write(
     let outcome = write_all_windows(writer, chunk)?;
 
     Ok(outcome)
+}
+
+/// Attempt one write and classify it into a non-fatal [`WriteEvent`].
+///
+/// This is the adapter between real descriptor I/O and the pure pump state
+/// machine in [`crate::pump_machine`]: it collapses [`WriteOutcome`] and the
+/// non-fatal error partition into the machine's two-variant `WriteEvent`, so
+/// only genuinely fatal failures escape as [`PumpError`]. A broken pipe or
+/// connection reset latches the writer closed, carrying the bytes accepted
+/// before the failure (zero when it preceded any progress).
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // A pipe whose read end is still open accepts the whole chunk.
+/// let event = classify_write(&mut writer, b"chunk")?;
+/// assert_eq!(event, WriteEvent::Complete { bytes: 5 });
+///
+/// // Once the reader hangs up, the same call latches the writer closed
+/// // instead of failing, reporting the bytes that were accepted.
+/// drop(reader);
+/// let event = classify_write(&mut writer, b"chunk")?;
+/// assert_eq!(event, WriteEvent::Closed { bytes: 0 });
+/// ```
+pub(crate) fn classify_write(
+    writer: &mut StreamHandle,
+    chunk: &[u8],
+) -> Result<WriteEvent, PumpError> {
+    match handle_write(writer, chunk) {
+        Ok(WriteOutcome::Complete(bytes)) => Ok(WriteEvent::Complete { bytes }),
+        Ok(WriteOutcome::NonFatalShortWrite(bytes)) => Ok(WriteEvent::Closed { bytes }),
+        Err(err) if err.is_nonfatal_write() => Ok(WriteEvent::Closed { bytes: 0 }),
+        Err(err) => Err(err),
+    }
 }
 
 #[cfg(unix)]

--- a/rust/cuprum-rust/src/io_utils/mod.rs
+++ b/rust/cuprum-rust/src/io_utils/mod.rs
@@ -128,35 +128,6 @@ pub(crate) fn handle_write(
     Ok(outcome)
 }
 
-/// Attempt to write a chunk and update the total written count.
-///
-/// Returns `Ok(true)` if the write succeeded and more writes are possible.
-/// Returns `Ok(false)` if the pipe is broken (caller should drain reader).
-/// Returns `Err` for fatal I/O errors.
-pub(crate) fn handle_write_result(
-    writer: &mut StreamHandle,
-    chunk: &[u8],
-    total_written: &mut u64,
-) -> Result<bool, PumpError> {
-    match handle_write(writer, chunk) {
-        Ok(WriteOutcome::Complete(bytes)) => {
-            *total_written = total_written.saturating_add(bytes);
-            Ok(true)
-        }
-        Ok(WriteOutcome::NonFatalShortWrite(bytes)) => {
-            *total_written = total_written.saturating_add(bytes);
-            Ok(false)
-        }
-        Err(err) => {
-            if err.is_nonfatal_write() {
-                Ok(false)
-            } else {
-                Err(err)
-            }
-        }
-    }
-}
-
 #[cfg(unix)]
 fn read_stream_unix(reader: &StreamHandle, buffer: &mut [u8]) -> Result<usize, PumpError> {
     read_raw_fd(reader.as_raw_fd(), buffer)

--- a/rust/cuprum-rust/src/io_utils/mod.rs
+++ b/rust/cuprum-rust/src/io_utils/mod.rs
@@ -155,10 +155,25 @@ pub(crate) fn classify_write(
     writer: &mut StreamHandle,
     chunk: &[u8],
 ) -> Result<WriteEvent, PumpError> {
-    match handle_write(writer, chunk) {
+    classify_write_outcome(handle_write(writer, chunk))
+}
+
+/// Map a completed write attempt onto the pure machine's `WriteEvent`.
+///
+/// Split from [`classify_write`] so the mapping can be exercised for every
+/// outcome — including a non-fatal short write carrying a positive byte count —
+/// without contriving a partial write against a real descriptor.
+///
+/// There is deliberately no non-fatal `Err` arm: [`map_short_write_error`] has
+/// already turned broken-pipe and connection-reset failures into
+/// [`WriteOutcome::NonFatalShortWrite`], so every `Err` reaching here is fatal
+/// and propagates.
+fn classify_write_outcome(
+    outcome: Result<WriteOutcome, PumpError>,
+) -> Result<WriteEvent, PumpError> {
+    match outcome {
         Ok(WriteOutcome::Complete(bytes)) => Ok(WriteEvent::Complete { bytes }),
         Ok(WriteOutcome::NonFatalShortWrite(bytes)) => Ok(WriteEvent::Closed { bytes }),
-        Err(err) if err.is_nonfatal_write() => Ok(WriteEvent::Closed { bytes: 0 }),
         Err(err) => Err(err),
     }
 }

--- a/rust/cuprum-rust/src/io_utils/tests.rs
+++ b/rust/cuprum-rust/src/io_utils/tests.rs
@@ -6,9 +6,10 @@ use std::os::fd::{AsRawFd, OwnedFd};
 use proptest::prelude::*;
 
 use super::{
-    PumpError, WriteOutcome, handle_write, map_short_write_error, read_raw_fd, read_raw_fd_with,
-    read_stream, write_all_unix_with,
+    PumpError, WriteOutcome, classify_write_outcome, handle_write, map_short_write_error,
+    read_raw_fd, read_raw_fd_with, read_stream, write_all_unix_with,
 };
+use crate::pump_machine::WriteEvent;
 use crate::test_support::{make_pipe, unwrap_err, unwrap_ok, write_all_to};
 use rstest::{fixture, rstest};
 
@@ -230,4 +231,35 @@ proptest! {
             Err(_) => prop_assert!(!is_nonfatal_kind(kind)),
         }
     }
+}
+
+#[rstest]
+#[case::zero_bytes(0)]
+#[case::positive_bytes(7)]
+fn classify_write_outcome_maps_nonfatal_short_write_to_closed(#[case] accepted: u64) {
+    // A non-fatal short write latches the writer closed while preserving the
+    // bytes accepted before the pipe broke — including none at all.
+    let event = unwrap_ok(classify_write_outcome(Ok(
+        WriteOutcome::NonFatalShortWrite(accepted),
+    )));
+
+    assert_eq!(event, WriteEvent::Closed { bytes: accepted });
+}
+
+#[test]
+fn classify_write_outcome_maps_complete_write_to_complete() {
+    let event = unwrap_ok(classify_write_outcome(Ok(WriteOutcome::Complete(5))));
+
+    assert_eq!(event, WriteEvent::Complete { bytes: 5 });
+}
+
+#[test]
+fn classify_write_outcome_propagates_fatal_errors() {
+    // map_short_write_error has already absorbed the non-fatal partition, so
+    // every error arriving here is fatal and must not latch the writer closed.
+    let err = unwrap_err(classify_write_outcome(Err(PumpError::from(
+        io::Error::from(io::ErrorKind::PermissionDenied),
+    ))));
+
+    assert!(matches!(err, PumpError::Io(_)));
 }

--- a/rust/cuprum-rust/src/io_utils/tests.rs
+++ b/rust/cuprum-rust/src/io_utils/tests.rs
@@ -6,8 +6,8 @@ use std::os::fd::{AsRawFd, OwnedFd};
 use proptest::prelude::*;
 
 use super::{
-    PumpError, WriteOutcome, handle_write, handle_write_result, map_short_write_error, read_raw_fd,
-    read_raw_fd_with, read_stream, write_all_unix_with,
+    PumpError, WriteOutcome, handle_write, map_short_write_error, read_raw_fd, read_raw_fd_with,
+    read_stream, write_all_unix_with,
 };
 use crate::test_support::{make_pipe, unwrap_err, unwrap_ok, write_all_to};
 use rstest::{fixture, rstest};
@@ -111,39 +111,6 @@ fn handle_write_reports_unwritable_descriptor(pipe: (OwnedFd, OwnedFd)) {
     let err = unwrap_err(handle_write(&mut read_end, b"chunk"));
 
     assert!(matches!(err, PumpError::Io(_)));
-}
-
-/// Call [`handle_write_result`] with `b"chunk"` starting from
-/// `initial_total` and return both the call's result and the
-/// (possibly updated) total.
-fn run_handle_write_result(
-    writer: &mut OwnedFd,
-    initial_total: u64,
-) -> (Result<bool, PumpError>, u64) {
-    let mut total_written = initial_total;
-    let result = handle_write_result(writer, b"chunk", &mut total_written);
-    (result, total_written)
-}
-
-#[rstest]
-fn handle_write_result_updates_total_on_success(pipe: (OwnedFd, OwnedFd)) {
-    let (read_end, mut write_end) = pipe;
-
-    let (result, total_written) = run_handle_write_result(&mut write_end, 7);
-
-    assert!(unwrap_ok(result));
-    assert_eq!(total_written, 12);
-    drop(read_end);
-}
-
-#[rstest]
-fn handle_write_result_preserves_total_on_fatal_error(pipe: (OwnedFd, OwnedFd)) {
-    let (mut read_end, _write_end) = pipe;
-
-    let (result, total_written) = run_handle_write_result(&mut read_end, 7);
-
-    assert!(matches!(unwrap_err(result), PumpError::Io(_)));
-    assert_eq!(total_written, 7);
 }
 
 #[test]

--- a/rust/cuprum-rust/src/io_utils/tests.rs
+++ b/rust/cuprum-rust/src/io_utils/tests.rs
@@ -6,8 +6,8 @@ use std::os::fd::{AsRawFd, OwnedFd};
 use proptest::prelude::*;
 
 use super::{
-    PumpError, WriteOutcome, classify_write_outcome, handle_write, map_short_write_error,
-    read_raw_fd, read_raw_fd_with, read_stream, write_all_unix_with,
+    PumpError, WriteOutcome, classify_write_outcome, classify_write_with, handle_write,
+    map_short_write_error, read_raw_fd, read_raw_fd_with, read_stream, write_all_unix_with,
 };
 use crate::pump_machine::WriteEvent;
 use crate::test_support::{make_pipe, unwrap_err, unwrap_ok, write_all_to};
@@ -260,6 +260,79 @@ fn classify_write_outcome_propagates_fatal_errors() {
     let err = unwrap_err(classify_write_outcome(Err(PumpError::from(
         io::Error::from(io::ErrorKind::PermissionDenied),
     ))));
+
+    assert!(matches!(err, PumpError::Io(_)));
+}
+
+/// Both non-fatal mappings, driven through `classify_write`'s own pipeline.
+///
+/// These go through [`classify_write_with`], which is what `classify_write`
+/// itself calls with the real `write(2)`; only the syscall differs. So the
+/// partial-write loop, the non-fatal error partitioning in
+/// `map_short_write_error`, and the outcome mapping all run exactly as they do
+/// in production — unlike a test that hands `classify_write_outcome` a
+/// pre-built `WriteOutcome` and therefore skips the two steps that produce it.
+///
+/// The short-write case cannot be forced through a real descriptor: it needs
+/// the peer to close *after* the kernel has accepted some bytes but before the
+/// rest, which no test can schedule deterministically.
+#[rstest]
+#[case::non_fatal_after_partial_progress(io::ErrorKind::BrokenPipe, 3, 3)]
+#[case::non_fatal_before_any_progress(io::ErrorKind::BrokenPipe, 0, 0)]
+#[case::reset_after_partial_progress(io::ErrorKind::ConnectionReset, 2, 2)]
+#[case::reset_before_any_progress(io::ErrorKind::ConnectionReset, 0, 0)]
+fn classify_write_latches_closed_carrying_accepted_bytes(
+    #[case] kind: io::ErrorKind,
+    #[case] accepted: usize,
+    #[case] expected_bytes: u64,
+) {
+    let chunk = b"chunk-of-bytes";
+    assert!(
+        accepted < chunk.len(),
+        "the injected write must stop short of the whole chunk",
+    );
+
+    // Accept `accepted` bytes on the first call, then fail non-fatally. With
+    // `accepted == 0` the failure precedes any progress.
+    let mut calls = 0_u32;
+    let event = unwrap_ok(classify_write_with(chunk, |_buffer| {
+        calls += 1;
+        if calls == 1 && accepted > 0 {
+            Ok(libc::ssize_t::try_from(accepted).unwrap_or(0))
+        } else {
+            Err(io::Error::from(kind))
+        }
+    }));
+
+    assert_eq!(
+        event,
+        WriteEvent::Closed {
+            bytes: expected_bytes
+        },
+        "a non-fatal write must latch the writer closed carrying the bytes it accepted",
+    );
+}
+
+/// A completed write through the same seam reports the full byte count and
+/// does not latch the writer closed.
+#[rstest]
+fn classify_write_with_reports_a_completed_write() {
+    let chunk = b"chunk";
+
+    let event = unwrap_ok(classify_write_with(chunk, |buffer| {
+        Ok(libc::ssize_t::try_from(buffer.len()).unwrap_or(0))
+    }));
+
+    assert_eq!(event, WriteEvent::Complete { bytes: 5 });
+}
+
+/// A fatal error is not swallowed by the non-fatal partition: it propagates
+/// out of `classify_write` rather than latching the writer closed.
+#[rstest]
+fn classify_write_with_propagates_a_fatal_error() {
+    let err = unwrap_err(classify_write_with(b"chunk", |_buffer| {
+        Err(io::Error::from(io::ErrorKind::PermissionDenied))
+    }));
 
     assert!(matches!(err, PumpError::Io(_)));
 }

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -42,7 +42,7 @@ mod utf8;
 
 use errors::PumpError;
 use io_utils::{StreamHandle, classify_write, operation_span, read_stream};
-use pump_machine::{Flow, PumpState, ReadEvent, step};
+use pump_machine::{Flow, PumpState, ReadEvent, drive_step};
 use utf8::{FinalChunk, decode_utf8_replace};
 
 /// Report whether the Rust extension is available.
@@ -309,19 +309,18 @@ fn pump_stream_files_readwrite(
             ReadEvent::Chunk
         };
 
-        // Write only when a chunk arrives while the writer is open; a closed
-        // writer just drains the reader. Fatal writes propagate the real error
+        // `drive_step` owns the write precondition — a chunk read while the
+        // writer is still open — so this loop and the machine's property tests
+        // share one definition of it. Fatal writes propagate the real error
         // and never reach the pure state machine.
-        let write = if read == ReadEvent::Chunk && state.writer_open() {
+        let flow = drive_step(&mut state, read, || {
             let chunk = buffer
                 .get(..read_len)
                 .ok_or(PumpError::BufferRangeExceeded)?;
-            Some(classify_write(writer, chunk)?)
-        } else {
-            None
-        };
+            classify_write(writer, chunk)
+        })?;
 
-        if step(&mut state, read, write) == Flow::Stop {
+        if flow == Flow::Stop {
             break;
         }
     }

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -309,6 +309,8 @@ fn pump_stream_files_readwrite(
             ReadEvent::Chunk
         };
 
+        let writer_was_open = state.writer_open();
+
         // `drive_step` owns the write precondition — a chunk read while the
         // writer is still open — so this loop and the machine's property tests
         // share one definition of it. Fatal writes propagate the real error
@@ -319,6 +321,16 @@ fn pump_stream_files_readwrite(
                 .ok_or(PumpError::BufferRangeExceeded)?;
             classify_write(writer, chunk)
         })?;
+
+        // The latch closing is the `head`-style early exit. Mirror splice's
+        // field and message so the event is not visible on one path only, and
+        // observe it here rather than in the deliberately pure `pump_machine`.
+        if writer_was_open && !state.writer_open() {
+            tracing::debug!(
+                bytes_transferred = state.total_written(),
+                "broken pipe; draining reader"
+            );
+        }
 
         if flow == Flow::Stop {
             break;

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -31,6 +31,7 @@ mod fd_tests;
 mod io_utils;
 #[cfg(all(test, unix))]
 mod lib_tests;
+mod pump_machine;
 #[cfg(target_os = "linux")]
 mod splice;
 #[cfg(all(test, unix))]
@@ -40,7 +41,8 @@ mod tracing_capture;
 mod utf8;
 
 use errors::PumpError;
-use io_utils::{StreamHandle, handle_write_result, operation_span, read_stream};
+use io_utils::{StreamHandle, WriteOutcome, handle_write, operation_span, read_stream};
+use pump_machine::{Flow, PumpState, ReadEvent, WriteEvent, step};
 use utf8::{FinalChunk, decode_utf8_replace};
 
 /// Report whether the Rust extension is available.
@@ -297,29 +299,52 @@ fn pump_stream_files_readwrite(
     io_utils::reset_retry_counters();
 
     let mut buffer = vec![0_u8; buffer_size.value()];
-    let mut total_written = 0_u64;
-    let mut writer_open = true;
+    let mut state = PumpState::start();
 
     loop {
         let read_len = read_stream(reader, &mut buffer)?;
-        if read_len == 0 {
+        let read = if read_len == 0 {
+            ReadEvent::Eof
+        } else {
+            ReadEvent::Chunk
+        };
+
+        // Write only when a chunk arrives while the writer is open; a closed
+        // writer just drains the reader. Fatal writes propagate the real error
+        // and never reach the pure state machine.
+        let write = if read == ReadEvent::Chunk && state.writer_open() {
+            let chunk = buffer
+                .get(..read_len)
+                .ok_or(PumpError::BufferRangeExceeded)?;
+            Some(classify_write(writer, chunk)?)
+        } else {
+            None
+        };
+
+        if step(&mut state, read, write) == Flow::Stop {
             break;
         }
-        if !writer_open {
-            continue;
-        }
-
-        let chunk = buffer
-            .get(..read_len)
-            .ok_or(PumpError::BufferRangeExceeded)?;
-
-        writer_open = handle_write_result(writer, chunk, &mut total_written)?;
     }
 
+    let total_written = state.total_written();
     span.record("total_bytes", total_written);
     span.record("read_retries", io_utils::read_retry_count());
     span.record("write_retries", io_utils::write_retry_count());
     Ok(total_written)
+}
+
+/// Attempt one write and classify it into a non-fatal [`WriteEvent`].
+///
+/// Fatal write failures propagate as [`PumpError`]. Non-fatal broken-pipe and
+/// connection-reset failures latch the writer closed, carrying the bytes
+/// accepted before the failure (zero when it preceded any progress).
+fn classify_write(writer: &mut StreamHandle, chunk: &[u8]) -> Result<WriteEvent, PumpError> {
+    match handle_write(writer, chunk) {
+        Ok(WriteOutcome::Complete(bytes)) => Ok(WriteEvent::Complete { bytes }),
+        Ok(WriteOutcome::NonFatalShortWrite(bytes)) => Ok(WriteEvent::Closed { bytes }),
+        Err(err) if err.is_nonfatal_write() => Ok(WriteEvent::Closed { bytes: 0 }),
+        Err(err) => Err(err),
+    }
 }
 
 fn consume_stream_files(

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -41,8 +41,8 @@ mod tracing_capture;
 mod utf8;
 
 use errors::PumpError;
-use io_utils::{StreamHandle, WriteOutcome, handle_write, operation_span, read_stream};
-use pump_machine::{Flow, PumpState, ReadEvent, WriteEvent, step};
+use io_utils::{StreamHandle, classify_write, operation_span, read_stream};
+use pump_machine::{Flow, PumpState, ReadEvent, step};
 use utf8::{FinalChunk, decode_utf8_replace};
 
 /// Report whether the Rust extension is available.
@@ -331,20 +331,6 @@ fn pump_stream_files_readwrite(
     span.record("read_retries", io_utils::read_retry_count());
     span.record("write_retries", io_utils::write_retry_count());
     Ok(total_written)
-}
-
-/// Attempt one write and classify it into a non-fatal [`WriteEvent`].
-///
-/// Fatal write failures propagate as [`PumpError`]. Non-fatal broken-pipe and
-/// connection-reset failures latch the writer closed, carrying the bytes
-/// accepted before the failure (zero when it preceded any progress).
-fn classify_write(writer: &mut StreamHandle, chunk: &[u8]) -> Result<WriteEvent, PumpError> {
-    match handle_write(writer, chunk) {
-        Ok(WriteOutcome::Complete(bytes)) => Ok(WriteEvent::Complete { bytes }),
-        Ok(WriteOutcome::NonFatalShortWrite(bytes)) => Ok(WriteEvent::Closed { bytes }),
-        Err(err) if err.is_nonfatal_write() => Ok(WriteEvent::Closed { bytes: 0 }),
-        Err(err) => Err(err),
-    }
 }
 
 fn consume_stream_files(

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -42,7 +42,7 @@ mod utf8;
 
 use errors::PumpError;
 use io_utils::{StreamHandle, classify_write, operation_span, read_stream};
-use pump_machine::{Flow, PumpState, ReadEvent, drive_step};
+use pump_machine::{Flow, PumpState, advance};
 use utf8::{FinalChunk, decode_utf8_replace};
 
 /// Report whether the Rust extension is available.
@@ -303,19 +303,14 @@ fn pump_stream_files_readwrite(
 
     loop {
         let read_len = read_stream(reader, &mut buffer)?;
-        let read = if read_len == 0 {
-            ReadEvent::Eof
-        } else {
-            ReadEvent::Chunk
-        };
-
         let writer_was_open = state.writer_open();
 
-        // `drive_step` owns the write precondition — a chunk read while the
-        // writer is still open — so this loop and the machine's property tests
-        // share one definition of it. Fatal writes propagate the real error
-        // and never reach the pure state machine.
-        let flow = drive_step(&mut state, read, || {
+        // `advance` owns both the zero-length-is-EOF translation and the write
+        // precondition — a chunk read while the writer is still open — so this
+        // loop, the property tests, and the bounded proofs share one
+        // definition of them. Fatal writes propagate the real error and never
+        // reach the pure state machine.
+        let flow = advance(&mut state, read_len, || {
             let chunk = buffer
                 .get(..read_len)
                 .ok_or(PumpError::BufferRangeExceeded)?;

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -265,8 +265,13 @@ fn pump_drains_the_reader_after_the_writer_breaks() {
     // splice path reports it, so the read/write fallback must too, or the same
     // hang-up is diagnosable on one path and silent on the other.
     assert!(
-        captured.event_has_fields(Level::DEBUG, &["bytes_transferred"]),
-        "the writer-close latch must report the hang-up with its byte total",
+        captured.event_matches(
+            Level::DEBUG,
+            "broken pipe; draining reader",
+            &[("bytes_transferred", "0")],
+        ),
+        "the writer-close latch must report the hang-up by name, with the zero \
+         byte total that reached the hung-up downstream",
     );
 
     // The reader must have been drained to EOF: a further read returns zero

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -4,11 +4,13 @@ use std::io::Read;
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
+use crate::errors::PumpError;
 use crate::io_utils::read_stream;
+use crate::pump_machine::WriteEvent;
 use crate::test_support::{fd_is_open, make_pipe, read_all_from, write_all_to};
 use crate::tracing_capture::capture;
 use crate::{
-    BufferSize, consume_stream_files, pump_stream_files_readwrite, stream_from_raw,
+    BufferSize, classify_write, consume_stream_files, pump_stream_files_readwrite, stream_from_raw,
     with_borrowed_reader,
 };
 use rstest::{fixture, rstest};
@@ -180,6 +182,32 @@ fn assert_panicking_reader_keeps_fd_open(raw_fd: i32) {
     }));
 
     assert!(outcome.is_err(), "the panic must propagate to the caller");
+}
+
+#[rstest]
+fn classify_write_reports_a_completed_write() {
+    let (read_end, mut write_end) = make_pipe();
+
+    let event = match classify_write(&mut write_end, b"chunk") {
+        Ok(event) => event,
+        Err(err) => panic!("write to an open pipe failed: {err:?}"),
+    };
+
+    assert_eq!(event, WriteEvent::Complete { bytes: 5 });
+    // Keep the read end open until after the write so the pipe never breaks.
+    drop(read_end);
+}
+
+#[rstest]
+fn classify_write_propagates_a_fatal_error() {
+    // Writing to the read end of a pipe is a fatal `EBADF`, which must
+    // propagate rather than latch the writer closed.
+    let (mut read_end, _write_end) = make_pipe();
+
+    match classify_write(&mut read_end, b"chunk") {
+        Ok(event) => panic!("expected a fatal write error, got {event:?}"),
+        Err(err) => assert!(matches!(err, PumpError::Io(_))),
+    }
 }
 
 fn assert_successful_reader_keeps_fd_usable(raw_fd: i32, write_end: OwnedFd) {

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -228,3 +228,45 @@ fn assert_successful_reader_keeps_fd_usable(raw_fd: i32, write_end: OwnedFd) {
 
     assert_eq!(collected, b"ping");
 }
+
+#[rstest]
+fn pump_drains_the_reader_after_the_writer_breaks() {
+    // The downstream stage hangs up before the pump writes anything, which is
+    // the real-world `head`-style early exit. The loop must latch the writer
+    // closed, keep draining the upstream reader to EOF, and report success
+    // with the bytes that actually reached the sink — none, here.
+    let (source_read, source_write) = make_pipe();
+    let (sink_read, sink_write) = make_pipe();
+    let payload = b"payload-written-after-the-downstream-hangs-up";
+    write_all_to(&source_write, payload);
+    // Close the source's write end so the read loop can reach EOF.
+    drop(source_write);
+    // Close the sink's read end so every write fails with a broken pipe.
+    drop(sink_read);
+
+    let mut reader = source_read;
+    let mut writer = sink_write;
+    // A small buffer forces several read iterations, so the drain path runs
+    // repeatedly after the writer has latched closed rather than just once.
+    let total = match pump_stream_files_readwrite(&mut reader, &mut writer, BufferSize(8)) {
+        Ok(total) => total,
+        Err(err) => panic!("a broken downstream pipe must not fail the pump: {err:?}"),
+    };
+
+    assert_eq!(
+        total, 0,
+        "no bytes reach a downstream that hung up before the first write",
+    );
+
+    // The reader must have been drained to EOF: a further read returns zero
+    // rather than the bytes the pump skipped.
+    let mut buffer = [0_u8; 8];
+    let remaining = match read_stream(&mut reader, &mut buffer) {
+        Ok(remaining) => remaining,
+        Err(err) => panic!("reading the drained source failed: {err:?}"),
+    };
+    assert_eq!(
+        remaining, 0,
+        "the pump must drain the upstream reader to EOF after the writer breaks",
+    );
+}

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -5,12 +5,12 @@ use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use crate::errors::PumpError;
-use crate::io_utils::read_stream;
+use crate::io_utils::{classify_write, read_stream};
 use crate::pump_machine::WriteEvent;
 use crate::test_support::{fd_is_open, make_pipe, read_all_from, write_all_to};
 use crate::tracing_capture::capture;
 use crate::{
-    BufferSize, classify_write, consume_stream_files, pump_stream_files_readwrite, stream_from_raw,
+    BufferSize, consume_stream_files, pump_stream_files_readwrite, stream_from_raw,
     with_borrowed_reader,
 };
 use rstest::{fixture, rstest};

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -248,14 +248,25 @@ fn pump_drains_the_reader_after_the_writer_breaks() {
     let mut writer = sink_write;
     // A small buffer forces several read iterations, so the drain path runs
     // repeatedly after the writer has latched closed rather than just once.
-    let total = match pump_stream_files_readwrite(&mut reader, &mut writer, BufferSize(8)) {
-        Ok(total) => total,
-        Err(err) => panic!("a broken downstream pipe must not fail the pump: {err:?}"),
-    };
+    let mut total = 0_u64;
+    let captured = capture(Level::DEBUG, || {
+        total = match pump_stream_files_readwrite(&mut reader, &mut writer, BufferSize(8)) {
+            Ok(delivered) => delivered,
+            Err(err) => panic!("a broken downstream pipe must not fail the pump: {err:?}"),
+        };
+    });
 
     assert_eq!(
         total, 0,
         "no bytes reach a downstream that hung up before the first write",
+    );
+
+    // The latch closing is an operational event, not just internal state: the
+    // splice path reports it, so the read/write fallback must too, or the same
+    // hang-up is diagnosable on one path and silent on the other.
+    assert!(
+        captured.event_has_fields(Level::DEBUG, &["bytes_transferred"]),
+        "the writer-close latch must report the hang-up with its byte total",
     );
 
     // The reader must have been drained to EOF: a further read returns zero

--- a/rust/cuprum-rust/src/pump_machine.rs
+++ b/rust/cuprum-rust/src/pump_machine.rs
@@ -177,6 +177,7 @@ mod tests {
     use std::convert::Infallible;
 
     use proptest::prelude::*;
+    use rstest::rstest;
 
     use super::{Flow, PumpState, ReadEvent, WriteEvent, drive_step};
 
@@ -207,21 +208,6 @@ mod tests {
             Ok(flow) => (flow, invoked),
             Err(never) => match never {},
         }
-    }
-
-    #[test]
-    fn drive_step_skips_the_write_at_eof() {
-        let mut state = PumpState::start();
-
-        let (flow, invoked) = drive_counting(
-            &mut state,
-            ReadEvent::Eof,
-            WriteEvent::Complete { bytes: 4 },
-        );
-
-        assert_eq!(flow, Flow::Stop);
-        assert!(!invoked, "EOF must not attempt a write");
-        assert_eq!(state.total_written(), 0, "EOF must accrue no bytes");
     }
 
     #[test]
@@ -256,22 +242,31 @@ mod tests {
         );
     }
 
-    #[test]
-    fn drive_step_performs_the_write_for_a_chunk_while_open() {
+    /// From the starting state, the read event alone decides whether the write
+    /// runs: a chunk drives it, EOF stops the loop without attempting one.
+    #[rstest]
+    #[case::chunk_while_open(ReadEvent::Chunk, Flow::Continue, true, 4)]
+    #[case::eof(ReadEvent::Eof, Flow::Stop, false, 0)]
+    fn drive_step_writes_only_for_a_chunk_while_open(
+        #[case] read: ReadEvent,
+        #[case] expected_flow: Flow,
+        #[case] expected_invoked: bool,
+        #[case] expected_total: u64,
+    ) {
         let mut state = PumpState::start();
 
-        let (flow, invoked) = drive_counting(
-            &mut state,
-            ReadEvent::Chunk,
-            WriteEvent::Complete { bytes: 4 },
-        );
+        let (flow, invoked) = drive_counting(&mut state, read, WriteEvent::Complete { bytes: 4 });
 
-        assert_eq!(flow, Flow::Continue);
-        assert!(
-            invoked,
-            "an open writer receiving a chunk must be written to"
+        assert_eq!(flow, expected_flow, "unexpected flow for {read:?}");
+        assert_eq!(
+            invoked, expected_invoked,
+            "the write must run only for a chunk read while the writer is open",
         );
-        assert_eq!(state.total_written(), 4);
+        assert_eq!(
+            state.total_written(),
+            expected_total,
+            "only a performed write may accrue bytes",
+        );
     }
 
     fn read_event() -> impl Strategy<Value = ReadEvent> {

--- a/rust/cuprum-rust/src/pump_machine.rs
+++ b/rust/cuprum-rust/src/pump_machine.rs
@@ -180,6 +180,31 @@ fn apply_write(state: &mut PumpState, write: WriteEvent) {
     }
 }
 
+/// Drive one iteration with a fixed write outcome, reporting whether the write
+/// actually ran.
+///
+/// Shared by the proptest harness and the Kani proofs so a change to
+/// [`advance`]'s signature cannot leave one of them driving the machine
+/// differently from the other — which is precisely how a harness stops testing
+/// what it claims to.
+///
+/// Whether the write was *invoked* is the observable that matters: `advance`
+/// promises not to call it at all when the transition forbids one, and the
+/// resulting state alone cannot distinguish "never called" from "called and
+/// its result discarded".
+#[cfg(any(test, kani))]
+pub(crate) fn drive(state: &mut PumpState, read_len: usize, write: WriteEvent) -> (Flow, bool) {
+    let mut invoked = false;
+    let outcome = advance(state, read_len, || {
+        invoked = true;
+        Ok::<WriteEvent, std::convert::Infallible>(write)
+    });
+    match outcome {
+        Ok(flow) => (flow, invoked),
+        Err(never) => match never {},
+    }
+}
+
 #[cfg(test)]
 #[path = "pump_machine_tests.rs"]
 mod tests;

--- a/rust/cuprum-rust/src/pump_machine.rs
+++ b/rust/cuprum-rust/src/pump_machine.rs
@@ -1,0 +1,211 @@
+//! Pure, `io::Error`-free model of the read/write pump loop.
+//!
+//! [`pump_stream_files_readwrite`](crate::pump_stream_files_readwrite) drives
+//! real descriptor I/O, but its bug-prone logic is pure: how a read outcome and
+//! a write outcome move the running byte total and the latched `writer_open`
+//! flag. Extracting that decision here lets it be checked exhaustively with
+//! proptest and Kani, free of descriptors and `io::Error`.
+//!
+//! Fatal read and write errors are handled by the caller — they short-circuit
+//! the loop by propagating the real [`PumpError`](crate::errors::PumpError), so
+//! they never reach this machine. It models only the non-fatal transitions:
+//! reading a chunk, reaching EOF, a completed write, and the non-fatal
+//! broken-pipe write that latches the writer closed.
+
+/// The non-fatal outcome of a read from the upstream descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ReadEvent {
+    /// A non-empty chunk was read.
+    Chunk,
+    /// The read returned zero bytes: end of input.
+    Eof,
+}
+
+/// The non-fatal outcome of writing a chunk while the writer is open.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WriteEvent {
+    /// The whole chunk was accepted: `bytes` written and the writer stays open.
+    Complete { bytes: u64 },
+    /// A broken pipe or connection reset accepted `bytes` (possibly zero)
+    /// before the writer latched closed.
+    Closed { bytes: u64 },
+}
+
+/// The running state of the pump loop.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PumpState {
+    total_written: u64,
+    writer_open: bool,
+}
+
+impl PumpState {
+    /// The initial state: nothing written yet, writer open.
+    pub(crate) const fn start() -> Self {
+        Self {
+            total_written: 0,
+            writer_open: true,
+        }
+    }
+
+    /// Build a state directly from its parts, for exhaustive verification from
+    /// an arbitrary starting point.
+    #[cfg(kani)]
+    pub(crate) const fn from_parts(total_written: u64, writer_open: bool) -> Self {
+        Self {
+            total_written,
+            writer_open,
+        }
+    }
+
+    /// Bytes confirmed written downstream so far.
+    pub(crate) const fn total_written(self) -> u64 {
+        self.total_written
+    }
+
+    /// Whether the writer is still accepting data.
+    pub(crate) const fn writer_open(self) -> bool {
+        self.writer_open
+    }
+}
+
+/// Whether the pump loop continues or stops after an iteration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Flow {
+    /// Keep reading.
+    Continue,
+    /// Stop: the read reached EOF.
+    Stop,
+}
+
+/// Advance the pump state by one loop iteration.
+///
+/// `write` carries the write outcome iff the caller performed a write this
+/// iteration — that is, iff `read` is a [`ReadEvent::Chunk`] and the writer is
+/// open. On EOF, or when a chunk is read while the writer has already latched
+/// closed (the reader drain), `write` is `None`.
+///
+/// A closed writer never reopens and never accrues more bytes: once the writer
+/// latches closed, further chunk reads only drain the upstream reader.
+pub(crate) fn step(state: &mut PumpState, read: ReadEvent, write: Option<WriteEvent>) -> Flow {
+    match read {
+        ReadEvent::Eof => Flow::Stop,
+        ReadEvent::Chunk => {
+            if state.writer_open {
+                if let Some(event) = write {
+                    apply_write(state, event);
+                }
+            }
+            // A closed writer drains the reader: the state is left unchanged.
+            Flow::Continue
+        }
+    }
+}
+
+/// Apply a write outcome to the running total and the `writer_open` latch.
+fn apply_write(state: &mut PumpState, write: WriteEvent) {
+    match write {
+        WriteEvent::Complete { bytes } => {
+            state.total_written = state.total_written.saturating_add(bytes);
+        }
+        WriteEvent::Closed { bytes } => {
+            state.total_written = state.total_written.saturating_add(bytes);
+            state.writer_open = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Property tests for the pure pump state machine.
+
+    use proptest::prelude::*;
+
+    use super::{Flow, PumpState, ReadEvent, WriteEvent, step};
+
+    /// Drive one iteration exactly as `pump_stream_files_readwrite` does: a
+    /// write is applied only when a chunk is read while the writer is open.
+    fn drive(state: &mut PumpState, read: ReadEvent, write: WriteEvent) -> Flow {
+        let performs_write = matches!(read, ReadEvent::Chunk) && state.writer_open();
+        step(state, read, performs_write.then_some(write))
+    }
+
+    fn read_event() -> impl Strategy<Value = ReadEvent> {
+        prop_oneof![Just(ReadEvent::Chunk), Just(ReadEvent::Eof)]
+    }
+
+    fn write_event() -> impl Strategy<Value = WriteEvent> {
+        prop_oneof![
+            (0_u64..=1 << 20).prop_map(|bytes| WriteEvent::Complete { bytes }),
+            (0_u64..=1 << 20).prop_map(|bytes| WriteEvent::Closed { bytes }),
+        ]
+    }
+
+    proptest! {
+        /// Across any script of iterations the running total never decreases,
+        /// the writer never reopens once closed, a closed writer accrues no
+        /// further bytes, and the loop stops exactly on EOF.
+        #[test]
+        fn invariants_hold_across_iterations(
+            script in prop::collection::vec((read_event(), write_event()), 0..64),
+        ) {
+            let mut state = PumpState::start();
+            for (read, write) in script {
+                let before = state;
+                let flow = drive(&mut state, read, write);
+
+                prop_assert!(
+                    state.total_written() >= before.total_written(),
+                    "total bytes must be monotonic",
+                );
+                prop_assert!(
+                    before.writer_open() || !state.writer_open(),
+                    "a closed writer must never reopen",
+                );
+                if !before.writer_open() {
+                    prop_assert_eq!(
+                        state.total_written(),
+                        before.total_written(),
+                        "a closed writer must accrue no further bytes",
+                    );
+                }
+                prop_assert_eq!(
+                    flow == Flow::Stop,
+                    read == ReadEvent::Eof,
+                    "the loop stops exactly on EOF",
+                );
+                // EOF halts the loop before any further state change.
+                if read == ReadEvent::Eof {
+                    prop_assert_eq!(state, before, "EOF leaves the state unchanged");
+                }
+            }
+        }
+
+        /// Once a broken-pipe write latches the writer closed, no later write
+        /// outcome — however large — can increase the total again.
+        #[test]
+        fn writes_stop_after_broken_pipe(
+            accepted in 0_u64..=1 << 20,
+            tail in prop::collection::vec(write_event(), 0..32),
+        ) {
+            let mut state = PumpState::start();
+            // First chunk latches the writer closed via a non-fatal short write.
+            drive(&mut state, ReadEvent::Chunk, WriteEvent::Closed { bytes: accepted });
+            prop_assert!(!state.writer_open());
+            let latched_total = state.total_written();
+
+            for write in tail {
+                drive(&mut state, ReadEvent::Chunk, write);
+                prop_assert!(!state.writer_open(), "writer stays closed");
+                prop_assert_eq!(
+                    state.total_written(),
+                    latched_total,
+                    "no bytes are written after the pipe breaks",
+                );
+            }
+        }
+    }
+}
+
+#[cfg(kani)]
+#[path = "pump_machine_kani_proofs.rs"]
+mod kani_proofs;

--- a/rust/cuprum-rust/src/pump_machine.rs
+++ b/rust/cuprum-rust/src/pump_machine.rs
@@ -132,6 +132,31 @@ pub(crate) fn step(state: &mut PumpState, read: ReadEvent, write: Option<WriteEv
     }
 }
 
+/// Advance the machine for one loop iteration, writing only when permitted.
+///
+/// This owns the pump loop's write precondition: `write_once` runs **only**
+/// when a chunk was read and the writer is still open. On EOF, or once the
+/// writer has latched closed, no write is attempted and the iteration just
+/// drains the reader. Production and the property tests both drive the machine
+/// through here, so neither can reimplement that precondition differently.
+///
+/// # Errors
+///
+/// Propagates whatever `write_once` returns, so a fatal I/O failure aborts the
+/// iteration before the state is advanced.
+pub(crate) fn drive_step<E>(
+    state: &mut PumpState,
+    read: ReadEvent,
+    write_once: impl FnOnce() -> Result<WriteEvent, E>,
+) -> Result<Flow, E> {
+    let write = if read == ReadEvent::Chunk && state.writer_open() {
+        Some(write_once()?)
+    } else {
+        None
+    };
+    Ok(step(state, read, write))
+}
+
 /// Apply a write outcome to the running total and the `writer_open` latch.
 fn apply_write(state: &mut PumpState, write: WriteEvent) {
     match write {
@@ -149,15 +174,104 @@ fn apply_write(state: &mut PumpState, write: WriteEvent) {
 mod tests {
     //! Property tests for the pure pump state machine.
 
+    use std::convert::Infallible;
+
     use proptest::prelude::*;
 
-    use super::{Flow, PumpState, ReadEvent, WriteEvent, step};
+    use super::{Flow, PumpState, ReadEvent, WriteEvent, drive_step};
 
     /// Drive one iteration exactly as `pump_stream_files_readwrite` does: a
     /// write is applied only when a chunk is read while the writer is open.
     fn drive(state: &mut PumpState, read: ReadEvent, write: WriteEvent) -> Flow {
-        let performs_write = matches!(read, ReadEvent::Chunk) && state.writer_open();
-        step(state, read, performs_write.then_some(write))
+        // Delegate to the production helper so these properties exercise the
+        // same write precondition the pump loop uses, not a copy of it.
+        match drive_step(state, read, || Ok::<WriteEvent, Infallible>(write)) {
+            Ok(flow) => flow,
+            Err(never) => match never {},
+        }
+    }
+
+    /// Drive one iteration, reporting whether the write operation ran.
+    ///
+    /// `drive_step`'s distinctive guarantee over `step` is that it does not
+    /// *invoke* the write at all when the transition forbids one — `step`
+    /// separately ignores a write it is handed, so observing state alone
+    /// cannot tell the two apart.
+    fn drive_counting(state: &mut PumpState, read: ReadEvent, write: WriteEvent) -> (Flow, bool) {
+        let mut invoked = false;
+        let outcome = drive_step(state, read, || {
+            invoked = true;
+            Ok::<WriteEvent, Infallible>(write)
+        });
+        match outcome {
+            Ok(flow) => (flow, invoked),
+            Err(never) => match never {},
+        }
+    }
+
+    #[test]
+    fn drive_step_skips_the_write_at_eof() {
+        let mut state = PumpState::start();
+
+        let (flow, invoked) = drive_counting(
+            &mut state,
+            ReadEvent::Eof,
+            WriteEvent::Complete { bytes: 4 },
+        );
+
+        assert_eq!(flow, Flow::Stop);
+        assert!(!invoked, "EOF must not attempt a write");
+        assert_eq!(state.total_written(), 0, "EOF must accrue no bytes");
+    }
+
+    #[test]
+    fn drive_step_skips_the_write_once_the_writer_is_closed() {
+        let mut state = PumpState::start();
+        // Latch the writer closed with a non-fatal short write.
+        drive_counting(
+            &mut state,
+            ReadEvent::Chunk,
+            WriteEvent::Closed { bytes: 2 },
+        );
+        assert!(
+            !state.writer_open(),
+            "the broken pipe must latch the writer"
+        );
+
+        let (flow, invoked) = drive_counting(
+            &mut state,
+            ReadEvent::Chunk,
+            WriteEvent::Complete { bytes: 9 },
+        );
+
+        assert_eq!(flow, Flow::Continue, "a drained chunk keeps the loop going");
+        assert!(
+            !invoked,
+            "a closed writer must not be written to again; the chunk only drains the reader",
+        );
+        assert_eq!(
+            state.total_written(),
+            2,
+            "draining must not accrue further bytes",
+        );
+    }
+
+    #[test]
+    fn drive_step_performs_the_write_for_a_chunk_while_open() {
+        let mut state = PumpState::start();
+
+        let (flow, invoked) = drive_counting(
+            &mut state,
+            ReadEvent::Chunk,
+            WriteEvent::Complete { bytes: 4 },
+        );
+
+        assert_eq!(flow, Flow::Continue);
+        assert!(
+            invoked,
+            "an open writer receiving a chunk must be written to"
+        );
+        assert_eq!(state.total_written(), 4);
     }
 
     fn read_event() -> impl Strategy<Value = ReadEvent> {
@@ -182,7 +296,15 @@ mod tests {
             let mut state = PumpState::start();
             for (read, write) in script {
                 let before = state;
-                let flow = drive(&mut state, read, write);
+                let (flow, invoked) = drive_counting(&mut state, read, write);
+
+                // `drive_step` must invoke the write exactly when the
+                // transition permits one.
+                prop_assert_eq!(
+                    invoked,
+                    read == ReadEvent::Chunk && before.writer_open(),
+                    "the write runs only for a chunk read while the writer is open",
+                );
 
                 prop_assert!(
                     state.total_written() >= before.total_written(),

--- a/rust/cuprum-rust/src/pump_machine.rs
+++ b/rust/cuprum-rust/src/pump_machine.rs
@@ -157,6 +157,13 @@ pub(crate) fn advance<E>(
 /// [`advance`] is its only constructor. The precondition is enforced once,
 /// where the decision is made, rather than re-checked defensively at the point
 /// of use — a second check would silently mask a caller that got it wrong.
+///
+/// "Only constructor" holds only while [`Transition`] and this function stay
+/// private to the module, so that claim is pinned by the compile-fail case
+/// `tests/ui/fail/pump_transition_unreachable.rs`: it includes this file as a
+/// child module and shows the compiler refusing an attempt to build a
+/// transition and apply it from the parent. Widening either item, even to
+/// `pub(crate)`, makes that case fail.
 fn step(state: &mut PumpState, transition: Transition) -> Flow {
     match transition {
         Transition::Eof => Flow::Stop,

--- a/rust/cuprum-rust/src/pump_machine.rs
+++ b/rust/cuprum-rust/src/pump_machine.rs
@@ -12,11 +12,22 @@
 //! reading a chunk, reaching EOF, a completed write, and the non-fatal
 //! broken-pipe write that latches the writer closed.
 
-/// The non-fatal outcome of a read from the upstream descriptor.
+/// What one loop iteration did, in a form that cannot express an impossible
+/// combination.
+///
+/// The previous API took a read event and an `Option<WriteEvent>`
+/// independently, so a caller could pass a write for an EOF read, or a write
+/// performed after the writer had latched closed. Both were silently ignored,
+/// which left the precondition living in a doc comment and in whatever each
+/// caller happened to do. Here those states are not representable, and
+/// [`advance`] is the only constructor.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ReadEvent {
-    /// A non-empty chunk was read.
-    Chunk,
+enum Transition {
+    /// A chunk was read while the writer was open, and this write resulted.
+    Wrote(WriteEvent),
+    /// A chunk was read after the writer latched closed, so the iteration only
+    /// drains the upstream reader.
+    Drained,
     /// The read returned zero bytes: end of input.
     Eof,
 }
@@ -77,15 +88,25 @@ pub(crate) enum Flow {
     Stop,
 }
 
-/// Advance the pump state by one loop iteration.
+/// Advance the machine by one loop iteration, writing only when permitted.
 ///
-/// `write` carries the write outcome iff the caller performed a write this
-/// iteration — that is, iff `read` is a [`ReadEvent::Chunk`] and the writer is
-/// open. On EOF, or when a chunk is read while the writer has already latched
-/// closed (the reader drain), `write` is `None`.
+/// This is the pump's whole transition policy and the only production entry
+/// point into the machine. It translates the raw read length — zero bytes is
+/// end of input, anything else is a chunk — and runs `write_once` **only**
+/// when a chunk was read while the writer is still open. On EOF, or once the
+/// writer has latched closed, no write is attempted and the iteration merely
+/// drains the reader.
 ///
-/// A closed writer never reopens and never accrues more bytes: once the writer
-/// latches closed, further chunk reads only drain the upstream reader.
+/// Keeping the length translation and the write precondition together here
+/// means the pump loop, the property tests, and the bounded proofs exercise
+/// one definition of them rather than three copies.
+///
+/// A closed writer never reopens and never accrues more bytes.
+///
+/// # Errors
+///
+/// Propagates whatever `write_once` returns, so a fatal I/O failure aborts the
+/// iteration before the state is advanced.
 ///
 /// # Examples
 ///
@@ -93,70 +114,59 @@ pub(crate) enum Flow {
 ///
 /// ```rust,ignore
 /// let mut state = PumpState::start();
-/// let flow = step(
-///     &mut state,
-///     ReadEvent::Chunk,
-///     Some(WriteEvent::Complete { bytes: 5 }),
-/// );
+/// let flow = advance(&mut state, 5, || {
+///     Ok::<_, Infallible>(WriteEvent::Complete { bytes: 5 })
+/// })?;
 /// assert_eq!(flow, Flow::Continue);
 /// assert_eq!(state.total_written(), 5);
 /// assert!(state.writer_open());
 /// ```
 ///
 /// A broken pipe latches the writer closed, after which chunk reads drain the
-/// reader without accruing bytes, and EOF stops the loop:
+/// reader without writing again, and a zero-length read stops the loop:
 ///
 /// ```rust,ignore
-/// let mut state = PumpState::start();
-/// step(&mut state, ReadEvent::Chunk, Some(WriteEvent::Closed { bytes: 2 }));
+/// advance(&mut state, 4, || Ok::<_, Infallible>(WriteEvent::Closed { bytes: 2 }))?;
 /// assert!(!state.writer_open());
 ///
-/// // The writer is closed, so the caller performs no write: `write` is `None`.
-/// step(&mut state, ReadEvent::Chunk, None);
+/// // The writer is closed, so this closure is never called.
+/// advance(&mut state, 4, || unreachable!("a closed writer is never written to"))?;
 /// assert_eq!(state.total_written(), 2, "a drained chunk adds nothing");
 ///
-/// assert_eq!(step(&mut state, ReadEvent::Eof, None), Flow::Stop);
+/// assert_eq!(advance(&mut state, 0, || unreachable!())?, Flow::Stop);
 /// ```
-pub(crate) fn step(state: &mut PumpState, read: ReadEvent, write: Option<WriteEvent>) -> Flow {
-    match read {
-        ReadEvent::Eof => Flow::Stop,
-        ReadEvent::Chunk => {
-            if state.writer_open {
-                if let Some(event) = write {
-                    apply_write(state, event);
-                }
-            }
-            // A closed writer drains the reader: the state is left unchanged.
+pub(crate) fn advance<E>(
+    state: &mut PumpState,
+    read_len: usize,
+    write_once: impl FnOnce() -> Result<WriteEvent, E>,
+) -> Result<Flow, E> {
+    let transition = if read_len == 0 {
+        Transition::Eof
+    } else if state.writer_open() {
+        Transition::Wrote(write_once()?)
+    } else {
+        Transition::Drained
+    };
+    Ok(step(state, transition))
+}
+
+/// Apply one transition to the state and report whether the loop continues.
+///
+/// There is deliberately no `writer_open` check here: [`Transition::Wrote`]
+/// can only exist for a chunk read while the writer was open, because
+/// [`advance`] is its only constructor. The precondition is enforced once,
+/// where the decision is made, rather than re-checked defensively at the point
+/// of use — a second check would silently mask a caller that got it wrong.
+fn step(state: &mut PumpState, transition: Transition) -> Flow {
+    match transition {
+        Transition::Eof => Flow::Stop,
+        Transition::Drained => Flow::Continue,
+        Transition::Wrote(event) => {
+            apply_write(state, event);
             Flow::Continue
         }
     }
 }
-
-/// Advance the machine for one loop iteration, writing only when permitted.
-///
-/// This owns the pump loop's write precondition: `write_once` runs **only**
-/// when a chunk was read and the writer is still open. On EOF, or once the
-/// writer has latched closed, no write is attempted and the iteration just
-/// drains the reader. Production and the property tests both drive the machine
-/// through here, so neither can reimplement that precondition differently.
-///
-/// # Errors
-///
-/// Propagates whatever `write_once` returns, so a fatal I/O failure aborts the
-/// iteration before the state is advanced.
-pub(crate) fn drive_step<E>(
-    state: &mut PumpState,
-    read: ReadEvent,
-    write_once: impl FnOnce() -> Result<WriteEvent, E>,
-) -> Result<Flow, E> {
-    let write = if read == ReadEvent::Chunk && state.writer_open() {
-        Some(write_once()?)
-    } else {
-        None
-    };
-    Ok(step(state, read, write))
-}
-
 /// Apply a write outcome to the running total and the `writer_open` latch.
 fn apply_write(state: &mut PumpState, write: WriteEvent) {
     match write {
@@ -171,188 +181,8 @@ fn apply_write(state: &mut PumpState, write: WriteEvent) {
 }
 
 #[cfg(test)]
-mod tests {
-    //! Property tests for the pure pump state machine.
-
-    use std::convert::Infallible;
-
-    use proptest::prelude::*;
-    use rstest::rstest;
-
-    use super::{Flow, PumpState, ReadEvent, WriteEvent, drive_step};
-
-    /// Drive one iteration exactly as `pump_stream_files_readwrite` does: a
-    /// write is applied only when a chunk is read while the writer is open.
-    fn drive(state: &mut PumpState, read: ReadEvent, write: WriteEvent) -> Flow {
-        // Delegate to the production helper so these properties exercise the
-        // same write precondition the pump loop uses, not a copy of it.
-        match drive_step(state, read, || Ok::<WriteEvent, Infallible>(write)) {
-            Ok(flow) => flow,
-            Err(never) => match never {},
-        }
-    }
-
-    /// Drive one iteration, reporting whether the write operation ran.
-    ///
-    /// `drive_step`'s distinctive guarantee over `step` is that it does not
-    /// *invoke* the write at all when the transition forbids one — `step`
-    /// separately ignores a write it is handed, so observing state alone
-    /// cannot tell the two apart.
-    fn drive_counting(state: &mut PumpState, read: ReadEvent, write: WriteEvent) -> (Flow, bool) {
-        let mut invoked = false;
-        let outcome = drive_step(state, read, || {
-            invoked = true;
-            Ok::<WriteEvent, Infallible>(write)
-        });
-        match outcome {
-            Ok(flow) => (flow, invoked),
-            Err(never) => match never {},
-        }
-    }
-
-    #[test]
-    fn drive_step_skips_the_write_once_the_writer_is_closed() {
-        let mut state = PumpState::start();
-        // Latch the writer closed with a non-fatal short write.
-        drive_counting(
-            &mut state,
-            ReadEvent::Chunk,
-            WriteEvent::Closed { bytes: 2 },
-        );
-        assert!(
-            !state.writer_open(),
-            "the broken pipe must latch the writer"
-        );
-
-        let (flow, invoked) = drive_counting(
-            &mut state,
-            ReadEvent::Chunk,
-            WriteEvent::Complete { bytes: 9 },
-        );
-
-        assert_eq!(flow, Flow::Continue, "a drained chunk keeps the loop going");
-        assert!(
-            !invoked,
-            "a closed writer must not be written to again; the chunk only drains the reader",
-        );
-        assert_eq!(
-            state.total_written(),
-            2,
-            "draining must not accrue further bytes",
-        );
-    }
-
-    /// From the starting state, the read event alone decides whether the write
-    /// runs: a chunk drives it, EOF stops the loop without attempting one.
-    #[rstest]
-    #[case::chunk_while_open(ReadEvent::Chunk, Flow::Continue, true, 4)]
-    #[case::eof(ReadEvent::Eof, Flow::Stop, false, 0)]
-    fn drive_step_writes_only_for_a_chunk_while_open(
-        #[case] read: ReadEvent,
-        #[case] expected_flow: Flow,
-        #[case] expected_invoked: bool,
-        #[case] expected_total: u64,
-    ) {
-        let mut state = PumpState::start();
-
-        let (flow, invoked) = drive_counting(&mut state, read, WriteEvent::Complete { bytes: 4 });
-
-        assert_eq!(flow, expected_flow, "unexpected flow for {read:?}");
-        assert_eq!(
-            invoked, expected_invoked,
-            "the write must run only for a chunk read while the writer is open",
-        );
-        assert_eq!(
-            state.total_written(),
-            expected_total,
-            "only a performed write may accrue bytes",
-        );
-    }
-
-    fn read_event() -> impl Strategy<Value = ReadEvent> {
-        prop_oneof![Just(ReadEvent::Chunk), Just(ReadEvent::Eof)]
-    }
-
-    fn write_event() -> impl Strategy<Value = WriteEvent> {
-        prop_oneof![
-            (0_u64..=1 << 20).prop_map(|bytes| WriteEvent::Complete { bytes }),
-            (0_u64..=1 << 20).prop_map(|bytes| WriteEvent::Closed { bytes }),
-        ]
-    }
-
-    proptest! {
-        /// Across any script of iterations the running total never decreases,
-        /// the writer never reopens once closed, a closed writer accrues no
-        /// further bytes, and the loop stops exactly on EOF.
-        #[test]
-        fn invariants_hold_across_iterations(
-            script in prop::collection::vec((read_event(), write_event()), 0..64),
-        ) {
-            let mut state = PumpState::start();
-            for (read, write) in script {
-                let before = state;
-                let (flow, invoked) = drive_counting(&mut state, read, write);
-
-                // `drive_step` must invoke the write exactly when the
-                // transition permits one.
-                prop_assert_eq!(
-                    invoked,
-                    read == ReadEvent::Chunk && before.writer_open(),
-                    "the write runs only for a chunk read while the writer is open",
-                );
-
-                prop_assert!(
-                    state.total_written() >= before.total_written(),
-                    "total bytes must be monotonic",
-                );
-                prop_assert!(
-                    before.writer_open() || !state.writer_open(),
-                    "a closed writer must never reopen",
-                );
-                if !before.writer_open() {
-                    prop_assert_eq!(
-                        state.total_written(),
-                        before.total_written(),
-                        "a closed writer must accrue no further bytes",
-                    );
-                }
-                prop_assert_eq!(
-                    flow == Flow::Stop,
-                    read == ReadEvent::Eof,
-                    "the loop stops exactly on EOF",
-                );
-                // EOF halts the loop before any further state change.
-                if read == ReadEvent::Eof {
-                    prop_assert_eq!(state, before, "EOF leaves the state unchanged");
-                }
-            }
-        }
-
-        /// Once a broken-pipe write latches the writer closed, no later write
-        /// outcome — however large — can increase the total again.
-        #[test]
-        fn writes_stop_after_broken_pipe(
-            accepted in 0_u64..=1 << 20,
-            tail in prop::collection::vec(write_event(), 0..32),
-        ) {
-            let mut state = PumpState::start();
-            // First chunk latches the writer closed via a non-fatal short write.
-            drive(&mut state, ReadEvent::Chunk, WriteEvent::Closed { bytes: accepted });
-            prop_assert!(!state.writer_open());
-            let latched_total = state.total_written();
-
-            for write in tail {
-                drive(&mut state, ReadEvent::Chunk, write);
-                prop_assert!(!state.writer_open(), "writer stays closed");
-                prop_assert_eq!(
-                    state.total_written(),
-                    latched_total,
-                    "no bytes are written after the pipe breaks",
-                );
-            }
-        }
-    }
-}
+#[path = "pump_machine_tests.rs"]
+mod tests;
 
 #[cfg(kani)]
 #[path = "pump_machine_kani_proofs.rs"]

--- a/rust/cuprum-rust/src/pump_machine.rs
+++ b/rust/cuprum-rust/src/pump_machine.rs
@@ -86,6 +86,37 @@ pub(crate) enum Flow {
 ///
 /// A closed writer never reopens and never accrues more bytes: once the writer
 /// latches closed, further chunk reads only drain the upstream reader.
+///
+/// # Examples
+///
+/// A completed write accrues its bytes and keeps pumping:
+///
+/// ```rust,ignore
+/// let mut state = PumpState::start();
+/// let flow = step(
+///     &mut state,
+///     ReadEvent::Chunk,
+///     Some(WriteEvent::Complete { bytes: 5 }),
+/// );
+/// assert_eq!(flow, Flow::Continue);
+/// assert_eq!(state.total_written(), 5);
+/// assert!(state.writer_open());
+/// ```
+///
+/// A broken pipe latches the writer closed, after which chunk reads drain the
+/// reader without accruing bytes, and EOF stops the loop:
+///
+/// ```rust,ignore
+/// let mut state = PumpState::start();
+/// step(&mut state, ReadEvent::Chunk, Some(WriteEvent::Closed { bytes: 2 }));
+/// assert!(!state.writer_open());
+///
+/// // The writer is closed, so the caller performs no write: `write` is `None`.
+/// step(&mut state, ReadEvent::Chunk, None);
+/// assert_eq!(state.total_written(), 2, "a drained chunk adds nothing");
+///
+/// assert_eq!(step(&mut state, ReadEvent::Eof, None), Flow::Stop);
+/// ```
 pub(crate) fn step(state: &mut PumpState, read: ReadEvent, write: Option<WriteEvent>) -> Flow {
     match read {
         ReadEvent::Eof => Flow::Stop,

--- a/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
+++ b/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
@@ -12,9 +12,7 @@
 //! guarantee is that `advance` never builds one — which is a property of
 //! `advance`.
 
-use std::convert::Infallible;
-
-use super::{Flow, PumpState, WriteEvent, advance};
+use super::{Flow, PumpState, WriteEvent, advance, drive};
 
 fn any_write() -> WriteEvent {
     let bytes: u64 = kani::any();
@@ -22,19 +20,6 @@ fn any_write() -> WriteEvent {
         WriteEvent::Complete { bytes }
     } else {
         WriteEvent::Closed { bytes }
-    }
-}
-
-/// Drive one iteration with a symbolic write, reporting whether it ran.
-fn drive(state: &mut PumpState, read_len: usize, write: WriteEvent) -> (Flow, bool) {
-    let mut invoked = false;
-    let outcome = advance(state, read_len, || {
-        invoked = true;
-        Ok::<WriteEvent, Infallible>(write)
-    });
-    match outcome {
-        Ok(flow) => (flow, invoked),
-        Err(never) => match never {},
     }
 }
 

--- a/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
+++ b/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
@@ -1,0 +1,119 @@
+//! Bounded Kani proofs for the pure pump state machine.
+//!
+//! These proofs establish the invariants #84 calls for over unbounded byte
+//! counts and arbitrary starting states: the running total is monotonic, the
+//! writer latch is sticky, a closed writer drains without accruing bytes, and
+//! the loop stops exactly on EOF.
+
+use super::{Flow, PumpState, ReadEvent, WriteEvent, step};
+
+fn any_read() -> ReadEvent {
+    if kani::any() {
+        ReadEvent::Chunk
+    } else {
+        ReadEvent::Eof
+    }
+}
+
+fn any_write() -> WriteEvent {
+    let bytes: u64 = kani::any();
+    if kani::any() {
+        WriteEvent::Complete { bytes }
+    } else {
+        WriteEvent::Closed { bytes }
+    }
+}
+
+fn any_opt_write() -> Option<WriteEvent> {
+    if kani::any() { Some(any_write()) } else { None }
+}
+
+#[kani::proof]
+fn total_is_monotonic_across_a_step() {
+    let mut state = PumpState::from_parts(kani::any(), kani::any());
+    let before = state.total_written();
+    step(&mut state, any_read(), any_opt_write());
+    kani::assert(
+        state.total_written() >= before,
+        "the running total never decreases",
+    );
+}
+
+#[kani::proof]
+fn loop_stops_exactly_on_eof() {
+    let mut state = PumpState::from_parts(kani::any(), kani::any());
+    let read = any_read();
+    let flow = step(&mut state, read, any_opt_write());
+    kani::assert(
+        (flow == Flow::Stop) == (read == ReadEvent::Eof),
+        "the loop stops iff the read reached EOF",
+    );
+}
+
+#[kani::proof]
+fn closed_writer_drains_without_writing() {
+    // Start from an already-closed writer with an arbitrary running total.
+    let mut state = PumpState::from_parts(kani::any(), false);
+    let before = state.total_written();
+    step(&mut state, any_read(), any_opt_write());
+    kani::assert(!state.writer_open(), "a closed writer never reopens");
+    kani::assert(
+        state.total_written() == before,
+        "a closed writer accrues no further bytes",
+    );
+}
+
+#[kani::proof]
+fn broken_pipe_latches_closed_and_counts_accepted_bytes() {
+    let mut state = PumpState::from_parts(kani::any(), true);
+    let before = state.total_written();
+    let bytes: u64 = kani::any();
+    step(
+        &mut state,
+        ReadEvent::Chunk,
+        Some(WriteEvent::Closed { bytes }),
+    );
+    kani::assert(
+        !state.writer_open(),
+        "a non-fatal short write latches the writer closed",
+    );
+    kani::assert(
+        state.total_written() == before.saturating_add(bytes),
+        "bytes accepted before the pipe broke are counted",
+    );
+}
+
+#[kani::proof]
+fn completed_write_keeps_open_and_counts_bytes() {
+    let mut state = PumpState::from_parts(kani::any(), true);
+    let before = state.total_written();
+    let bytes: u64 = kani::any();
+    step(
+        &mut state,
+        ReadEvent::Chunk,
+        Some(WriteEvent::Complete { bytes }),
+    );
+    kani::assert(
+        state.writer_open(),
+        "a completed write keeps the writer open",
+    );
+    kani::assert(
+        state.total_written() == before.saturating_add(bytes),
+        "written bytes are counted",
+    );
+}
+
+#[kani::proof]
+#[kani::unwind(4)]
+fn total_stays_monotonic_over_three_steps() {
+    let mut state = PumpState::start();
+    let mut before = state.total_written();
+    for _ in 0..3 {
+        step(&mut state, any_read(), any_opt_write());
+        kani::assert(
+            state.total_written() >= before,
+            "the running total never decreases across iterations",
+        );
+        before = state.total_written();
+    }
+}

--- a/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
+++ b/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
@@ -11,6 +11,12 @@
 //! `Transition` type makes an invalid combination unrepresentable, so the
 //! guarantee is that `advance` never builds one — which is a property of
 //! `advance`.
+//!
+//! That premise is not itself provable here, since no proof can observe a
+//! transition it is unable to spell. It is pinned instead by the compile-fail
+//! case `tests/ui/fail/pump_transition_unreachable.rs`, which shows that code
+//! outside the module can neither construct a `Transition` nor apply one with
+//! `step`, and fails if either is widened.
 
 use super::{Flow, PumpState, WriteEvent, advance, drive};
 

--- a/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
+++ b/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
@@ -64,42 +64,24 @@ fn closed_writer_drains_without_writing() {
 }
 
 #[kani::proof]
-fn broken_pipe_latches_closed_and_counts_accepted_bytes() {
+fn write_counts_bytes_and_latches_by_variant() {
+    // Cover both write outcomes in one proof: either counts its accepted bytes,
+    // and only a completed write leaves the writer open (a broken-pipe short
+    // write latches it closed).
     let mut state = PumpState::from_parts(kani::any(), true);
     let before = state.total_written();
-    let bytes: u64 = kani::any();
-    step(
-        &mut state,
-        ReadEvent::Chunk,
-        Some(WriteEvent::Closed { bytes }),
-    );
-    kani::assert(
-        !state.writer_open(),
-        "a non-fatal short write latches the writer closed",
-    );
+    let write = any_write();
+    let bytes = match write {
+        WriteEvent::Complete { bytes } | WriteEvent::Closed { bytes } => bytes,
+    };
+    step(&mut state, ReadEvent::Chunk, Some(write));
     kani::assert(
         state.total_written() == before.saturating_add(bytes),
-        "bytes accepted before the pipe broke are counted",
-    );
-}
-
-#[kani::proof]
-fn completed_write_keeps_open_and_counts_bytes() {
-    let mut state = PumpState::from_parts(kani::any(), true);
-    let before = state.total_written();
-    let bytes: u64 = kani::any();
-    step(
-        &mut state,
-        ReadEvent::Chunk,
-        Some(WriteEvent::Complete { bytes }),
+        "accepted bytes are counted for either write outcome",
     );
     kani::assert(
-        state.writer_open(),
-        "a completed write keeps the writer open",
-    );
-    kani::assert(
-        state.total_written() == before.saturating_add(bytes),
-        "written bytes are counted",
+        state.writer_open() == matches!(write, WriteEvent::Complete { .. }),
+        "only a completed write keeps the writer open",
     );
 }
 

--- a/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
+++ b/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
@@ -5,12 +5,20 @@
 //! writer latch is sticky, a closed writer drains without accruing bytes, and
 //! the loop stops exactly on EOF.
 //!
-//! They drive [`advance`](super::advance) rather than the private `step`,
+//! They exercise [`advance`](super::advance) rather than the private `step`,
 //! because `advance` is where the write precondition lives. Proving `step`
 //! alone would establish nothing about a closed writer: the narrowed
 //! `Transition` type makes an invalid combination unrepresentable, so the
 //! guarantee is that `advance` never builds one — which is a property of
 //! `advance`.
+//!
+//! Every proof reaches `advance` through [`drive`](super::drive), the helper it
+//! shares with the proptest harness: `drive` supplies the write closure and
+//! reports whether `advance` actually called it. Calling `advance` directly
+//! here would let the proofs and the proptests drift into driving the machine
+//! differently, and the "was the write invoked?" observable — the one a dropped
+//! precondition would change without changing the resulting state — would have
+//! to be rebuilt in each proof.
 //!
 //! That premise is not itself provable here, since no proof can observe a
 //! transition it is unable to spell. It is pinned instead by the compile-fail
@@ -18,7 +26,7 @@
 //! outside the module can neither construct a `Transition` nor apply one with
 //! `step`, and fails if either is widened.
 
-use super::{Flow, PumpState, WriteEvent, advance, drive};
+use super::{Flow, PumpState, WriteEvent, drive};
 
 fn any_write() -> WriteEvent {
     let bytes: u64 = kani::any();

--- a/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
+++ b/rust/cuprum-rust/src/pump_machine_kani_proofs.rs
@@ -4,16 +4,17 @@
 //! counts and arbitrary starting states: the running total is monotonic, the
 //! writer latch is sticky, a closed writer drains without accruing bytes, and
 //! the loop stops exactly on EOF.
+//!
+//! They drive [`advance`](super::advance) rather than the private `step`,
+//! because `advance` is where the write precondition lives. Proving `step`
+//! alone would establish nothing about a closed writer: the narrowed
+//! `Transition` type makes an invalid combination unrepresentable, so the
+//! guarantee is that `advance` never builds one — which is a property of
+//! `advance`.
 
-use super::{Flow, PumpState, ReadEvent, WriteEvent, step};
+use std::convert::Infallible;
 
-fn any_read() -> ReadEvent {
-    if kani::any() {
-        ReadEvent::Chunk
-    } else {
-        ReadEvent::Eof
-    }
-}
+use super::{Flow, PumpState, WriteEvent, advance};
 
 fn any_write() -> WriteEvent {
     let bytes: u64 = kani::any();
@@ -24,15 +25,24 @@ fn any_write() -> WriteEvent {
     }
 }
 
-fn any_opt_write() -> Option<WriteEvent> {
-    if kani::any() { Some(any_write()) } else { None }
+/// Drive one iteration with a symbolic write, reporting whether it ran.
+fn drive(state: &mut PumpState, read_len: usize, write: WriteEvent) -> (Flow, bool) {
+    let mut invoked = false;
+    let outcome = advance(state, read_len, || {
+        invoked = true;
+        Ok::<WriteEvent, Infallible>(write)
+    });
+    match outcome {
+        Ok(flow) => (flow, invoked),
+        Err(never) => match never {},
+    }
 }
 
 #[kani::proof]
 fn total_is_monotonic_across_a_step() {
     let mut state = PumpState::from_parts(kani::any(), kani::any());
     let before = state.total_written();
-    step(&mut state, any_read(), any_opt_write());
+    drive(&mut state, kani::any(), any_write());
     kani::assert(
         state.total_written() >= before,
         "the running total never decreases",
@@ -42,11 +52,11 @@ fn total_is_monotonic_across_a_step() {
 #[kani::proof]
 fn loop_stops_exactly_on_eof() {
     let mut state = PumpState::from_parts(kani::any(), kani::any());
-    let read = any_read();
-    let flow = step(&mut state, read, any_opt_write());
+    let read_len: usize = kani::any();
+    let (flow, _) = drive(&mut state, read_len, any_write());
     kani::assert(
-        (flow == Flow::Stop) == (read == ReadEvent::Eof),
-        "the loop stops iff the read reached EOF",
+        (flow == Flow::Stop) == (read_len == 0),
+        "the loop stops iff the read returned zero bytes",
     );
 }
 
@@ -55,12 +65,25 @@ fn closed_writer_drains_without_writing() {
     // Start from an already-closed writer with an arbitrary running total.
     let mut state = PumpState::from_parts(kani::any(), false);
     let before = state.total_written();
-    step(&mut state, any_read(), any_opt_write());
+    let (_, invoked) = drive(&mut state, kani::any(), any_write());
+    kani::assert(!invoked, "a closed writer is never written to");
     kani::assert(!state.writer_open(), "a closed writer never reopens");
     kani::assert(
         state.total_written() == before,
         "a closed writer accrues no further bytes",
     );
+}
+
+#[kani::proof]
+fn eof_never_writes() {
+    // A zero-length read must stop without attempting a write, whatever the
+    // writer's state.
+    let mut state = PumpState::from_parts(kani::any(), kani::any());
+    let before = state;
+    let (flow, invoked) = drive(&mut state, 0, any_write());
+    kani::assert(!invoked, "EOF must not attempt a write");
+    kani::assert(flow == Flow::Stop, "EOF stops the loop");
+    kani::assert(state == before, "EOF leaves the state unchanged");
 }
 
 #[kani::proof]
@@ -74,7 +97,10 @@ fn write_counts_bytes_and_latches_by_variant() {
     let bytes = match write {
         WriteEvent::Complete { bytes } | WriteEvent::Closed { bytes } => bytes,
     };
-    step(&mut state, ReadEvent::Chunk, Some(write));
+    let read_len: usize = kani::any();
+    kani::assume(read_len != 0);
+    let (_, invoked) = drive(&mut state, read_len, write);
+    kani::assert(invoked, "an open writer and a chunk must perform the write");
     kani::assert(
         state.total_written() == before.saturating_add(bytes),
         "accepted bytes are counted for either write outcome",
@@ -91,7 +117,7 @@ fn total_stays_monotonic_over_three_steps() {
     let mut state = PumpState::start();
     let mut before = state.total_written();
     for _ in 0..3 {
-        step(&mut state, any_read(), any_opt_write());
+        drive(&mut state, kani::any(), any_write());
         kani::assert(
             state.total_written() >= before,
             "the running total never decreases across iterations",

--- a/rust/cuprum-rust/src/pump_machine_tests.rs
+++ b/rust/cuprum-rust/src/pump_machine_tests.rs
@@ -5,33 +5,13 @@
 //! are the ones the pump loop actually uses rather than a copy living only in
 //! test code.
 
-use std::convert::Infallible;
-
 use proptest::prelude::*;
 use rstest::rstest;
 
-use super::{Flow, PumpState, WriteEvent, advance};
+use super::{Flow, PumpState, WriteEvent, advance, drive};
 
 /// A read length standing in for "a chunk was read".
 const CHUNK_LEN: usize = 4;
-
-/// Drive one iteration, reporting the flow and whether the write ran.
-///
-/// Whether the write was *invoked* is the observable that matters: `advance`
-/// promises not to call it at all when the transition forbids one, and the
-/// resulting state alone cannot distinguish "never called" from "called and
-/// its result discarded".
-fn drive(state: &mut PumpState, read_len: usize, write: WriteEvent) -> (Flow, bool) {
-    let mut invoked = false;
-    let outcome = advance(state, read_len, || {
-        invoked = true;
-        Ok::<WriteEvent, Infallible>(write)
-    });
-    match outcome {
-        Ok(flow) => (flow, invoked),
-        Err(never) => match never {},
-    }
-}
 
 #[test]
 fn advance_skips_the_write_once_the_writer_is_closed() {

--- a/rust/cuprum-rust/src/pump_machine_tests.rs
+++ b/rust/cuprum-rust/src/pump_machine_tests.rs
@@ -1,0 +1,213 @@
+//! Property and example tests for the pure pump state machine.
+//!
+//! Everything here drives [`advance`](super::advance), the production entry
+//! point, so the read-length translation and the write precondition under test
+//! are the ones the pump loop actually uses rather than a copy living only in
+//! test code.
+
+use std::convert::Infallible;
+
+use proptest::prelude::*;
+use rstest::rstest;
+
+use super::{Flow, PumpState, WriteEvent, advance};
+
+/// A read length standing in for "a chunk was read".
+const CHUNK_LEN: usize = 4;
+
+/// Drive one iteration, reporting the flow and whether the write ran.
+///
+/// Whether the write was *invoked* is the observable that matters: `advance`
+/// promises not to call it at all when the transition forbids one, and the
+/// resulting state alone cannot distinguish "never called" from "called and
+/// its result discarded".
+fn drive(state: &mut PumpState, read_len: usize, write: WriteEvent) -> (Flow, bool) {
+    let mut invoked = false;
+    let outcome = advance(state, read_len, || {
+        invoked = true;
+        Ok::<WriteEvent, Infallible>(write)
+    });
+    match outcome {
+        Ok(flow) => (flow, invoked),
+        Err(never) => match never {},
+    }
+}
+
+#[test]
+fn advance_skips_the_write_once_the_writer_is_closed() {
+    let mut state = PumpState::start();
+    // Latch the writer closed with a non-fatal short write.
+    drive(&mut state, CHUNK_LEN, WriteEvent::Closed { bytes: 2 });
+    assert!(
+        !state.writer_open(),
+        "the broken pipe must latch the writer"
+    );
+
+    let (flow, invoked) = drive(&mut state, CHUNK_LEN, WriteEvent::Complete { bytes: 9 });
+
+    assert_eq!(flow, Flow::Continue, "a drained chunk keeps the loop going");
+    assert!(
+        !invoked,
+        "a closed writer must not be written to again; the chunk only drains the reader",
+    );
+    assert_eq!(
+        state.total_written(),
+        2,
+        "draining must not accrue further bytes",
+    );
+}
+
+/// From the starting state the read length alone decides whether the write
+/// runs: a non-empty read drives it, a zero-length read stops the loop.
+#[rstest]
+#[case::chunk_while_open(CHUNK_LEN, Flow::Continue, true, 4)]
+#[case::eof(0, Flow::Stop, false, 0)]
+fn advance_writes_only_for_a_chunk_while_open(
+    #[case] read_len: usize,
+    #[case] expected_flow: Flow,
+    #[case] expected_invoked: bool,
+    #[case] expected_total: u64,
+) {
+    let mut state = PumpState::start();
+
+    let (flow, invoked) = drive(&mut state, read_len, WriteEvent::Complete { bytes: 4 });
+
+    assert_eq!(
+        flow, expected_flow,
+        "unexpected flow for read_len {read_len}"
+    );
+    assert_eq!(
+        invoked, expected_invoked,
+        "the write must run only for a chunk read while the writer is open",
+    );
+    assert_eq!(
+        state.total_written(),
+        expected_total,
+        "only a performed write may accrue bytes",
+    );
+}
+
+/// Only a zero length is EOF; every other length is a chunk, including the
+/// one-byte read a small buffer produces.
+#[rstest]
+#[case::one_byte(1)]
+#[case::small(7)]
+#[case::whole_buffer(65_536)]
+fn advance_treats_every_non_zero_length_as_a_chunk(#[case] read_len: usize) {
+    let mut state = PumpState::start();
+
+    let (flow, invoked) = drive(&mut state, read_len, WriteEvent::Complete { bytes: 1 });
+
+    assert_eq!(flow, Flow::Continue, "a non-empty read must keep pumping");
+    assert!(
+        invoked,
+        "a non-empty read while open must perform the write"
+    );
+}
+
+/// A fatal write aborts the iteration without advancing the state, so the
+/// caller's error is what propagates rather than a half-applied transition.
+#[test]
+fn advance_propagates_a_failed_write_without_advancing() {
+    let mut state = PumpState::start();
+    let before = state;
+
+    let outcome: Result<Flow, &str> = advance(&mut state, CHUNK_LEN, || Err("fatal write"));
+
+    assert_eq!(
+        outcome,
+        Err("fatal write"),
+        "the write error must propagate"
+    );
+    assert_eq!(
+        state, before,
+        "a failed write must leave the state untouched",
+    );
+}
+
+fn read_len() -> impl Strategy<Value = usize> {
+    // Zero is EOF; every other length is a chunk, so both are generated.
+    prop_oneof![Just(0_usize), 1_usize..=1 << 16]
+}
+
+fn write_event() -> impl Strategy<Value = WriteEvent> {
+    prop_oneof![
+        (0_u64..=1 << 20).prop_map(|bytes| WriteEvent::Complete { bytes }),
+        (0_u64..=1 << 20).prop_map(|bytes| WriteEvent::Closed { bytes }),
+    ]
+}
+
+proptest! {
+    /// Across any script of iterations the running total never decreases, the
+    /// writer never reopens once closed, a closed writer accrues no further
+    /// bytes, and the loop stops exactly on a zero-length read.
+    #[test]
+    fn invariants_hold_across_iterations(
+        script in prop::collection::vec((read_len(), write_event()), 0..64),
+    ) {
+        let mut state = PumpState::start();
+        for (read_len, write) in script {
+            let before = state;
+            let (flow, invoked) = drive(&mut state, read_len, write);
+
+            // `advance` must invoke the write exactly when the transition
+            // permits one.
+            prop_assert_eq!(
+                invoked,
+                read_len != 0 && before.writer_open(),
+                "the write runs only for a chunk read while the writer is open",
+            );
+
+            prop_assert!(
+                state.total_written() >= before.total_written(),
+                "total bytes must be monotonic",
+            );
+            prop_assert!(
+                before.writer_open() || !state.writer_open(),
+                "a closed writer must never reopen",
+            );
+            if !before.writer_open() {
+                prop_assert_eq!(
+                    state.total_written(),
+                    before.total_written(),
+                    "a closed writer must accrue no further bytes",
+                );
+            }
+            prop_assert_eq!(
+                flow == Flow::Stop,
+                read_len == 0,
+                "the loop stops exactly on a zero-length read",
+            );
+            // EOF halts the loop before any further state change.
+            if read_len == 0 {
+                prop_assert_eq!(state, before, "EOF leaves the state unchanged");
+            }
+        }
+    }
+
+    /// Once a broken-pipe write latches the writer closed, no later write
+    /// outcome — however large — can increase the total again, and no further
+    /// write is even attempted.
+    #[test]
+    fn writes_stop_after_broken_pipe(
+        accepted in 0_u64..=1 << 20,
+        tail in prop::collection::vec(write_event(), 0..32),
+    ) {
+        let mut state = PumpState::start();
+        // First chunk latches the writer closed via a non-fatal short write.
+        drive(&mut state, CHUNK_LEN, WriteEvent::Closed { bytes: accepted });
+        prop_assert!(!state.writer_open());
+        let latched_total = state.total_written();
+
+        for write in tail {
+            let (_, invoked) = drive(&mut state, CHUNK_LEN, write);
+            prop_assert!(!invoked, "a closed writer is never written to again");
+            prop_assert!(!state.writer_open(), "writer stays closed");
+            prop_assert_eq!(
+                state.total_written(),
+                latched_total,
+                "no bytes are written after the pipe breaks",
+            );
+        }
+    }
+}

--- a/rust/cuprum-rust/src/tracing_capture.rs
+++ b/rust/cuprum-rust/src/tracing_capture.rs
@@ -16,12 +16,20 @@ use tracing::field::{Field, Visit};
 use tracing::span::{Attributes, Id, Record};
 use tracing::{Event, Level, Metadata, Subscriber};
 
-/// A captured event: its level and the field names reachable from the active
-/// span stack when it was emitted.
+/// A captured event: its level, the field names reachable from the active span
+/// stack when it was emitted, and the values it carried itself.
+///
+/// `fields` and `values` answer different questions. `fields` includes names
+/// inherited from enclosing spans, so it shows whether an event kept its
+/// operation context. `values` holds only what the event recorded directly —
+/// including its message, which `tracing` stores under the `message` field —
+/// so it can identify *which* event fired rather than merely that some event
+/// carried a given field name.
 #[derive(Debug, Clone)]
 pub(crate) struct CapturedEvent {
     pub(crate) level: Level,
     pub(crate) fields: BTreeSet<String>,
+    pub(crate) values: BTreeMap<String, String>,
 }
 
 /// The result of a capture run.
@@ -37,6 +45,27 @@ impl Captured {
         self.events
             .iter()
             .any(|event| event.level == level && fields.iter().all(|f| event.fields.contains(*f)))
+    }
+
+    /// True when some event at `level` carried exactly `message` and every
+    /// listed field/value pair.
+    ///
+    /// Stricter than [`Self::event_has_fields`], which any event carrying the
+    /// named fields satisfies: this pins the specific event, so an unrelated
+    /// one cannot stand in for a missing or malformed diagnostic.
+    pub(crate) fn event_matches(
+        &self,
+        level: Level,
+        message: &str,
+        values: &[(&str, &str)],
+    ) -> bool {
+        self.events.iter().any(|event| {
+            event.level == level
+                && event.values.get("message").map(String::as_str) == Some(message)
+                && values.iter().all(|(name, value)| {
+                    event.values.get(*name).map(String::as_str) == Some(*value)
+                })
+        })
     }
 
     /// The recorded value of `field` on the span whose `operation` field equals
@@ -134,10 +163,11 @@ impl Subscriber for FilterCapture {
         };
         let mut own = BTreeMap::new();
         event.record(&mut FieldVisitor(&mut own));
-        fields.extend(own.into_keys());
+        fields.extend(own.keys().cloned());
         lock(&self.state).events.push(CapturedEvent {
             level: *event.metadata().level(),
             fields,
+            values: own,
         });
     }
 

--- a/rust/cuprum-rust/src/tracing_capture.rs
+++ b/rust/cuprum-rust/src/tracing_capture.rs
@@ -203,3 +203,54 @@ pub(crate) fn capture(max_level: Level, body: impl FnOnce()) -> Captured {
         spans: guard.span_fields.values().cloned().collect(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the capture harness's own matchers.
+    //!
+    //! `event_matches` is what other modules assert their diagnostics with, so
+    //! a predicate it quietly ignores would weaken every one of those tests at
+    //! once. The negative cases below vary exactly one of level, message, and
+    //! field value, so no single dropped predicate can pass them all.
+
+    use rstest::rstest;
+    use tracing::Level;
+
+    use super::capture;
+
+    /// Emit one known event and return what the harness captured.
+    fn captured_probe() -> super::Captured {
+        capture(Level::DEBUG, || {
+            tracing::debug!(bytes_transferred = 0_u64, "probe event");
+        })
+    }
+
+    #[rstest]
+    fn event_matches_accepts_the_exact_event() {
+        assert!(
+            captured_probe().event_matches(
+                Level::DEBUG,
+                "probe event",
+                &[("bytes_transferred", "0")],
+            ),
+            "the event that fired must match its own level, message, and fields",
+        );
+    }
+
+    #[rstest]
+    #[case::wrong_level(Level::WARN, "probe event", "bytes_transferred", "0")]
+    #[case::wrong_message(Level::DEBUG, "a different event", "bytes_transferred", "0")]
+    #[case::wrong_value(Level::DEBUG, "probe event", "bytes_transferred", "1")]
+    #[case::absent_field(Level::DEBUG, "probe event", "no_such_field", "0")]
+    fn event_matches_rejects_a_single_mismatch(
+        #[case] level: Level,
+        #[case] message: &str,
+        #[case] field: &str,
+        #[case] value: &str,
+    ) {
+        assert!(
+            !captured_probe().event_matches(level, message, &[(field, value)]),
+            "event_matches must require every predicate, not just some",
+        );
+    }
+}

--- a/rust/cuprum-rust/tests/ui/fail/pump_transition_unreachable.rs
+++ b/rust/cuprum-rust/tests/ui/fail/pump_transition_unreachable.rs
@@ -19,9 +19,10 @@
 // The workspace declares `cfg(kani)` via `[workspace.lints.rust]`, but the
 // throwaway crate trybuild builds around this file inherits no lint table, so
 // the module's `#[cfg(kani)]` gates would otherwise fill the expected stderr
-// with noise unrelated to the boundary under test.
-#![allow(unexpected_cfgs, reason = "trybuild's crate inherits no check-cfg")]
-
+// with noise unrelated to the boundary under test. Scope the expectation to the
+// included module: nothing outside it needs the suppression, and `expect`
+// rather than `allow` means the suppression fails loudly if the gates go away.
+#[expect(unexpected_cfgs, reason = "trybuild's crate inherits no check-cfg")]
 #[path = "../../../src/pump_machine.rs"]
 mod pump_machine;
 

--- a/rust/cuprum-rust/tests/ui/fail/pump_transition_unreachable.rs
+++ b/rust/cuprum-rust/tests/ui/fail/pump_transition_unreachable.rs
@@ -1,0 +1,35 @@
+//! Compile-fail UI test: an invalid pump transition cannot be fabricated from
+//! outside `pump_machine`.
+//!
+//! `step` deliberately omits a `writer_open` check, and the Kani proofs drive
+//! `advance` rather than `step`, because both rest on the same claim: a
+//! `Transition::Wrote` can only exist for a chunk read while the writer was
+//! open, since `advance` is its only constructor. That claim holds only while
+//! `Transition` and `step` stay private to their module, so this case pins it.
+//!
+//! The real module source is included here so the probe below sits in the
+//! module's parent — exactly the relationship `lib.rs` has with
+//! `pump_machine`, and exactly where a future caller would sit. Widening
+//! `Transition` or `step` even to `pub(crate)` changes what the compiler
+//! reports here, so this case fails.
+//!
+//! `WriteEvent` and `PumpState` are `pub(crate)`, so they resolve; only the
+//! transition type and its applicator do not. That is the boundary under test.
+
+// The workspace declares `cfg(kani)` via `[workspace.lints.rust]`, but the
+// throwaway crate trybuild builds around this file inherits no lint table, so
+// the module's `#[cfg(kani)]` gates would otherwise fill the expected stderr
+// with noise unrelated to the boundary under test.
+#![allow(unexpected_cfgs, reason = "trybuild's crate inherits no check-cfg")]
+
+#[path = "../../../src/pump_machine.rs"]
+mod pump_machine;
+
+fn main() {
+    let mut state = pump_machine::PumpState::start();
+    // The combination the machine forbids: a write recorded for an iteration
+    // whose writer had already latched closed.
+    let write = pump_machine::WriteEvent::Complete { bytes: 1 };
+    let transition = pump_machine::Transition::Wrote(write);
+    let _ = pump_machine::step(&mut state, transition);
+}

--- a/rust/cuprum-rust/tests/ui/fail/pump_transition_unreachable.stderr
+++ b/rust/cuprum-rust/tests/ui/fail/pump_transition_unreachable.stderr
@@ -1,0 +1,25 @@
+error[E0603]: enum `Transition` is private
+  --> tests/ui/fail/pump_transition_unreachable.rs:33:36
+   |
+33 |     let transition = pump_machine::Transition::Wrote(write);
+   |                                    ^^^^^^^^^^  ----- tuple variant `Wrote` is not publicly re-exported
+   |                                    |
+   |                                    private enum
+   |
+note: the enum `Transition` is defined here
+  --> tests/ui/fail/../../../src/pump_machine.rs
+   |
+   | enum Transition {
+   | ^^^^^^^^^^^^^^^
+
+error[E0603]: function `step` is private
+  --> tests/ui/fail/pump_transition_unreachable.rs:34:27
+   |
+34 |     let _ = pump_machine::step(&mut state, transition);
+   |                           ^^^^ private function
+   |
+note: the function `step` is defined here
+  --> tests/ui/fail/../../../src/pump_machine.rs
+   |
+   | fn step(state: &mut PumpState, transition: Transition) -> Flow {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rust/cuprum-rust/tests/ui/fail/pump_transition_unreachable.stderr
+++ b/rust/cuprum-rust/tests/ui/fail/pump_transition_unreachable.stderr
@@ -1,7 +1,7 @@
 error[E0603]: enum `Transition` is private
-  --> tests/ui/fail/pump_transition_unreachable.rs:33:36
+  --> tests/ui/fail/pump_transition_unreachable.rs:34:36
    |
-33 |     let transition = pump_machine::Transition::Wrote(write);
+34 |     let transition = pump_machine::Transition::Wrote(write);
    |                                    ^^^^^^^^^^  ----- tuple variant `Wrote` is not publicly re-exported
    |                                    |
    |                                    private enum
@@ -13,9 +13,9 @@ note: the enum `Transition` is defined here
    | ^^^^^^^^^^^^^^^
 
 error[E0603]: function `step` is private
-  --> tests/ui/fail/pump_transition_unreachable.rs:34:27
+  --> tests/ui/fail/pump_transition_unreachable.rs:35:27
    |
-34 |     let _ = pump_machine::step(&mut state, transition);
+35 |     let _ = pump_machine::step(&mut state, transition);
    |                           ^^^^ private function
    |
 note: the function `step` is defined here


### PR DESCRIPTION
## Summary

`pump_stream_files_readwrite` drove real descriptor I/O and inlined its own byte-total accounting and `writer_open` latch, with no seam for scripted verification. This extracts that control flow into a pure, `io::Error`-free state machine and verifies it with proptest and Kani, as #84 requested.

## Design

`src/pump_machine.rs` (pure — no descriptors, no `io::Error`):

- `ReadEvent` — `Chunk` / `Eof`
- `WriteEvent` — `Complete { bytes }` / `Closed { bytes }` (the non-fatal broken-pipe latch)
- `PumpState { total_written, writer_open }`
- `step(&mut PumpState, ReadEvent, Option<WriteEvent>) -> Flow`

`pump_stream_files_readwrite` now drives the machine: it translates real I/O into events via a new `classify_write` helper and **propagates fatal `PumpError`s out of band**, so they never reach the machine. The now-redundant `io_utils::handle_write_result` is removed; its coverage moves to two `classify_write` tests plus the machine's property tests.

## Verification (all four #84 goals)

**proptest** (`cargo nextest`) folds random event scripts through `step`:
- total bytes are **monotonic**
- the writer **never reopens** once a broken pipe latches it closed
- a closed writer **drains without accruing bytes** (reader drain continues after writer close)
- the loop **stops exactly on `Eof`**

**Kani** (`src/pump_machine_kani_proofs.rs`, `#[cfg(kani)]` — outside the commit gate) proves the same invariants over **unbounded** byte counts and **arbitrary** starting states, plus fatal-write accounting:

```
Complete - 6 successfully verified harnesses, 0 failures, 6 total.
```

Fatal-error propagation (the fourth goal) is realised by the loop's early `?` return and covered by `classify_write_propagates_a_fatal_error` and the existing `io_utils` write tests.

## Behaviour preserved

Every existing pump/consume test is unchanged and still passes — the refactor is behaviour-preserving, only relocating the decision logic behind a verifiable seam.

## Validation

Full gates green: `make check-fmt`, `make lint` (clippy `-D warnings`, interrogate 100%, pylint 10.00/10), `make test` (pytest 755 passed/47 skipped; Rust nextest **59/59**), `make markdownlint`, `make nixie`. Kani verified separately: 6/6 harnesses SUCCESSFUL.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract the read/write pump loop control flow into a pure state machine and drive it from the existing I/O-based pump implementation, with property-based and model-checking verification.

Enhancements:
- Introduce a pure PumpState-based state machine to model read/write pump control flow independently of descriptor I/O.
- Refactor pump_stream_files_readwrite to translate I/O results into state-machine events and classify non-fatal vs fatal write outcomes via classify_write.
- Remove the legacy handle_write_result helper in favour of the new write classification and state machine integration.

Documentation:
- Document the new pump state machine design, its invariants, and Kani-based verification in the developer guide, including how it satisfies the model-checking follow-up from issue #84.

Tests:
- Add proptest-based property tests for the pump state machine invariants and classify_write behaviour.
- Add Kani proofs (behind #[cfg(kani)]) to formally verify pump state machine invariants over arbitrary states and byte counts.