### PR TITLE
Refine docstring structure guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@
   ("-ize" / "-yse" / "-our") spelling and grammar, with the exception of
   references to external APIs. Markdown prose is enforced mechanically by the
   pinned `typos` spelling gate in `make lint` and `make markdownlint`.
-- **Document public methods comprehensively.** Public methods must have
-  comprehensive NumPy-style docstrings, including clear examples that
-  demonstrate usage and outcome where appropriate.
+- **Document public APIs comprehensively.** Public functions, classes, and
+  methods must have comprehensive NumPy-style docstrings, including clear
+  examples that demonstrate usage and outcome where appropriate.
 - **Keep private helper docstrings concise.** Prefer single-line docstrings for
   private helpers. When a private helper needs an explanatory paragraph,
   inspect whether that need exposes conflated responsibilities, an unclear

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,24 @@
   ("-ize" / "-yse" / "-our") spelling and grammar, with the exception of
   references to external APIs. Markdown prose is enforced mechanically by the
   pinned `typos` spelling gate in `make lint` and `make markdownlint`.
-- **Illustrate with clear examples.** Function documentation must include clear
-  examples demonstrating usage and outcome. Test documentation should omit
+- **Document public methods comprehensively.** Public methods must have
+  comprehensive NumPy-style docstrings, including clear examples that
+  demonstrate usage and outcome where appropriate.
+- **Keep private helper docstrings concise.** Prefer single-line docstrings for
+  private helpers. When a private helper needs an explanatory paragraph,
+  inspect whether that need exposes conflated responsibilities, an unclear
+  command/query boundary, or another CQRS or cohesion failure:
+  - Split the helper when it performs distinct query and command
+    responsibilities or combines unrelated concerns.
+  - Extract a focused helper when doing so makes the invariant or boundary
+    local and simpler.
+  - Keep the helper intact when its responsibility is cohesive and the
+    explanation documents an unavoidable local constraint; retain the
+    paragraph in that case.
+- **Structure private helper docstrings selectively.** Use structured
+  NumPy-style sections for private helpers only when they describe non-obvious
+  behaviour.
+- **Keep test documentation meaningful.** Test documentation should omit
   examples that only restate the test logic.
 - **Keep file size manageable.** No single code file should be longer than 400
   lines. Long switch statements or dispatch tables should be broken up by

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1264,6 +1264,19 @@ The short version is:
   `--with 'pylint==$(PYLINT_VERSION)'` because the shim revision and Pylint
   package version are separate sources of lint behaviour.
 
+### Docstring structure
+
+Public functions, classes, and methods require comprehensive NumPy-style
+docstrings, with examples where appropriate. Prefer single-line docstrings for
+private helpers, and use structured NumPy-style sections only to describe
+non-obvious behaviour.
+
+When a private helper needs an explanatory paragraph, first inspect whether it
+combines query and command responsibilities or unrelated concerns. Split or
+extract a focused helper when doing so makes the boundary or invariant local
+and simpler. Retain the paragraph when the helper remains cohesive and the
+explanation records an unavoidable local constraint.
+
 Run the complete lint gate with:
 
 ```bash


### PR DESCRIPTION
## Summary

This branch clarifies the repository's docstring policy so all public functions, classes, and methods receive comprehensive NumPy-style documentation while private helpers remain proportionate to their scope.

It also makes a longer private-helper explanation a prompt to inspect command/query boundaries, CQRS and cohesion before retaining the paragraph, and records that convention in the developers' guide so contributors can discover it alongside the Python linting policy.

## Review walkthrough

- Start with [AGENTS.md](https://github.com/leynos/cuprum/blob/4f98ea5a1c4403c50f41c3d3bc75f5e136622bd2/AGENTS.md#L22) for the complete public API requirement, private-helper decision rules, and selective use of structured NumPy-style sections.
- Then review [docs/developers-guide.md](https://github.com/leynos/cuprum/blob/4f98ea5a1c4403c50f41c3d3bc75f5e136622bd2/docs/developers-guide.md#L1267) for the contributor-facing copy of the docstring structure convention.

## Validation

- `make fmt`: passed.
- `make markdownlint`: passed.
- `nixie --no-sandbox AGENTS.md docs/developers-guide.md`: passed.
- `make nixie`: passed.

## References

- [Lody session](https://lody.ai/leynos/sessions/6fa9b48d-c352-4f89-ae27-e0146bfbbad6)