### PR TITLE
Align design-doc §13.2 with the backend probe/resolve seam

### DIFF
--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1635,7 +1635,11 @@ The availability probe is separate from the stream shim. The Python module
 `cuprum._rust_backend_native`, returns `False` when that native module is
 missing, and re-raises other import failures after logging a warning. The
 cached resolver in `cuprum._backend._check_rust_available()` wraps that probe
-for `cuprum.rust.is_rust_available()` and `get_stream_backend()`.
+for `cuprum.rust.is_rust_available()` and — through the
+`_probe_rust_availability()` seam — `get_stream_backend()`. Section 13.4
+describes the full `_parse_backend_value` → `_probe_rust_availability` →
+`_resolve_backend` resolution; `get_stream_backend()` does not delegate to
+`_check_rust_available()` directly.
 
 For screen readers: The following flowchart shows how Cuprum selects between
 the Python and Rust stream pathways based on environment configuration and


### PR DESCRIPTION
## Summary

Follow-up to the merged #224 backend seam refactor. CodeRabbit's post-merge "Developer Documentation" warning flagged that `docs/cuprum-design.md` still described `get_stream_backend()` as delegating to `_check_rust_available()`, conflicting with the implemented probe→resolve seam.

The stale wording is in **§13.2** (the "Extension Architecture" overview): it said the cached `_check_rust_available()` resolver wraps the probe "for `is_rust_available()` and `get_stream_backend()`", implying a direct delegation. §13.3 and §13.4 already describe the authoritative seam model (`_parse_backend_value` → `_probe_rust_availability` → `_resolve_backend`, with only `_probe_rust_availability()` wrapping the cached `_check_rust_available()`).

## Change

Qualify the §13.2 sentence so `get_stream_backend()` is fed **through the `_probe_rust_availability()` seam**, mirroring §13.3, and add a one-line cross-reference to §13.4's full resolution plus an explicit "does not delegate to `_check_rust_available()` directly". The document now keeps one authoritative backend model; the high-level flowchart (which never claimed direct delegation) is unchanged.

Docs-only.

## Validation

`make markdownlint` (49 files, 0 errors; spelling sub-target clean) and `make nixie` (all Mermaid diagrams validated) pass.

## Summary by Sourcery

Update the backend architecture documentation to accurately describe the probe-to-resolve seam.

Enhancements:
- Clarify the design documentation’s backend resolution model by documenting that `get_stream_backend()` uses the probe seam rather than delegating directly to the cached availability resolver.

Documentation:
- Align §13.2 with the authoritative probe-to-resolve backend flow and cross-reference the detailed resolution description in §13.4.

## References

- Lody session: https://lody.ai/leynos/sessions/beeee726-0484-4769-b5d2-f9d0d108a4d8