### PR TITLE
Hypothesis stateful tests for the metrics event reducer (#78)

### DIFF
--- a/cuprum/adapters/metrics_adapter.py
+++ b/cuprum/adapters/metrics_adapter.py
@@ -316,10 +316,11 @@ class MetricsHook:
 
         So if the collector raises on the second call, the first stays applied:
         a failure can be recorded without its duration. That is accepted rather
-        than hidden. The exception propagates out of this hook, where
-        :func:`cuprum._observability._emit_exec_event` catches it, logs
-        ``observe_hook_failed``, and lets the command continue — a broken
-        metrics backend must not fail the user's command.
+        than hidden. The exception then leaves this hook and is not swallowed:
+        :func:`cuprum._observability._emit_exec_event` logs
+        ``observe_hook_failed`` and re-raises, so a raising collector fails the
+        user's command. A collector that must not do that has to swallow its
+        own errors.
 
         Collector implementations should therefore treat each call as
         independent and ordered, and must not assume that seeing a

--- a/cuprum/adapters/metrics_adapter.py
+++ b/cuprum/adapters/metrics_adapter.py
@@ -181,6 +181,74 @@ class InMemoryMetrics(_LockedStore):
         self.histograms.clear()
 
 
+@dc.dataclass(frozen=True, slots=True)
+class _CounterOp:
+    """A counter increment the metrics hook intends to apply."""
+
+    name: str
+    value: float
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _HistogramOp:
+    """A histogram observation the metrics hook intends to apply."""
+
+    name: str
+    value: float
+
+
+_MetricOp = _CounterOp | _HistogramOp
+
+# Phases that map to a single unit-counter increment, keyed by event phase.
+_PHASE_COUNTERS: dict[str, str] = {
+    "start": "cuprum_executions_total",
+    "stdout": "cuprum_stdout_lines_total",
+    "stderr": "cuprum_stderr_lines_total",
+    "stdin_error": "cuprum_stdin_errors_total",
+}
+
+
+def _exit_operations(event: ExecEvent) -> tuple[_MetricOp, ...]:
+    """Return the failure counter and duration histogram ops for an exit event.
+
+    A failure counter is produced only for a known non-zero exit code, and a
+    duration observation only when a duration was measured; a clean exit with
+    no duration therefore produces nothing.
+    """
+    operations: list[_MetricOp] = []
+    if event.exit_code is not None and event.exit_code != 0:
+        operations.append(_CounterOp("cuprum_failures_total", 1.0))
+    if event.duration_s is not None:
+        operations.append(_HistogramOp("cuprum_duration_seconds", event.duration_s))
+    return tuple(operations)
+
+
+def _metric_operations(event: ExecEvent) -> tuple[_MetricOp, ...]:
+    """Map an execution event to the metric operations it should produce.
+
+    This is the pure event-to-operation reducer behind
+    [`MetricsHook.__call__`][cuprum.adapters.metrics_adapter.MetricsHook.__call__]
+    — the single source of truth for which counters and histogram observations
+    each phase yields, so the operations can be verified without a collector.
+    Labels are applied by the caller. ``plan`` yields nothing; a ``stdin`` event
+    without a byte count yields nothing; an unknown phase is a contract
+    violation and raises ``_UnhandledMetricsPhaseError``.
+    """
+    phase = event.phase
+    if phase == "plan":
+        return ()
+    counter_name = _PHASE_COUNTERS.get(phase)
+    if counter_name is not None:
+        return (_CounterOp(counter_name, 1.0),)
+    if phase == "stdin":
+        if event.byte_count is None:
+            return ()
+        return (_CounterOp("cuprum_stdin_bytes_total", float(event.byte_count)),)
+    if phase == "exit":
+        return _exit_operations(event)
+    raise _UnhandledMetricsPhaseError(event.phase)
+
+
 class MetricsHook:
     """Observe hook that collects Prometheus-style metrics.
 
@@ -222,76 +290,31 @@ class MetricsHook:
         self._collector = collector
 
     def __call__(self, event: ExecEvent) -> None:
-        """Process an execution event and update metrics."""
-        match event.phase:
-            case "plan":
-                pass
-            case "start":
-                self._increment(
-                    "cuprum_executions_total",
-                    labels=self._extract_labels(event),
-                )
-            case "stdout":
-                self._increment(
-                    "cuprum_stdout_lines_total",
-                    labels=self._extract_labels(event),
-                )
-            case "stderr":
-                self._increment(
-                    "cuprum_stderr_lines_total",
-                    labels=self._extract_labels(event),
-                )
-            case "stdin_error":
-                self._increment(
-                    "cuprum_stdin_errors_total",
-                    labels=self._extract_labels(event),
-                )
-            case "stdin":
-                self._record_stdin_bytes(event, labels=self._extract_labels(event))
-            case "exit":
-                self._record_exit(event, labels=self._extract_labels(event))
-            case _:
-                raise _UnhandledMetricsPhaseError(event.phase)
+        """Process an execution event and update metrics.
 
-    def _increment(
-        self,
-        name: str,
-        *,
-        labels: cabc.Mapping[str, str],
-        value: float = 1.0,
-    ) -> None:
-        """Increment a counter with the current event labels."""
-        self._collector.inc_counter(name, value, labels)
+        The pure ``_metric_operations`` reducer decides which counters and
+        histograms this event yields; the labels are resolved and applied only
+        when there is at least one operation, so a ``plan`` (or a phaseless
+        no-op) event never computes labels.
+        """
+        operations = _metric_operations(event)
+        if not operations:
+            return
+        labels = self._extract_labels(event)
+        for operation in operations:
+            self._apply(operation, labels)
 
-    def _record_stdin_bytes(
+    def _apply(
         self,
-        event: ExecEvent,
-        *,
+        operation: _MetricOp,
         labels: cabc.Mapping[str, str],
     ) -> None:
-        """Record stdin byte throughput when the event carries a byte count."""
-        if event.byte_count is not None:
-            self._increment(
-                "cuprum_stdin_bytes_total",
-                value=float(event.byte_count),
-                labels=labels,
-            )
-
-    def _record_exit(
-        self,
-        event: ExecEvent,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Record exit-code and duration metrics for an exit event."""
-        if event.exit_code is not None and event.exit_code != 0:
-            self._increment("cuprum_failures_total", labels=labels)
-        if event.duration_s is not None:
-            self._collector.observe_histogram(
-                "cuprum_duration_seconds",
-                event.duration_s,
-                labels,
-            )
+        """Apply one metric operation to the collector with the event labels."""
+        match operation:
+            case _CounterOp(name=name, value=value):
+                self._collector.inc_counter(name, value, labels)
+            case _HistogramOp(name=name, value=value):
+                self._collector.observe_histogram(name, value, labels)
 
     @staticmethod
     def _extract_labels(event: ExecEvent) -> dict[str, str]:

--- a/cuprum/adapters/metrics_adapter.py
+++ b/cuprum/adapters/metrics_adapter.py
@@ -322,9 +322,13 @@ class MetricsHook:
         metrics backend must not fail the user's command.
 
         Collector implementations should therefore treat each call as
-        independent and idempotent-safe, and must not assume that seeing a
+        independent and ordered, and must not assume that seeing a
         ``cuprum_failures_total`` increment guarantees a matching
         ``cuprum_duration_seconds`` observation will follow.
+
+        No event or operation identifier is passed, so a collector has nothing
+        to deduplicate on and a repeated call increments again. Nothing here is
+        idempotent, and this hook never retries a failed call.
         """
         operations = _metric_operations(event)
         if not operations:

--- a/cuprum/adapters/metrics_adapter.py
+++ b/cuprum/adapters/metrics_adapter.py
@@ -197,7 +197,7 @@ class _HistogramOp:
     value: float
 
 
-_MetricOp = _CounterOp | _HistogramOp
+type _MetricOp = _CounterOp | _HistogramOp
 
 # Phases that map to a single unit-counter increment, keyed by event phase.
 _PHASE_COUNTERS: dict[str, str] = {
@@ -235,18 +235,22 @@ def _metric_operations(event: ExecEvent) -> tuple[_MetricOp, ...]:
     violation and raises ``_UnhandledMetricsPhaseError``.
     """
     phase = event.phase
-    if phase == "plan":
-        return ()
-    counter_name = _PHASE_COUNTERS.get(phase)
-    if counter_name is not None:
-        return (_CounterOp(counter_name, 1.0),)
-    if phase == "stdin":
-        if event.byte_count is None:
+    match phase:
+        case "plan":
             return ()
-        return (_CounterOp("cuprum_stdin_bytes_total", float(event.byte_count)),)
-    if phase == "exit":
-        return _exit_operations(event)
-    raise _UnhandledMetricsPhaseError(event.phase)
+        case "stdin":
+            if event.byte_count is None:
+                return ()
+            return (_CounterOp("cuprum_stdin_bytes_total", float(event.byte_count)),)
+        case "exit":
+            return _exit_operations(event)
+        case _ if (counter_name := _PHASE_COUNTERS.get(phase)) is not None:
+            # The unit-counter phases stay keyed by `_PHASE_COUNTERS` rather
+            # than repeated as a literal alternation, so the metric names have
+            # exactly one definition.
+            return (_CounterOp(counter_name, 1.0),)
+        case _:
+            raise _UnhandledMetricsPhaseError(phase)
 
 
 class MetricsHook:

--- a/cuprum/adapters/metrics_adapter.py
+++ b/cuprum/adapters/metrics_adapter.py
@@ -303,6 +303,28 @@ class MetricsHook:
         histograms this event yields; the labels are resolved and applied only
         when there is at least one operation, so a ``plan`` (or a phaseless
         no-op) event never computes labels.
+
+        Partial-failure semantics
+        -------------------------
+        An ``exit`` event can yield two operations — a failure counter and a
+        duration observation — applied as two independent collector calls, in
+        that order. There is no atomicity across them, and none is attempted:
+        the collector wraps an arbitrary backend (``prometheus_client``,
+        statsd, OpenTelemetry), and this adapter cannot make two writes to such
+        a backend transactional. Buffering them to apply together would only
+        move the problem, while delaying when metrics appear.
+
+        So if the collector raises on the second call, the first stays applied:
+        a failure can be recorded without its duration. That is accepted rather
+        than hidden. The exception propagates out of this hook, where
+        :func:`cuprum._observability._emit_exec_event` catches it, logs
+        ``observe_hook_failed``, and lets the command continue — a broken
+        metrics backend must not fail the user's command.
+
+        Collector implementations should therefore treat each call as
+        independent and idempotent-safe, and must not assume that seeing a
+        ``cuprum_failures_total`` increment guarantees a matching
+        ``cuprum_duration_seconds`` observation will follow.
         """
         operations = _metric_operations(event)
         if not operations:

--- a/cuprum/adapters/metrics_adapter.py
+++ b/cuprum/adapters/metrics_adapter.py
@@ -60,6 +60,7 @@ Example with prometheus_client::
 from __future__ import annotations
 
 import dataclasses as dc
+import types
 import typing as typ
 
 from cuprum.adapters._support import (
@@ -200,12 +201,14 @@ class _HistogramOp:
 type _MetricOp = _CounterOp | _HistogramOp
 
 # Phases that map to a single unit-counter increment, keyed by event phase.
-_PHASE_COUNTERS: dict[str, str] = {
+# Read-only, so the single source of truth for these metric names cannot be
+# rewritten at runtime by an importing module.
+_PHASE_COUNTERS: cabc.Mapping[str, str] = types.MappingProxyType({
     "start": "cuprum_executions_total",
     "stdout": "cuprum_stdout_lines_total",
     "stderr": "cuprum_stderr_lines_total",
     "stdin_error": "cuprum_stdin_errors_total",
-}
+})
 
 
 def _exit_operations(event: ExecEvent) -> tuple[_MetricOp, ...]:

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -93,6 +93,7 @@
       'cuprum/unittests/test_folded_summary.py',
       'cuprum/unittests/test_line_splitting.py',
       'cuprum/unittests/test_logging_adapter.py',
+      'cuprum/unittests/test_logging_adapter_properties.py',
       'cuprum/unittests/test_logging_hook.py',
       'cuprum/unittests/test_manylinux_container_ref_properties.py',
       'cuprum/unittests/test_maturin_build.py',

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -99,6 +99,7 @@
       'cuprum/unittests/test_maturin_pins.py',
       'cuprum/unittests/test_maturin_toolchain.py',
       'cuprum/unittests/test_metrics_adapter.py',
+      'cuprum/unittests/test_metrics_adapter_stateful.py',
       'cuprum/unittests/test_observe.py',
       'cuprum/unittests/test_observe_stdin_early_close.py',
       'cuprum/unittests/test_performance_guidance_docs.py',

--- a/cuprum/unittests/test_logging_adapter_properties.py
+++ b/cuprum/unittests/test_logging_adapter_properties.py
@@ -1,0 +1,242 @@
+"""Property tests for the structured logging hook.
+
+`structured_logging_hook` is a pure per-event function: it maps a phase to a
+level, builds an ``extra`` mapping, formats a message, and emits exactly one
+record. It holds no active map, so a `RuleBasedStateMachine` would generate
+interleavings that cannot distinguish any two implementations — the tracing and
+metrics hooks earn one because they accumulate state across events, and this
+one does not.
+
+What can go wrong is per-event and shape-dependent, which is what these
+properties cover: an extra key colliding with a reserved `LogRecord` attribute
+(a `KeyError` raised inside the user's logging stack, not in cuprum), a phase
+falling through the level map, and a value that `JsonLoggingFormatter` cannot
+serialize. Each fails only for particular event shapes that hand-written cases
+are unlikely to enumerate.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import typing as typ
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from cuprum.adapters.logging_adapter import (
+    JsonLoggingFormatter,
+    LogLevels,
+    _format_message,
+    structured_logging_hook,
+)
+from cuprum.events import ExecEvent
+
+if typ.TYPE_CHECKING:
+    from cuprum.events import ExecPhase
+    from cuprum.program import Program
+
+_KNOWN_PHASES = ["plan", "start", "stdout", "stderr", "stdin", "stdin_error", "exit"]
+
+# Reserved names live directly on every LogRecord. Passing any of them through
+# `extra=` makes `Logger.makeRecord` raise, so the `cuprum_` prefix is what
+# keeps the hook from breaking a caller's logging configuration.
+_RESERVED_RECORD_ATTRIBUTES = frozenset(
+    vars(logging.LogRecord("n", 0, "p", 0, "m", (), None))
+)
+
+
+class _CollectingHandler(logging.Handler):
+    """Handler retaining every record it is given."""
+
+    def __init__(self) -> None:
+        """Start with no records collected."""
+        super().__init__(level=logging.NOTSET)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Retain ``record`` for inspection."""
+        self.records.append(record)
+
+
+def _capturing_logger(name: str) -> tuple[logging.Logger, _CollectingHandler]:
+    """Return a logger that captures everything, plus its handler.
+
+    The level is set explicitly rather than left at ``NOTSET``, which would
+    defer to the root logger's ``WARNING`` and make the hook skip its own
+    debug and info records — a real behaviour of the hook (it checks
+    ``isEnabledFor`` before building anything), but not the one under test
+    here.
+    """
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    handler = _CollectingHandler()
+    logger.addHandler(handler)
+    return logger, handler
+
+
+_awkward_text = st.text(
+    # Control characters, quotes, and non-BMP scalars all have to survive the
+    # JSON round trip, so generate them rather than plain ASCII.
+    alphabet=st.characters(min_codepoint=1, max_codepoint=0x10FFFF),
+    max_size=40,
+)
+
+
+class _Opaque:
+    """A tag value with no JSON representation of its own."""
+
+    def __repr__(self) -> str:
+        """Render a stable placeholder for the coerced form."""
+        return "<opaque>"
+
+
+# `ExecEvent.tags` is typed `Mapping[str, object]`, so a caller may attach any
+# object. Generating only strings would make the JSON property vacuous: it is
+# precisely these values that `_json_serializable` and `default=str` exist for.
+_tag_values = st.one_of(
+    _awkward_text,
+    st.integers(),
+    st.booleans(),
+    st.none(),
+    st.builds(_Opaque),
+    st.lists(st.builds(_Opaque), max_size=2),
+    st.dictionaries(_awkward_text, st.builds(_Opaque), max_size=2),
+)
+
+
+@st.composite
+def _events(draw: st.DrawFn) -> ExecEvent:
+    """Draw an event with phase-appropriate fields and awkward text."""
+    phase = draw(st.sampled_from([*_KNOWN_PHASES, "unheard-of"]))
+    return ExecEvent(
+        phase=typ.cast("ExecPhase", phase),
+        program=typ.cast("Program", draw(_awkward_text)),
+        argv=tuple(draw(st.lists(_awkward_text, max_size=3))),
+        cwd=None,
+        env=None,
+        pid=draw(st.none() | st.integers(min_value=0, max_value=1 << 20)),
+        timestamp=0.0,
+        line=draw(st.none() | _awkward_text),
+        exit_code=draw(st.none() | st.integers(min_value=-3, max_value=3)),
+        duration_s=draw(
+            st.none()
+            | st.floats(
+                min_value=0.0,
+                max_value=100.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        ),
+        tags=dict(
+            draw(st.lists(st.tuples(_awkward_text, _tag_values), max_size=3)),
+        ),
+        byte_count=draw(st.none() | st.integers(min_value=0, max_value=1 << 20)),
+    )
+
+
+@given(event=_events())
+@settings(max_examples=200)
+def test_every_event_emits_exactly_one_record(event: ExecEvent) -> None:
+    """No phase is silently dropped, and none emits twice."""
+    logger, handler = _capturing_logger("cuprum.test.one_record")
+    structured_logging_hook(logger=logger)(event)
+
+    assert len(handler.records) == 1, (
+        f"phase {event.phase!r} emitted {len(handler.records)} records, expected 1"
+    )
+
+
+@given(event=_events())
+@settings(max_examples=200)
+def test_extras_cannot_collide_with_reserved_record_attributes(
+    event: ExecEvent,
+) -> None:
+    """Every attached field is ``cuprum_``-prefixed, so nothing is shadowed.
+
+    A collision does not fail in cuprum: ``Logger.makeRecord`` raises a
+    ``KeyError`` deep inside the caller's logging stack, which is expensive to
+    trace back here.
+    """
+    logger, handler = _capturing_logger("cuprum.test.reserved")
+    structured_logging_hook(logger=logger)(event)
+
+    record = handler.records[0]
+    attached = set(vars(record)) - _RESERVED_RECORD_ATTRIBUTES
+    unprefixed = {name for name in attached if not name.startswith("cuprum_")}
+    assert not unprefixed, (
+        f"every attached field must be cuprum_-prefixed, found {unprefixed}"
+    )
+    assert attached, "the hook must attach the structured fields it documents"
+
+
+@given(event=_events())
+@settings(max_examples=200)
+def test_records_survive_the_json_formatter(event: ExecEvent) -> None:
+    """Any event formats to JSON that ``json.loads`` accepts."""
+    logger, handler = _capturing_logger("cuprum.test.json")
+    structured_logging_hook(logger=logger)(event)
+
+    rendered = JsonLoggingFormatter().format(handler.records[0])
+    decoded = json.loads(rendered)
+
+    assert decoded["cuprum_phase"] == event.phase, (
+        "the decoded record must report the event's own phase"
+    )
+    assert decoded["message"], "a formatted record must carry a non-empty message"
+
+
+@given(event=_events())
+@settings(max_examples=200)
+def test_message_formatting_is_total(event: ExecEvent) -> None:
+    """Every phase formats to a non-empty message, known or not."""
+    message = _format_message(event)
+
+    assert message, f"phase {event.phase!r} produced an empty message"
+    assert message.startswith("cuprum."), (
+        f"messages must be namespaced, found {message!r}"
+    )
+
+
+@given(
+    event=_events(),
+    levels=st.builds(
+        LogLevels,
+        plan_level=st.sampled_from([logging.DEBUG, logging.INFO]),
+        start_level=st.sampled_from([logging.INFO, logging.WARNING]),
+        output_level=st.sampled_from([logging.DEBUG, logging.INFO]),
+        exit_level=st.sampled_from([logging.INFO, logging.ERROR]),
+    ),
+)
+@settings(max_examples=200)
+def test_each_phase_logs_at_its_configured_level(
+    event: ExecEvent,
+    levels: LogLevels,
+) -> None:
+    """Every known phase logs at its own configured level.
+
+    The expected level is derived here independently rather than by accepting
+    any configured value: a permissive check passes even if a phase is dropped
+    from the map entirely and silently falls back to ``DEBUG``.
+
+    An unknown phase must fall back rather than raise — phases are part of the
+    event contract and may grow, and a logging hook is the wrong place to
+    discover that.
+    """
+    logger, handler = _capturing_logger("cuprum.test.levels")
+    structured_logging_hook(logger=logger, levels=levels)(event)
+
+    expected = {
+        "plan": levels.plan_level,
+        "start": levels.start_level,
+        "stdout": levels.output_level,
+        "stderr": levels.output_level,
+        "exit": levels.exit_level,
+    }.get(event.phase, logging.DEBUG)
+
+    assert handler.records[0].levelno == expected, (
+        f"phase {event.phase!r} logged at {handler.records[0].levelname}, "
+        f"expected {logging.getLevelName(expected)}"
+    )

--- a/cuprum/unittests/test_metrics_adapter_stateful.py
+++ b/cuprum/unittests/test_metrics_adapter_stateful.py
@@ -76,12 +76,16 @@ def _event(
 @pytest.mark.parametrize(("phase", "counter"), _UNIT_COUNTER_PHASES)
 def test_unit_counter_phases_yield_one_increment(phase: str, counter: str) -> None:
     """Each simple phase yields exactly one unit increment of its counter."""
-    assert _metric_operations(_event(phase)) == (_CounterOp(counter, 1.0),)
+    assert _metric_operations(_event(phase)) == (_CounterOp(counter, 1.0),), (
+        f"phase {phase!r} must yield exactly one unit increment of {counter!r}"
+    )
 
 
 def test_plan_phase_yields_no_operations() -> None:
     """The plan phase produces no metric operations."""
-    assert _metric_operations(_event("plan")) == ()
+    assert _metric_operations(_event("plan")) == (), (
+        "the plan phase precedes execution, so it must yield no operations"
+    )
 
 
 @given(byte_count=st.none() | st.integers(min_value=0, max_value=1_000_000))
@@ -92,10 +96,15 @@ def test_stdin_yields_bytes_counter_only_when_counted(
     """A stdin event yields a bytes counter iff it carries a byte count."""
     operations = _metric_operations(_event("stdin", byte_count=byte_count))
     if byte_count is None:
-        assert operations == ()
+        assert operations == (), (
+            f"an uncounted stdin event must yield no operations, found {operations!r}"
+        )
     else:
         assert operations == (
             _CounterOp("cuprum_stdin_bytes_total", float(byte_count)),
+        ), (
+            f"a stdin event carrying {byte_count} bytes must yield exactly that "
+            f"counter, found {operations!r}"
         )
 
 
@@ -118,7 +127,10 @@ def test_exit_yields_failure_and_duration_only_when_present(
         expected.append(_CounterOp("cuprum_failures_total", 1.0))
     if duration_s is not None:
         expected.append(_HistogramOp("cuprum_duration_seconds", duration_s))
-    assert list(operations) == expected
+    assert list(operations) == expected, (
+        f"exit(exit_code={exit_code!r}, duration_s={duration_s!r}) must yield "
+        f"{expected!r}, found {list(operations)!r}"
+    )
 
 
 def test_unknown_phase_raises_structured_error() -> None:
@@ -207,13 +219,22 @@ class _MetricsAccumulationMachine(RuleBasedStateMachine):
     @invariant()
     def collector_matches_independent_expectations(self) -> None:
         """Check the collector reflects exactly the counted per-phase effects."""
-        assert self.metrics.counters == self.expected_counters
-        assert (
-            self.metrics.histograms.get("cuprum_duration_seconds", [])
-            == self.expected_durations
+        assert self.metrics.counters == self.expected_counters, (
+            "collected counters must match the independent phase-count oracle; "
+            f"collected {self.metrics.counters!r}, expected "
+            f"{self.expected_counters!r}"
+        )
+        observed_durations = self.metrics.histograms.get("cuprum_duration_seconds", [])
+        assert observed_durations == self.expected_durations, (
+            "the duration histogram must hold exactly the measured durations, in "
+            f"order; observed {observed_durations!r}, expected "
+            f"{self.expected_durations!r}"
         )
         # The duration histogram is the only histogram the hook ever writes.
-        assert set(self.metrics.histograms) <= {"cuprum_duration_seconds"}
+        assert set(self.metrics.histograms) <= {"cuprum_duration_seconds"}, (
+            "the hook must write no histogram beyond cuprum_duration_seconds, "
+            f"found {sorted(self.metrics.histograms)}"
+        )
 
 
 TestMetricsAccumulation = _MetricsAccumulationMachine.TestCase

--- a/cuprum/unittests/test_metrics_adapter_stateful.py
+++ b/cuprum/unittests/test_metrics_adapter_stateful.py
@@ -1,0 +1,224 @@
+"""Property and stateful tests for the metrics event-to-operation reducer.
+
+`_metric_operations` is the pure reducer mapping each `ExecEvent` to the counter
+and histogram operations the metrics hook should apply. The property tests pin
+the operations produced per phase; the `RuleBasedStateMachine` drives random
+event streams through a real `MetricsHook`/`InMemoryMetrics` and checks the
+accumulated counters and histograms against an independent phase-count oracle —
+so counters and observations are created exactly when intended, and only then.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
+
+from cuprum.adapters.metrics_adapter import (
+    InMemoryMetrics,
+    MetricsHook,
+    _CounterOp,
+    _HistogramOp,
+    _metric_operations,
+    _UnhandledMetricsPhaseError,
+)
+from cuprum.events import ExecEvent
+
+if typ.TYPE_CHECKING:
+    from cuprum.events import ExecPhase
+    from cuprum.program import Program
+
+_KNOWN_PHASES: list[str] = [
+    "plan",
+    "start",
+    "stdout",
+    "stderr",
+    "stdin",
+    "stdin_error",
+    "exit",
+]
+
+_UNIT_COUNTER_PHASES = [
+    ("start", "cuprum_executions_total"),
+    ("stdout", "cuprum_stdout_lines_total"),
+    ("stderr", "cuprum_stderr_lines_total"),
+    ("stdin_error", "cuprum_stdin_errors_total"),
+]
+
+
+def _event(
+    phase: str,
+    *,
+    byte_count: int | None = None,
+    exit_code: int | None = None,
+    duration_s: float | None = None,
+) -> ExecEvent:
+    """Build an ``ExecEvent`` carrying only the fields the reducer reads."""
+    return ExecEvent(
+        phase=typ.cast("ExecPhase", phase),
+        program=typ.cast("Program", "prog"),
+        argv=("prog",),
+        cwd=None,
+        env=None,
+        pid=None,
+        timestamp=0.0,
+        line=None,
+        exit_code=exit_code,
+        duration_s=duration_s,
+        tags={},
+        byte_count=byte_count,
+    )
+
+
+@pytest.mark.parametrize(("phase", "counter"), _UNIT_COUNTER_PHASES)
+def test_unit_counter_phases_yield_one_increment(phase: str, counter: str) -> None:
+    """Each simple phase yields exactly one unit increment of its counter."""
+    assert _metric_operations(_event(phase)) == (_CounterOp(counter, 1.0),)
+
+
+def test_plan_phase_yields_no_operations() -> None:
+    """The plan phase produces no metric operations."""
+    assert _metric_operations(_event("plan")) == ()
+
+
+@given(byte_count=st.none() | st.integers(min_value=0, max_value=1_000_000))
+def test_stdin_yields_bytes_counter_only_when_counted(
+    *,
+    byte_count: int | None,
+) -> None:
+    """A stdin event yields a bytes counter iff it carries a byte count."""
+    operations = _metric_operations(_event("stdin", byte_count=byte_count))
+    if byte_count is None:
+        assert operations == ()
+    else:
+        assert operations == (
+            _CounterOp("cuprum_stdin_bytes_total", float(byte_count)),
+        )
+
+
+@given(
+    exit_code=st.none() | st.integers(min_value=-3, max_value=3),
+    duration_s=st.none()
+    | st.floats(min_value=0.0, max_value=100.0, allow_nan=False, allow_infinity=False),
+)
+def test_exit_yields_failure_and_duration_only_when_present(
+    *,
+    exit_code: int | None,
+    duration_s: float | None,
+) -> None:
+    """An exit event counts a failure iff non-zero, and a duration iff measured."""
+    operations = _metric_operations(
+        _event("exit", exit_code=exit_code, duration_s=duration_s),
+    )
+    expected: list[_CounterOp | _HistogramOp] = []
+    if exit_code is not None and exit_code != 0:
+        expected.append(_CounterOp("cuprum_failures_total", 1.0))
+    if duration_s is not None:
+        expected.append(_HistogramOp("cuprum_duration_seconds", duration_s))
+    assert list(operations) == expected
+
+
+def test_unknown_phase_raises_structured_error() -> None:
+    """An out-of-contract phase raises the structured metrics error."""
+    with pytest.raises(_UnhandledMetricsPhaseError):
+        _metric_operations(_event("future_phase"))
+
+
+@st.composite
+def _events(draw: st.DrawFn) -> ExecEvent:
+    """Draw an event across the known phases with phase-appropriate fields."""
+    phase = draw(st.sampled_from(_KNOWN_PHASES))
+    byte_count = (
+        draw(st.none() | st.integers(min_value=0, max_value=1_000_000))
+        if phase == "stdin"
+        else None
+    )
+    exit_code = (
+        draw(st.none() | st.integers(min_value=-3, max_value=3))
+        if phase == "exit"
+        else None
+    )
+    duration_s = (
+        draw(
+            st.none()
+            | st.floats(
+                min_value=0.0,
+                max_value=100.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        )
+        if phase == "exit"
+        else None
+    )
+    return _event(
+        phase,
+        byte_count=byte_count,
+        exit_code=exit_code,
+        duration_s=duration_s,
+    )
+
+
+class _MetricsAccumulationMachine(RuleBasedStateMachine):
+    """Feed random event streams to a real hook and check accumulated metrics.
+
+    Expectations are tracked independently of the reducer — by counting events
+    per phase — so the machine cross-checks the reducer, the operation
+    application, and the collector's accumulation together.
+    """
+
+    def __init__(self) -> None:
+        """Start with a fresh collector, hook, and empty expectations."""
+        super().__init__()
+        self.metrics = InMemoryMetrics()
+        self.hook = MetricsHook(self.metrics)
+        self.expected_counters: dict[str, float] = {}
+        self.expected_durations: list[float] = []
+
+    def _expect_counter(self, name: str, value: float) -> None:
+        """Record an independently-computed counter increment."""
+        self.expected_counters[name] = self.expected_counters.get(name, 0.0) + value
+
+    @rule(event=_events())
+    def emit(self, event: ExecEvent) -> None:
+        """Apply an event to the hook and to the independent expectations."""
+        self.hook(event)
+
+        phase = event.phase
+        simple = {
+            "start": "cuprum_executions_total",
+            "stdout": "cuprum_stdout_lines_total",
+            "stderr": "cuprum_stderr_lines_total",
+            "stdin_error": "cuprum_stdin_errors_total",
+        }
+        if phase in simple:
+            self._expect_counter(simple[phase], 1.0)
+        elif phase == "stdin" and event.byte_count is not None:
+            self._expect_counter("cuprum_stdin_bytes_total", float(event.byte_count))
+        elif phase == "exit":
+            if event.exit_code is not None and event.exit_code != 0:
+                self._expect_counter("cuprum_failures_total", 1.0)
+            if event.duration_s is not None:
+                self.expected_durations.append(event.duration_s)
+
+    @invariant()
+    def collector_matches_independent_expectations(self) -> None:
+        """Check the collector reflects exactly the counted per-phase effects."""
+        assert self.metrics.counters == self.expected_counters
+        assert (
+            self.metrics.histograms.get("cuprum_duration_seconds", [])
+            == self.expected_durations
+        )
+        # The duration histogram is the only histogram the hook ever writes.
+        assert set(self.metrics.histograms) <= {"cuprum_duration_seconds"}
+
+
+TestMetricsAccumulation = _MetricsAccumulationMachine.TestCase
+TestMetricsAccumulation.settings = settings(
+    max_examples=60,
+    stateful_step_count=20,
+    deadline=None,
+)

--- a/cuprum/unittests/test_metrics_adapter_stateful.py
+++ b/cuprum/unittests/test_metrics_adapter_stateful.py
@@ -10,6 +10,7 @@ so counters and observations are created exactly when intended, and only then.
 
 from __future__ import annotations
 
+import types
 import typing as typ
 
 import pytest
@@ -49,6 +50,15 @@ _UNIT_COUNTER_PHASES = [
     ("stderr", "cuprum_stderr_lines_total"),
     ("stdin_error", "cuprum_stdin_errors_total"),
 ]
+
+# The same pairs keyed for lookup, so the stateful oracle and the parametrized
+# cases cannot drift apart. This stays a *test-local* restatement of the
+# mapping rather than an import of the adapter's `_PHASE_COUNTERS`: an oracle
+# that read the production table would agree with it by construction and could
+# not catch a wrong metric name.
+_UNIT_COUNTERS: cabc.Mapping[str, str] = types.MappingProxyType(
+    dict(_UNIT_COUNTER_PHASES)
+)
 
 
 def _event(
@@ -201,22 +211,23 @@ class _MetricsAccumulationMachine(RuleBasedStateMachine):
         """Apply an event to the hook and to the independent expectations."""
         self.hook(event)
 
-        phase = event.phase
-        simple = {
-            "start": "cuprum_executions_total",
-            "stdout": "cuprum_stdout_lines_total",
-            "stderr": "cuprum_stderr_lines_total",
-            "stdin_error": "cuprum_stdin_errors_total",
-        }
-        if phase in simple:
-            self._expect_counter(simple[phase], 1.0)
-        elif phase == "stdin" and event.byte_count is not None:
-            self._expect_counter("cuprum_stdin_bytes_total", float(event.byte_count))
-        elif phase == "exit":
-            if event.exit_code is not None and event.exit_code != 0:
-                self._expect_counter("cuprum_failures_total", 1.0)
-            if event.duration_s is not None:
-                self.expected_durations.append(event.duration_s)
+        match event.phase:
+            case _ if (counter := _UNIT_COUNTERS.get(event.phase)) is not None:
+                self._expect_counter(counter, 1.0)
+            case "stdin" if event.byte_count is not None:
+                self._expect_counter(
+                    "cuprum_stdin_bytes_total",
+                    float(event.byte_count),
+                )
+            case "exit":
+                if event.exit_code is not None and event.exit_code != 0:
+                    self._expect_counter("cuprum_failures_total", 1.0)
+                if event.duration_s is not None:
+                    self.expected_durations.append(event.duration_s)
+            case _:
+                # `plan` records nothing, and a `stdin` event carrying no byte
+                # count contributes no bytes. Both leave the oracle unchanged.
+                pass
 
     @invariant()
     def collector_matches_independent_expectations(self) -> None:

--- a/cuprum/unittests/test_metrics_adapter_stateful.py
+++ b/cuprum/unittests/test_metrics_adapter_stateful.py
@@ -28,6 +28,8 @@ from cuprum.adapters.metrics_adapter import (
 from cuprum.events import ExecEvent
 
 if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
     from cuprum.events import ExecPhase
     from cuprum.program import Program
 
@@ -243,3 +245,48 @@ TestMetricsAccumulation.settings = settings(
     stateful_step_count=20,
     deadline=None,
 )
+
+
+class _FailingHistogramCollector(InMemoryMetrics):
+    """A collector whose histogram writes always fail.
+
+    Stands in for a metrics backend that is reachable for one call and not the
+    next — the case that decides what a partially-applied event leaves behind.
+    """
+
+    @typ.override
+    def observe_histogram(
+        self,
+        name: str,
+        value: float,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Fail as a backend rejecting the observation would."""
+        msg = f"metrics backend rejected {name}"
+        raise RuntimeError(msg)
+
+
+def test_a_failing_second_operation_leaves_the_first_applied() -> None:
+    """A partly-applied exit event keeps what already landed, and reports.
+
+    An exit event yields a failure counter then a duration observation, as two
+    independent collector calls. There is no atomicity across them and none is
+    attempted, so this pins what a caller actually observes rather than leaving
+    it to chance: the counter stays, the histogram is absent, and the error
+    reaches the hook's caller — which isolates it, so the command survives.
+    """
+    collector = _FailingHistogramCollector()
+    hook = MetricsHook(collector)
+    event = _event("exit", exit_code=3, duration_s=1.5)
+
+    with pytest.raises(RuntimeError, match="rejected cuprum_duration_seconds"):
+        hook(event)
+
+    assert collector.counters == {"cuprum_failures_total": 1.0}, (
+        "the counter applied before the failure must remain recorded, found "
+        f"{collector.counters!r}"
+    )
+    assert collector.histograms == {}, (
+        "the observation that raised must not be recorded, found "
+        f"{collector.histograms!r}"
+    )

--- a/cuprum/unittests/test_metrics_adapter_stateful.py
+++ b/cuprum/unittests/test_metrics_adapter_stateful.py
@@ -18,6 +18,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
 
+from cuprum import sh
 from cuprum.adapters.metrics_adapter import (
     InMemoryMetrics,
     MetricsHook,
@@ -26,7 +27,9 @@ from cuprum.adapters.metrics_adapter import (
     _metric_operations,
     _UnhandledMetricsPhaseError,
 )
+from cuprum.context import ScopeConfig, scoped
 from cuprum.events import ExecEvent
+from cuprum.unittests._adapter_test_support import _python_builder
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -258,6 +261,10 @@ TestMetricsAccumulation.settings = settings(
 )
 
 
+class _MetricsBackendError(Exception):
+    """Test exception standing in for a backend rejecting a metric write."""
+
+
 class _FailingHistogramCollector(InMemoryMetrics):
     """A collector whose histogram writes always fail.
 
@@ -274,7 +281,7 @@ class _FailingHistogramCollector(InMemoryMetrics):
     ) -> None:
         """Fail as a backend rejecting the observation would."""
         msg = f"metrics backend rejected {name}"
-        raise RuntimeError(msg)
+        raise _MetricsBackendError(msg)
 
 
 def test_a_failing_second_operation_leaves_the_first_applied() -> None:
@@ -283,14 +290,14 @@ def test_a_failing_second_operation_leaves_the_first_applied() -> None:
     An exit event yields a failure counter then a duration observation, as two
     independent collector calls. There is no atomicity across them and none is
     attempted, so this pins what a caller actually observes rather than leaving
-    it to chance: the counter stays, the histogram is absent, and the error
-    reaches the hook's caller — which isolates it, so the command survives.
+    it to chance: the counter stays, the histogram is absent, and the backend's
+    own exception leaves the hook unwrapped rather than being absorbed.
     """
     collector = _FailingHistogramCollector()
     hook = MetricsHook(collector)
     event = _event("exit", exit_code=3, duration_s=1.5)
 
-    with pytest.raises(RuntimeError, match="rejected cuprum_duration_seconds"):
+    with pytest.raises(_MetricsBackendError, match="rejected cuprum_duration_seconds"):
         hook(event)
 
     assert collector.counters == {"cuprum_failures_total": 1.0}, (
@@ -301,3 +308,24 @@ def test_a_failing_second_operation_leaves_the_first_applied() -> None:
         "the observation that raised must not be recorded, found "
         f"{collector.histograms!r}"
     )
+
+
+def test_a_failing_collector_fails_the_command() -> None:
+    """A raising collector is not isolated; its exception fails the command.
+
+    Cuprum logs ``observe_hook_failed`` and then re-raises, so the backend's
+    own exception type reaches the caller of ``run_sync`` unchanged. This pins
+    the escalation path the adapter documents, and is why the reducer's
+    fail-closed phase match matters: an unhandled phase would take commands
+    down for every caller that has registered the hook.
+    """
+    builder, catalogue = _python_builder(project_name="metrics-failure")
+    cmd = builder("-c", "pass")
+    hook = MetricsHook(_FailingHistogramCollector())
+
+    with (
+        scoped(ScopeConfig(allowlist=catalogue.allowlist)),
+        sh.observe(hook),
+        pytest.raises(_MetricsBackendError, match="rejected cuprum_duration_seconds"),
+    ):
+        cmd.run_sync()

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -772,7 +772,13 @@ Internally, command execution can be described in terms of events:
 - `plan` – intention to run a particular `Program` with argv/cwd/env;
 - `start` – process successfully spawned, with pid and timestamp;
 - `stdout` / `stderr` – output lines or chunks (optional);
+- `stdin` – bytes written to the child's standard input, with a byte count;
+- `stdin_error` – a standard-input write or close failed, with the failing
+  operation and the raised error's type;
 - `exit` – process finished, with exit code and duration.
+
+These seven phases are the whole of `ExecPhase`; there is no other value a
+hook can receive.
 
 These events are surfaced to user code via hooks. A typical hook signature
 might be:
@@ -780,7 +786,9 @@ might be:
 ```python
 @dataclass
 class ExecEvent:
-    phase: Literal["plan", "start", "stdout", "stderr", "exit"]
+    phase: Literal[
+        "plan", "start", "stdout", "stderr", "exit", "stdin", "stdin_error"
+    ]
     program: Program | None
     argv: tuple[str, ...]
     cwd: Path | None
@@ -978,9 +986,10 @@ The following design decisions were made during implementation:
 The structured event stream (`ExecEvent`) is exposed via `sh.observe()` and
 implemented with the following decisions:
 
-- **Event phases:** Cuprum emits `plan`, `start`, `stdout`, `stderr`, and `exit`
-  phases for both single commands and pipeline stages. Pipeline stage events
-  are tagged with a stage index and stage count.
+- **Event phases:** Cuprum emits `plan`, `start`, `stdout`, `stderr`, `stdin`,
+  `stdin_error`, and `exit` phases for both single commands and pipeline
+  stages — the full `ExecPhase` set. Pipeline stage events are tagged with a
+  stage index and stage count.
 - **Correlation:** every event for one execution carries the same
   `ExecEvent.exec_id`, a stable token minted once per execution (per pipeline
   stage for pipelines). Consumers that track per-execution state — such as the
@@ -1472,9 +1481,15 @@ design decisions guide these adapters:
   property-tested without a collector at all.
 - Labels are resolved only when the reducer yields at least one operation, so a
   `plan` event — which records nothing — never projects labels off the event.
-- The reducer is total over the documented phase contract: an unrecognized
-  phase raises `_UnhandledMetricsPhaseError` rather than being silently
-  ignored, so a new phase cannot be added without a deliberate decision here.
+- The reducer is total over `ExecPhase` — all seven phases (`plan`, `start`,
+  `stdout`, `stderr`, `stdin`, `stdin_error`, `exit`) have an arm — and
+  fail-closed beyond it: any other phase raises `_UnhandledMetricsPhaseError`
+  rather than being silently ignored. That is deliberate, and its cost is
+  worth stating plainly. A hook exception is not swallowed, so adding a value
+  to `ExecPhase` without adding an arm here would raise for every caller that
+  has already registered `MetricsHook`. A new phase therefore cannot reach
+  metrics without a decision in this reducer. The structured logging adapter
+  is fail-open by contrast, formatting an unrecognized phase generically.
 
 For screen readers: The following sequence diagram shows how one execution
 event becomes collector calls. The observe-hook dispatcher invokes
@@ -1538,10 +1553,13 @@ Three consequences follow, and collector implementations depend on them:
 - **The order is fixed.** The failure counter is applied before the duration
   observation, so a partial application is always the prefix, never the
   suffix.
-- **The exception propagates.** It leaves the hook, and
-  `cuprum._observability._emit_exec_event` catches it, logs
-  `observe_hook_failed`, and lets the command continue: a broken metrics
-  backend must not fail a user's command.
+- **The exception propagates, and the command fails with it.**
+  `cuprum._observability._emit_exec_event` logs `observe_hook_failed`, then
+  wraps the error in `_ExecEventEmissionError` so that observe-hook tasks
+  already scheduled survive cleanup; `_StageObservation.emit` unwraps that
+  wrapper and re-raises the collector's original exception. A broken metrics
+  backend therefore takes the user's command down rather than being absorbed,
+  so a collector that must not do that has to swallow its own errors.
 
 So a collector must treat each call as independent and ordered, and must
 never assume that seeing a `cuprum_failures_total` increment guarantees a

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1543,11 +1543,20 @@ Three consequences follow, and collector implementations depend on them:
   `observe_hook_failed`, and lets the command continue: a broken metrics
   backend must not fail a user's command.
 
-So a collector must treat each call as independent and idempotent-safe, and
-must never assume that seeing a `cuprum_failures_total` increment guarantees a
-matching `cuprum_duration_seconds` observation will follow. The label mapping
-is read-only for the duration of the loop — it is extracted once, before the
-first call, and the same mapping is passed to every operation.
+So a collector must treat each call as independent and ordered, and must
+never assume that seeing a `cuprum_failures_total` increment guarantees a
+matching `cuprum_duration_seconds` observation will follow.
+
+Note what the adapter does *not* offer. No event or operation identifier is
+passed to `inc_counter` or `observe_histogram`, so a collector has nothing to
+deduplicate on: a repeated call increments again. Nothing here is idempotent,
+and the adapter never retries a failed call — which is why a partial
+application stays partial rather than being replayed. A collector that wants
+exactly-once semantics has to obtain the identity from somewhere else.
+
+The label mapping is read-only for the duration of the loop — it is extracted
+once, before the first call, and the same mapping is passed to every
+operation.
 
 ______________________________________________________________________
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1462,6 +1462,56 @@ design decisions guide these adapters:
 - Provides configurable log levels per phase (plan, start, output, exit).
 - Includes a `JsonLoggingFormatter` for log aggregation systems.
 
+**Event-to-operation reduction:**
+
+- `MetricsHook` does not touch the collector while deciding what to record.
+  The pure `_metric_operations` reducer maps an `ExecEvent` to a tuple of
+  `_CounterOp` and `_HistogramOp` records, and `_apply` is the only step that
+  reaches the `MetricsCollector`. That split is the single source of truth for
+  which counters and observations each phase yields, and it lets the mapping be
+  property-tested without a collector at all.
+- Labels are resolved only when the reducer yields at least one operation, so a
+  `plan` event — which records nothing — never projects labels off the event.
+- The reducer is total over the documented phase contract: an unrecognized
+  phase raises `_UnhandledMetricsPhaseError` rather than being silently
+  ignored, so a new phase cannot be added without a deliberate decision here.
+
+For screen readers: The following sequence diagram shows how one execution
+event becomes collector calls. The observe-hook dispatcher invokes
+`MetricsHook` with the `ExecEvent`; the hook asks `_metric_operations` for the
+operations that event yields and receives a tuple of `_MetricOp` records. When
+the tuple is empty the hook returns immediately without computing labels.
+Otherwise it extracts the `program` and `project` labels once, then applies
+each operation in turn: a `_CounterOp` becomes `inc_counter(name, value,
+labels)` on the collector, and a `_HistogramOp` becomes `observe_histogram(name,
+value, labels)`.
+
+```mermaid
+sequenceDiagram
+    participant ExecEvent
+    participant MetricsHook
+    participant Reducer as _metric_operations
+    participant Collector as MetricsCollector
+
+    ExecEvent ->> MetricsHook: __call__(event)
+    MetricsHook ->> Reducer: _metric_operations(event)
+    Reducer -->> MetricsHook: tuple[_MetricOp]
+
+    alt no operations
+        MetricsHook -->> ExecEvent: return
+    else has operations
+        MetricsHook ->> MetricsHook: _extract_labels(event)
+        loop for each operation
+            MetricsHook ->> MetricsHook: _apply(operation, labels)
+            alt _CounterOp
+                MetricsHook ->> Collector: inc_counter(name, value, labels)
+            else _HistogramOp
+                MetricsHook ->> Collector: observe_histogram(name, value, labels)
+            end
+        end
+    end
+```
+
 ______________________________________________________________________
 
 ## 9. Error Model

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1486,6 +1486,8 @@ each operation in turn: a `_CounterOp` becomes `inc_counter(name, value,
 labels)` on the collector, and a `_HistogramOp` becomes `observe_histogram(name,
 value, labels)`.
 
+Figure 8: Metrics hook dispatch, from `ExecEvent` to collector calls
+
 ```mermaid
 sequenceDiagram
     participant ExecEvent
@@ -1511,6 +1513,41 @@ sequenceDiagram
         end
     end
 ```
+
+For screen readers: an `ExecEvent` calls the `MetricsHook`, which asks
+`_metric_operations` for that event's operations and receives a tuple of
+`_MetricOp` records. If the tuple is empty the hook returns immediately,
+without computing labels. Otherwise it extracts the labels once and then loops
+over the operations, applying each: a `_CounterOp` calls `inc_counter(name,
+value, labels)` on the collector, and a `_HistogramOp` calls
+`observe_histogram(name, value, labels)`.
+
+The loop is the contract, and it is deliberately **not** atomic. An `exit`
+event yields up to two operations — the failure counter, then the duration
+observation — applied as two independent collector calls in that order.
+Atomicity is not attempted: the collector wraps an arbitrary backend
+(`prometheus_client`, statsd, OpenTelemetry) that this adapter cannot make
+transactional, and buffering the pair to apply together would only move the
+problem while delaying when metrics appear.
+
+Three consequences follow, and collector implementations depend on them:
+
+- **Partial application is possible.** If the collector raises on the second
+  call, the first stays applied — a failure can be recorded without its
+  duration.
+- **The order is fixed.** The failure counter is applied before the duration
+  observation, so a partial application is always the prefix, never the
+  suffix.
+- **The exception propagates.** It leaves the hook, and
+  `cuprum._observability._emit_exec_event` catches it, logs
+  `observe_hook_failed`, and lets the command continue: a broken metrics
+  backend must not fail a user's command.
+
+So a collector must treat each call as independent and idempotent-safe, and
+must never assume that seeing a `cuprum_failures_total` increment guarantees a
+matching `cuprum_duration_seconds` observation will follow. The label mapping
+is read-only for the duration of the loop — it is extracted once, before the
+first call, and the same mapping is passed to every operation.
 
 ______________________________________________________________________
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -267,6 +267,22 @@ responsibility of observe-hook adapters such as `MetricsHook` and
 `TracingHook`, which consume `ExecEvent` values without coupling core execution
 to a telemetry vendor.
 
+`MetricsHook` keeps that consumption in two halves. The pure
+`_metric_operations` reducer maps an `ExecEvent` to a tuple of `_CounterOp` and
+`_HistogramOp` records, and `_apply` is the only step that reaches the
+`MetricsCollector`. The reducer is therefore the single source of truth for
+which counters and observations each phase yields, and it can be property
+tested without a collector at all — `test_metrics_adapter_stateful.py` drives
+random event streams through it and checks the accumulated totals against an
+independent phase-count oracle.
+
+Two consequences are worth preserving when changing the mapping. Labels are
+projected only when the reducer yields at least one operation, so a `plan`
+event never touches `event.program` or the project tag. And the reducer is
+total over the documented phase contract: an unrecognized phase raises
+`_UnhandledMetricsPhaseError` rather than being silently dropped, so a new
+`ExecPhase` cannot reach metrics without a deliberate decision here.
+
 Stream pumping continues to drain the upstream reader after
 `_write_to_stream_writer` reports `_WriteOutcome.CLOSED`.  `_pump_stream`
 closes the writer in a `finally` block, so writer cleanup runs after success,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -283,6 +283,18 @@ total over the documented phase contract: an unrecognized phase raises
 `_UnhandledMetricsPhaseError` rather than being silently dropped, so a new
 `ExecPhase` cannot reach metrics without a deliberate decision here.
 
+Applying the operations is deliberately non-atomic, and that is a contract
+collectors rely on rather than an implementation detail. An `exit` event yields
+up to two operations — the failure counter, then the duration observation —
+applied as separate collector calls in that order, so a collector that raises
+on the second leaves the first applied. The exception propagates out of the
+hook, where `_emit_exec_event` logs `observe_hook_failed` and lets the command
+continue. The labels are extracted once before the loop and are read-only
+within it. A collector must therefore treat each call as independent and never
+infer a duration observation from a failure increment; see the metrics-hook
+dispatch figure in [the design document](cuprum-design.md) for the full
+statement, and `test_metrics_adapter_stateful.py` for the case that pins it.
+
 ### Choosing a test shape per observe hook
 
 The three observe-hook adapters are verified differently, and the difference is

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -283,6 +283,34 @@ total over the documented phase contract: an unrecognized phase raises
 `_UnhandledMetricsPhaseError` rather than being silently dropped, so a new
 `ExecPhase` cannot reach metrics without a deliberate decision here.
 
+### Choosing a test shape per observe hook
+
+The three observe-hook adapters are verified differently, and the difference is
+driven by whether the hook accumulates state across events rather than by
+preference:
+
+Table 1: verification shape for each observe hook, and why
+
+| Hook | Shape | Why |
+| --- | --- | --- |
+| `TracingHook` | `RuleBasedStateMachine` (`test_tracing_span_stateful.py`) | holds `_active_spans` keyed by `ExecId`; the interesting bugs are correlation and drain failures across interleaved events |
+| `MetricsHook` | `RuleBasedStateMachine` (`test_metrics_adapter_stateful.py`) | accumulates counters and histograms, checked against an independent phase-count oracle |
+| `structured_logging_hook` | `@given` properties (`test_logging_adapter_properties.py`) | holds no state at all: one record per event, no map to drain |
+
+A state machine over the logging hook would generate interleavings that cannot
+distinguish any two implementations, because nothing carries between events.
+Its risks are per-event and shape-dependent instead: an `extra` key colliding
+with a reserved `LogRecord` attribute — which raises inside the caller's
+logging stack, not in cuprum — a phase falling through the level map, and a tag
+value that `JsonLoggingFormatter` cannot serialize. `ExecEvent.tags` is typed
+`Mapping[str, object]`, so arbitrary values are in contract, which is why
+`_json_serializable` and `json.dumps(..., default=str)` both exist and why the
+generator must produce values that are not JSON-native.
+
+Only `TracingHook` has an active map, so "the active map drains correctly" is a
+claim about that hook alone; `test_tracing_span_stateful.py` asserts it directly
+by cross-checking `hook._active_spans` against a model after every step.
+
 Stream pumping continues to drain the upstream reader after
 `_write_to_stream_writer` reports `_WriteOutcome.CLOSED`.  `_pump_stream`
 closes the writer in a `finally` block, so writer cleanup runs after success,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -291,9 +291,11 @@ on the second leaves the first applied. The exception propagates out of the
 hook, where `_emit_exec_event` logs `observe_hook_failed` and lets the command
 continue. The labels are extracted once before the loop and are read-only
 within it. A collector must therefore treat each call as independent and never
-infer a duration observation from a failure increment; see the metrics-hook
-dispatch figure in [the design document](cuprum-design.md) for the full
-statement, and `test_metrics_adapter_stateful.py` for the case that pins it.
+infer a duration observation from a failure increment. No operation identifier
+is passed either, so a repeated call increments again — nothing here is
+idempotent, and the hook never retries. See the metrics-hook dispatch figure in
+[the design document](cuprum-design.md) for the full statement, and
+`test_metrics_adapter_stateful.py` for the case that pins it.
 
 ### Choosing a test shape per observe hook
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -279,19 +279,29 @@ independent phase-count oracle.
 Two consequences are worth preserving when changing the mapping. Labels are
 projected only when the reducer yields at least one operation, so a `plan`
 event never touches `event.program` or the project tag. And the reducer is
-total over the documented phase contract: an unrecognized phase raises
-`_UnhandledMetricsPhaseError` rather than being silently dropped, so a new
-`ExecPhase` cannot reach metrics without a deliberate decision here.
+total over `ExecPhase` — all seven phases (`plan`, `start`, `stdout`,
+`stderr`, `stdin`, `stdin_error`, `exit`) have an arm — and fail-closed beyond
+it: any other phase raises `_UnhandledMetricsPhaseError` rather than being
+silently dropped. That is deliberate, and its cost is worth stating plainly. A
+hook exception is not swallowed, so adding a value to `ExecPhase` without
+adding an arm here would raise for every caller that has already registered
+`MetricsHook`. A new phase therefore cannot reach metrics without a decision in
+this reducer. The structured logging adapter is fail-open by contrast,
+formatting an unrecognized phase generically.
 
 Applying the operations is deliberately non-atomic, and that is a contract
 collectors rely on rather than an implementation detail. An `exit` event yields
 up to two operations — the failure counter, then the duration observation —
 applied as separate collector calls in that order, so a collector that raises
 on the second leaves the first applied. The exception propagates out of the
-hook, where `_emit_exec_event` logs `observe_hook_failed` and lets the command
-continue. The labels are extracted once before the loop and are read-only
-within it. A collector must therefore treat each call as independent and never
-infer a duration observation from a failure increment. No operation identifier
+hook and is not swallowed: `_emit_exec_event` logs `observe_hook_failed` and
+wraps the error in `_ExecEventEmissionError` so already-scheduled observe tasks
+survive cleanup, then `_StageObservation.emit` unwraps it and re-raises the
+collector's original exception — so a raising collector fails the user's
+command. A collector that must not do that has to swallow its own errors. The
+labels are extracted once before the loop and are read-only within it. A
+collector must therefore treat each call as independent and never infer a
+duration observation from a failure increment. No operation identifier
 is passed either, so a repeated call increments again — nothing here is
 idempotent, and the hook never retries. See the metrics-hook dispatch figure in
 [the design document](cuprum-design.md) for the full statement, and

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -781,7 +781,8 @@ with scoped(ScopeConfig(allowlist=frozenset([ECHO]))):
 
 The hook attaches selected `cuprum_*` prefixed extra fields to log records:
 
-- `cuprum_phase`: Event phase (plan, start, stdout, stderr, exit)
+- `cuprum_phase`: Event phase (plan, start, stdout, stderr, stdin,
+  stdin_error, exit)
 - `cuprum_program`: Program being executed
 - `cuprum_argv`: The command's argument vector, recorded verbatim (see the
   security note below)


### PR DESCRIPTION
## Summary

`MetricsHook.__call__` was a phase-dispatch that reached straight into the collector, with no seam to verify which counters and histograms each event yields across varied phase/order/pid combinations (#78).

## Seam

Extract the pure event-to-operation reducer `_metric_operations(event) -> tuple[_MetricOp, ...]`:

- `_CounterOp` / `_HistogramOp` records describe the intended operations; a `_PHASE_COUNTERS` lookup collapses the unit-counter phases.
- `MetricsHook.__call__` now applies the reducer's operations, resolving labels only when there is at least one operation — so `plan` (and an unknown phase) still compute no labels, as the existing tests require.
- The former `_increment`/`_record_stdin_bytes`/`_record_exit` helpers are removed; behaviour is unchanged and `test_metrics_adapter.py` still passes.

## Tests

`cuprum/unittests/test_metrics_adapter_stateful.py`:

- **Property tests** pin the operations produced per phase — unit counters for `start`/`stdout`/`stderr`/`stdin_error`; `plan` yields nothing; `stdin` yields a bytes counter only when a byte count is present; `exit` counts a failure only for a non-zero code and a duration only when measured; an unknown phase raises.
- A **Hypothesis `RuleBasedStateMachine`** streams random events (all seven phases, phase-appropriate fields) through a real `MetricsHook`/`InMemoryMetrics` and, after every step, checks the accumulated counters and histograms against an **independent phase-count oracle** (not the reducer). This proves counters and observations are created exactly when intended, and only then, across arbitrary event orders.

## Scope

`#78` is titled "Hypothesis stateful tests for metrics/tracing/logging hooks".
Its body scopes the work to `cuprum/adapters/metrics_adapter.py`, but taking the
title at its word, all three adapters now have randomised event coverage:

Table 1: verification shape for each observe hook, and why

| Adapter | Coverage | Shape, and why |
| --- | --- | --- |
| `tracing_adapter.py` | `test_tracing_span_stateful.py` (pre-existing) | state machine — holds `_active_spans`, so correlation and drain are the risks |
| `metrics_adapter.py` | `test_metrics_adapter_stateful.py` (added here) | state machine — accumulates counters and histograms |
| `logging_adapter.py` | `test_logging_adapter_properties.py` (added here) | `@given` properties — holds no state at all |

The logging hook gets properties rather than a fourth state machine because it
carries nothing between events: one record in, one record out. Interleavings
cannot distinguish any two implementations of it. Its risks are per-event and
shape-dependent — a reserved-`LogRecord` collision, a phase falling through the
level map, a tag value the JSON formatter cannot serialize — and the five
properties pin exactly those.

On **active map draining**: only `TracingHook` has an active map.
`metrics_adapter.py` has none, and neither does the logging hook, so the claim
applies to tracing alone — where `test_tracing_span_stateful.py` asserts it
directly, cross-checking `hook._active_spans` against a model after every step
and pinning that an exit removes only its own execution's span.

#252 was raised to track the logging work while it was still outstanding; it is
now delivered here and can be closed.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract a pure event-to-metrics reducer for the metrics hook and add property-based and stateful tests to verify metrics behavior across execution phases.

New Features:
- Introduce a pure `_metric_operations` reducer that maps execution events to counter and histogram operations for the metrics hook.
- Add Hypothesis-based property and stateful tests that validate metrics accumulation over randomized execution event streams.

Enhancements:
- Refactor `MetricsHook.__call__` to delegate to the shared reducer and a generic operation applier, avoiding label computation for no-op events.

