### PR TITLE
Preserve the OS errno across the PyO3 boundary (#265)

### DIFF
--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -108,6 +108,7 @@
       'cuprum/unittests/test_prerequisite_docs.py',
       'cuprum/unittests/test_profile_driver.py',
       'cuprum/unittests/test_public_api.py',
+      'cuprum/unittests/test_rust_errno.py',
       'cuprum/unittests/test_rust_extension.py',
       'cuprum/unittests/test_rust_splice.py',
       'cuprum/unittests/test_rust_streams.py',

--- a/cuprum/unittests/test_rust_errno.py
+++ b/cuprum/unittests/test_rust_errno.py
@@ -1,0 +1,135 @@
+"""`OSError`s crossing the PyO3 boundary carry a usable `errno`.
+
+An extension that reports failures only in message text forces callers to parse
+English to tell one failure from another, and message text is not a stable
+interface. These tests pin the two properties that make the error branchable:
+`errno` is populated, and the exception is the subclass that errno implies.
+
+They isolate the conversion rather than reaching it through a pump: the pump
+treats a broken pipe as non-fatal and drains, so most interesting errnos never
+propagate through it. Calling the exported entry points with a deliberately
+unusable descriptor reaches the conversion directly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import os
+import typing as typ
+
+import pytest
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+    from types import ModuleType
+
+
+@pytest.fixture(name="broken_pipe_fds")
+def fixture_broken_pipe_fds() -> cabc.Iterator[tuple[int, int]]:
+    """Yield ``(closed_read_fd, open_write_fd)`` for a pipe.
+
+    The read end is closed before the test runs, so any attempt to read it
+    fails with ``EBADF`` while the write end stays valid.
+    """
+    read_fd, write_fd = os.pipe()
+    os.close(read_fd)
+    try:
+        yield read_fd, write_fd
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(write_fd)
+
+
+@pytest.fixture(name="directory_fd")
+def fixture_directory_fd() -> cabc.Iterator[int]:
+    """Yield a descriptor open on a directory, which cannot be read."""
+    fd = os.open(".", os.O_RDONLY)
+    try:
+        yield fd
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+def test_pump_error_reports_a_branchable_errno(
+    rust_streams: ModuleType,
+    broken_pipe_fds: tuple[int, int],
+) -> None:
+    """A failed pump reports `errno`, not just a message mentioning it.
+
+    PyO3's own conversion builds the exception from a single argument — the
+    error's `Display` string — and Python only fills in `errno` and `strerror`
+    when given two or more. The number then survives in the text and nowhere a
+    caller can branch on, which is the defect this pins.
+    """
+    closed_read_fd, write_fd = broken_pipe_fds
+
+    with pytest.raises(OSError, match="Bad file descriptor") as excinfo:
+        rust_streams.rust_pump_stream(closed_read_fd, write_fd)
+
+    assert excinfo.value.errno == errno.EBADF, (
+        f"a closed descriptor must report EBADF in errno, found {excinfo.value.errno!r}"
+    )
+    assert excinfo.value.strerror, (
+        "strerror must be populated alongside errno, so the pair reads as a "
+        "normal OSError"
+    )
+
+
+def test_consume_error_reports_a_branchable_errno(
+    rust_streams: ModuleType,
+    broken_pipe_fds: tuple[int, int],
+) -> None:
+    """The consume entry point preserves `errno` on the same terms."""
+    closed_read_fd, _write_fd = broken_pipe_fds
+
+    with pytest.raises(OSError, match="Bad file descriptor") as excinfo:
+        rust_streams.rust_consume_stream(closed_read_fd)
+
+    assert excinfo.value.errno == errno.EBADF, (
+        f"expected EBADF, found {excinfo.value.errno!r}"
+    )
+
+
+def test_the_exception_subclass_follows_the_errno(
+    rust_streams: ModuleType,
+    directory_fd: int,
+) -> None:
+    """The raised type is the subclass the errno implies.
+
+    Reading a directory yields `EISDIR`, whose Python subclass is
+    `IsADirectoryError`. Passing `(errno, strerror)` lets CPython select that
+    subclass itself, which is both the authoritative mapping and the behaviour
+    the previous conversion reached for through a parallel `ErrorKind` table.
+    """
+    with pytest.raises(IsADirectoryError) as excinfo:
+        rust_streams.rust_consume_stream(directory_fd)
+
+    assert excinfo.value.errno == errno.EISDIR, (
+        f"expected EISDIR, found {excinfo.value.errno!r}"
+    )
+
+
+def test_the_message_states_the_error_number_once(
+    rust_streams: ModuleType,
+    broken_pipe_fds: tuple[int, int],
+) -> None:
+    """`strerror` carries no duplicate of the number Python already prefixes.
+
+    Rust renders a raw OS error as ``"{strerror} (os error {code})"``. Passing
+    that whole string through would render as ``"[Errno 9] Bad file descriptor
+    (os error 9)"``, stating the number twice.
+    """
+    closed_read_fd, _write_fd = broken_pipe_fds
+
+    with pytest.raises(OSError, match="Bad file descriptor") as excinfo:
+        rust_streams.rust_consume_stream(closed_read_fd)
+
+    assert "os error" not in str(excinfo.value), (
+        "the Rust-side suffix must be stripped, leaving Python's own "
+        f"[Errno N] prefix as the only mention; found {str(excinfo.value)!r}"
+    )
+    assert str(excinfo.value).startswith(f"[Errno {errno.EBADF}]"), (
+        f"expected a normal OSError rendering, found {str(excinfo.value)!r}"
+    )

--- a/cuprum/unittests/test_rust_errno.py
+++ b/cuprum/unittests/test_rust_errno.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
+import re
 import sys
 import typing as typ
 
@@ -34,6 +35,11 @@ pytestmark = pytest.mark.skipif(
     sys.platform == "win32",
     reason="asserts POSIX errno values and the subclasses derived from them",
 )
+
+# `pytest.raises(OSError)` needs a `match` (ruff PT011), but `strerror` comes
+# from the C library and is translated under a non-English locale. Anchor on
+# the `[Errno N]` prefix CPython formats itself, which no locale changes.
+_ERRNO_PREFIX_RE = re.escape(f"[Errno {errno.EBADF}]")
 
 
 @pytest.fixture(name="broken_pipe_fds")
@@ -76,7 +82,7 @@ def test_pump_error_reports_a_branchable_errno(
     """
     closed_read_fd, write_fd = broken_pipe_fds
 
-    with pytest.raises(OSError, match="Bad file descriptor") as excinfo:
+    with pytest.raises(OSError, match=_ERRNO_PREFIX_RE) as excinfo:
         rust_streams.rust_pump_stream(closed_read_fd, write_fd)
 
     assert excinfo.value.errno == errno.EBADF, (
@@ -95,7 +101,7 @@ def test_consume_error_reports_a_branchable_errno(
     """The consume entry point preserves `errno` on the same terms."""
     closed_read_fd, _write_fd = broken_pipe_fds
 
-    with pytest.raises(OSError, match="Bad file descriptor") as excinfo:
+    with pytest.raises(OSError, match=_ERRNO_PREFIX_RE) as excinfo:
         rust_streams.rust_consume_stream(closed_read_fd)
 
     assert excinfo.value.errno == errno.EBADF, (
@@ -134,7 +140,7 @@ def test_the_message_states_the_error_number_once(
     """
     closed_read_fd, _write_fd = broken_pipe_fds
 
-    with pytest.raises(OSError, match="Bad file descriptor") as excinfo:
+    with pytest.raises(OSError, match=_ERRNO_PREFIX_RE) as excinfo:
         rust_streams.rust_consume_stream(closed_read_fd)
 
     assert "os error" not in str(excinfo.value), (

--- a/cuprum/unittests/test_rust_errno.py
+++ b/cuprum/unittests/test_rust_errno.py
@@ -9,6 +9,9 @@ They isolate the conversion rather than reaching it through a pump: the pump
 treats a broken pipe as non-fatal and drains, so most interesting errnos never
 propagate through it. Calling the exported entry points with a deliberately
 unusable descriptor reaches the conversion directly.
+
+The conversion has a POSIX arm and a Windows arm, and they hand the number over
+differently, so each arm has its own platform-scoped cases below.
 """
 
 from __future__ import annotations
@@ -24,22 +27,35 @@ import pytest
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
+    import pathlib
     from types import ModuleType
 
-# These cases name POSIX errnos and the subclasses CPython derives from them.
-# Windows reaches the same conversion but carries a Win32 code through
-# `winerror`, from which CPython derives a different errno, so the expected
-# numbers here do not hold there. Skip rather than encode both taxonomies:
-# the Windows arm has no test job to run in.
-pytestmark = pytest.mark.skipif(
+# The two platform arms of the conversion carry different taxonomies, so each
+# set of assertions is scoped to the platform it describes rather than the
+# module being skipped wholesale. POSIX cases name an `errno` and the subclass
+# CPython derives from it; the Windows cases name a `winerror` and the `errno`
+# CPython derives from *that*, which is a different number for the same
+# failure. Only the POSIX arm has a job that executes it today (see
+# `docs/developers-guide.md`, "Preserving the operating-system error code");
+# the Windows assertions encode the contract until one exists.
+_posix_only = pytest.mark.skipif(
     sys.platform == "win32",
     reason="asserts POSIX errno values and the subclasses derived from them",
+)
+_windows_only = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="asserts Win32 winerror values and the errno derived from them",
 )
 
 # `pytest.raises(OSError)` needs a `match` (ruff PT011), but `strerror` comes
 # from the C library and is translated under a non-English locale. Anchor on
 # the `[Errno N]` prefix CPython formats itself, which no locale changes.
 _ERRNO_PREFIX_RE = re.escape(f"[Errno {errno.EBADF}]")
+
+# The Windows rendering is `[WinError N] strerror`. The code is left open
+# because the assertions derive their expectations from whichever code the
+# failure actually raises rather than fixing one.
+_WINERROR_PREFIX_RE = r"^\[WinError \d+\] "
 
 
 @pytest.fixture(name="broken_pipe_fds")
@@ -69,6 +85,7 @@ def fixture_directory_fd() -> cabc.Iterator[int]:
             os.close(fd)
 
 
+@_posix_only
 def test_pump_error_reports_a_branchable_errno(
     rust_streams: ModuleType,
     broken_pipe_fds: tuple[int, int],
@@ -94,6 +111,7 @@ def test_pump_error_reports_a_branchable_errno(
     )
 
 
+@_posix_only
 def test_consume_error_reports_a_branchable_errno(
     rust_streams: ModuleType,
     broken_pipe_fds: tuple[int, int],
@@ -109,6 +127,7 @@ def test_consume_error_reports_a_branchable_errno(
     )
 
 
+@_posix_only
 def test_the_exception_subclass_follows_the_errno(
     rust_streams: ModuleType,
     directory_fd: int,
@@ -128,6 +147,7 @@ def test_the_exception_subclass_follows_the_errno(
     )
 
 
+@_posix_only
 def test_the_message_states_the_error_number_once(
     rust_streams: ModuleType,
     broken_pipe_fds: tuple[int, int],
@@ -149,4 +169,72 @@ def test_the_message_states_the_error_number_once(
     )
     assert str(excinfo.value).startswith(f"[Errno {errno.EBADF}]"), (
         f"expected a normal OSError rendering, found {str(excinfo.value)!r}"
+    )
+
+
+def _winerror_of(exc: OSError) -> int | None:
+    """Read the Win32 code CPython attaches to a Windows ``OSError``.
+
+    ``OSError.winerror`` exists only on Windows, so a type check run on any
+    other platform does not know the attribute. The suppression is confined to
+    this one accessor rather than repeated at each use.
+    """
+    return exc.winerror  # ty: ignore[unresolved-attribute]
+
+
+@pytest.fixture(name="write_only_handle")
+def fixture_write_only_handle(tmp_path: pathlib.Path) -> cabc.Iterator[int]:
+    """Yield a native Windows handle open for writing, which cannot be read.
+
+    The Windows entry points take a native ``HANDLE`` rather than a C runtime
+    descriptor, so the descriptor is converted with ``msvcrt.get_osfhandle``.
+    ``ReadFile`` on a handle opened ``GENERIC_WRITE`` fails, which is what puts
+    a Win32 code on the ``io::Error`` the conversion then has to preserve.
+    """
+    msvcrt = pytest.importorskip("msvcrt", reason="Windows-only handle conversion")
+    fd = os.open(tmp_path / "write-only.bin", os.O_WRONLY | os.O_CREAT)
+    try:
+        yield msvcrt.get_osfhandle(fd)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+@_windows_only
+def test_windows_failures_carry_the_native_code_as_winerror(
+    rust_streams: ModuleType,
+    write_only_handle: int,
+) -> None:
+    """A Win32 failure arrives as `winerror`, with the rest derived from it.
+
+    On Windows `raw_os_error` is a `GetLastError` code, not an `errno`. Handing
+    it over where Python expects an `errno` would assign an unrelated number,
+    leave `winerror` unset, and pick the subclass from the wrong value. The
+    five-argument form passes the native code as `winerror`; CPython then
+    derives `errno` from it and selects the subclass from the derived value.
+
+    The expected `errno` and subclass are not hard-coded. They are read back
+    from an `OSError` this test builds from the observed `winerror`, so the
+    assertions pin the *derivation* without depending on which Win32 code this
+    particular failure happens to raise.
+    """
+    with pytest.raises(OSError, match=_WINERROR_PREFIX_RE) as excinfo:
+        rust_streams.rust_consume_stream(write_only_handle)
+
+    raised = excinfo.value
+    winerror = _winerror_of(raised)
+    assert winerror, f"the Win32 code must survive in winerror, found {winerror!r}"
+
+    derived = OSError(0, raised.strerror, None, winerror, None)
+    assert type(raised) is type(derived), (
+        f"winerror {winerror} implies {type(derived).__name__}, "
+        f"found {type(raised).__name__}"
+    )
+    assert raised.errno == derived.errno, (
+        f"errno must be the one CPython derives from winerror {winerror}: "
+        f"expected {derived.errno!r}, found {raised.errno!r}"
+    )
+    assert "os error" not in str(raised), (
+        "the Rust-side suffix must be stripped, leaving Python's own "
+        f"[WinError N] prefix as the only mention; found {str(raised)!r}"
     )

--- a/cuprum/unittests/test_rust_errno.py
+++ b/cuprum/unittests/test_rust_errno.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
+import sys
 import typing as typ
 
 import pytest
@@ -23,6 +24,16 @@ import pytest
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
     from types import ModuleType
+
+# These cases name POSIX errnos and the subclasses CPython derives from them.
+# Windows reaches the same conversion but carries a Win32 code through
+# `winerror`, from which CPython derives a different errno, so the expected
+# numbers here do not hold there. Skip rather than encode both taxonomies:
+# the Windows arm has no test job to run in.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="asserts POSIX errno values and the subclasses derived from them",
+)
 
 
 @pytest.fixture(name="broken_pipe_fds")

--- a/cuprum/unittests/test_rust_errno.py
+++ b/cuprum/unittests/test_rust_errno.py
@@ -12,11 +12,19 @@ unusable descriptor reaches the conversion directly.
 
 The conversion has a POSIX arm and a Windows arm, and they hand the number over
 differently, so each arm has its own platform-scoped cases below.
+
+Every expectation comes from outside the exception under test. Deriving one
+from the raised exception would let a hard-coded or simply wrong native code
+satisfy the assertion, which is no test at all. The POSIX arm names the `errno`
+outright and takes `strerror` from `os.strerror`; the Windows arm performs the
+same failing `ReadFile` through `ctypes` and reads the code back from
+`GetLastError`.
 """
 
 from __future__ import annotations
 
 import contextlib
+import ctypes
 import errno
 import os
 import re
@@ -35,9 +43,11 @@ if typ.TYPE_CHECKING:
 # module being skipped wholesale. POSIX cases name an `errno` and the subclass
 # CPython derives from it; the Windows cases name a `winerror` and the `errno`
 # CPython derives from *that*, which is a different number for the same
-# failure. Only the POSIX arm has a job that executes it today (see
-# `docs/developers-guide.md`, "Preserving the operating-system error code");
-# the Windows assertions encode the contract until one exists.
+# failure. Neither arm has a job that executes it today (see
+# `docs/developers-guide.md`, "Preserving the operating-system error code"):
+# POSIX execution arrives with the `extension-tests` job in #269, and native
+# Windows runtime coverage is tracked by leynos/cuprum#277. Until then these
+# encode the contract.
 _posix_only = pytest.mark.skipif(
     sys.platform == "win32",
     reason="asserts POSIX errno values and the subclasses derived from them",
@@ -51,11 +61,6 @@ _windows_only = pytest.mark.skipif(
 # from the C library and is translated under a non-English locale. Anchor on
 # the `[Errno N]` prefix CPython formats itself, which no locale changes.
 _ERRNO_PREFIX_RE = re.escape(f"[Errno {errno.EBADF}]")
-
-# The Windows rendering is `[WinError N] strerror`. The code is left open
-# because the assertions derive their expectations from whichever code the
-# failure actually raises rather than fixing one.
-_WINERROR_PREFIX_RE = r"^\[WinError \d+\] "
 
 
 @pytest.fixture(name="broken_pipe_fds")
@@ -105,9 +110,10 @@ def test_pump_error_reports_a_branchable_errno(
     assert excinfo.value.errno == errno.EBADF, (
         f"a closed descriptor must report EBADF in errno, found {excinfo.value.errno!r}"
     )
-    assert excinfo.value.strerror, (
-        "strerror must be populated alongside errno, so the pair reads as a "
-        "normal OSError"
+    assert excinfo.value.strerror == os.strerror(errno.EBADF), (
+        "strerror must be the system's own description of EBADF, obtained "
+        "here from CPython rather than from the exception under test; found "
+        f"{excinfo.value.strerror!r}"
     )
 
 
@@ -182,6 +188,90 @@ def _winerror_of(exc: OSError) -> int | None:
     return exc.winerror  # ty: ignore[unresolved-attribute]
 
 
+def _win32_readfile_error(handle: int) -> int:
+    """Return the Win32 code a direct ``ReadFile`` on ``handle`` reports.
+
+    This is the oracle the boundary is measured against. It issues the same
+    system call the extension does — a Windows stream handle is a
+    ``std::fs::File``, whose ``read`` is ``ReadFile`` — but through ``ctypes``,
+    so nothing it returns passes through the code under test. A hard-coded or
+    mistaken native code on the Rust side therefore fails the comparison.
+
+    ``use_last_error`` makes ``ctypes`` stash ``GetLastError`` immediately on
+    return, before the interpreter can make a call of its own and overwrite it.
+
+    Parameters
+    ----------
+    handle : int
+        A native ``HANDLE`` that cannot be read.
+
+    Returns
+    -------
+    int
+        The ``GetLastError`` code the failed read reported.
+
+    Examples
+    --------
+    >>> _win32_readfile_error(write_only_handle)  # doctest: +SKIP
+    5
+    """
+    kernel32 = ctypes.WinDLL(  # ty: ignore[unresolved-attribute]
+        "kernel32",
+        use_last_error=True,
+    )
+    read_file = kernel32.ReadFile
+    # A HANDLE is pointer-sized; without argtypes ctypes would pass it as a C
+    # int and truncate it on 64-bit Windows.
+    read_file.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.c_void_p,
+    )
+    read_file.restype = ctypes.c_int
+    taken = ctypes.c_uint32(0)
+    succeeded = read_file(
+        ctypes.c_void_p(handle),
+        ctypes.create_string_buffer(1),
+        1,
+        ctypes.byref(taken),
+        None,
+    )
+    assert not succeeded, (
+        "the probe read must fail, or it cannot say which code the extension "
+        "should have reported"
+    )
+    return ctypes.get_last_error()  # ty: ignore[unresolved-attribute]
+
+
+def _win32_oracle(code: int) -> OSError:
+    """Build the ``OSError`` CPython itself produces for a Win32 ``code``.
+
+    ``ctypes.WinError`` looks the message up with ``FormatMessage`` and hands
+    the code to ``OSError`` as ``winerror``, so CPython derives ``errno`` and
+    selects the subclass. That makes it the authoritative statement of what the
+    extension's exception should look like, built from the independently
+    obtained code rather than from the exception itself.
+
+    Parameters
+    ----------
+    code : int
+        A Win32 error code.
+
+    Returns
+    -------
+    OSError
+        The exception CPython derives from ``code``.
+
+    Examples
+    --------
+    >>> _win32_oracle(5).errno  # doctest: +SKIP
+    13
+    """
+    return ctypes.WinError(code)  # ty: ignore[unresolved-attribute]
+
+
 @pytest.fixture(name="write_only_handle")
 def fixture_write_only_handle(tmp_path: pathlib.Path) -> cabc.Iterator[int]:
     """Yield a native Windows handle open for writing, which cannot be read.
@@ -213,26 +303,36 @@ def test_windows_failures_carry_the_native_code_as_winerror(
     five-argument form passes the native code as `winerror`; CPython then
     derives `errno` from it and selects the subclass from the derived value.
 
-    The expected `errno` and subclass are not hard-coded. They are read back
-    from an `OSError` this test builds from the observed `winerror`, so the
-    assertions pin the *derivation* without depending on which Win32 code this
-    particular failure happens to raise.
+    None of the expectations come from the exception. The same read is issued
+    first through `ctypes`, and the code it reports is what the extension is
+    held to; `errno`, `strerror` and the subclass then come from the `OSError`
+    CPython derives from that code. An extension that reported a constant, or
+    the wrong code, or a code it never obtained from the failure, fails here —
+    which is exactly what deriving the expectations from the raised `winerror`
+    could not detect.
     """
-    with pytest.raises(OSError, match=_WINERROR_PREFIX_RE) as excinfo:
+    expected = _win32_readfile_error(write_only_handle)
+    oracle = _win32_oracle(expected)
+
+    with pytest.raises(OSError, match=re.escape(f"[WinError {expected}]")) as excinfo:
         rust_streams.rust_consume_stream(write_only_handle)
 
     raised = excinfo.value
-    winerror = _winerror_of(raised)
-    assert winerror, f"the Win32 code must survive in winerror, found {winerror!r}"
-
-    derived = OSError(0, raised.strerror, None, winerror, None)
-    assert type(raised) is type(derived), (
-        f"winerror {winerror} implies {type(derived).__name__}, "
+    assert _winerror_of(raised) == expected, (
+        f"ReadFile reported {expected}, so winerror must carry that code; "
+        f"found {_winerror_of(raised)!r}"
+    )
+    assert type(raised) is type(oracle), (
+        f"winerror {expected} implies {type(oracle).__name__}, "
         f"found {type(raised).__name__}"
     )
-    assert raised.errno == derived.errno, (
-        f"errno must be the one CPython derives from winerror {winerror}: "
-        f"expected {derived.errno!r}, found {raised.errno!r}"
+    assert raised.errno == oracle.errno, (
+        f"errno must be the one CPython derives from winerror {expected}: "
+        f"expected {oracle.errno!r}, found {raised.errno!r}"
+    )
+    assert raised.strerror == oracle.strerror, (
+        f"strerror must be the system's description of winerror {expected}: "
+        f"expected {oracle.strerror!r}, found {raised.strerror!r}"
     )
     assert "os error" not in str(raised), (
         "the Rust-side suffix must be stripped, leaving Python's own "

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1162,14 +1162,57 @@ with `thiserror`:
 - `Io(io::Error)` — an operating-system I/O failure (transparent wrapper).
 
 Conversion to a Python exception happens in exactly one place
-(`From<PumpError> for PyErr`): `Io` preserves a raw operating-system error code
-as Python's machine-readable `OSError.errno`, while errors without a raw code
-use `pyo3`'s standard `io::Error` translation. The overflow variants surface as
+(`From<PumpError> for PyErr`). The overflow variants surface as plain
 `OSError`. The non-fatal write classification (broken pipe / connection reset)
 lives on the enum as `PumpError::is_nonfatal_write`, replacing the free
 function the splice and read/write paths previously shared. New failure
 conditions get a variant here rather than a stringly-typed
 `io::Error::other(...)`.
+
+### Preserving the operating-system error code
+
+The `Io` variant needs care, because PyO3's own `From<io::Error> for PyErr`
+loses the number. It selects the exception *type* from `io::ErrorKind` and then
+constructs it with a single argument, the error's `Display` string — and Python
+populates `OSError.errno` and `OSError.strerror` only when it receives **two or
+more** arguments. The number therefore survived in the message text and nowhere
+a caller could branch on, forcing callers to parse English to tell `EBADF` from
+`EPIPE`. This was issue `#265`; `io_error_to_py_err` now handles it.
+
+The construction is platform-specific, so it sits behind a `cfg`-selected
+`os_error_to_py_err`:
+
+- **Unix** — `raw_os_error` *is* an `errno`, so the two-argument form
+  `OSError(code, strerror)` is exactly right. It also fixes the exception type
+  for free: CPython maps the errno to the matching subclass itself, so
+  `OSError(32, ...)` *is* a `BrokenPipeError` and reading a directory raises
+  `IsADirectoryError`. That is the same subclass selection PyO3 reached for
+  through `ErrorKind`, taken from the authoritative source instead of a
+  parallel table.
+- **Windows** — `raw_os_error` carries a `GetLastError` code, not an `errno`.
+  Passing it as an `errno` would assign an unrelated number
+  (`ERROR_INVALID_HANDLE` is 6, which as an `errno` is `ENXIO`) and pick the
+  subclass from it. The five-argument form `OSError(errno, strerror, filename,
+  winerror, filename2)` is the one that carries a native code: given a
+  `winerror`, CPython ignores the `errno` argument, derives `errno` from the
+  Win32 code, and selects the subclass from the derived value, so all three
+  agree.
+
+Two details are worth knowing before changing this code. First, `io::Error`
+renders a raw OS error as `"{strerror} (os error {code})"`, so the suffix is
+stripped before it becomes `strerror` — otherwise the number appears twice, as
+`"[Errno 9] Bad file descriptor (os error 9)"`. `strip_os_error_suffix` is
+anchored to *this* error's own code so it can never truncate a message
+belonging to a different one; three proptests pin that. Second, an `io::Error`
+with no `raw_os_error` — one synthesized in Rust rather than returned by a
+syscall — has no number to preserve, so PyO3's `ErrorKind` mapping remains the
+best available and is used unchanged.
+
+`cuprum/unittests/test_rust_errno.py` covers the Unix arm end to end. The
+Windows arm is verified only by cross-compilation (`cargo check --target
+x86_64-pc-windows-msvc`): wheels are built for Windows but no job runs the
+Python suite there, so those tests carry a `sys.platform == "win32"` skip
+rather than encoding both errno taxonomies.
 
 ## Rust FD-borrow ownership contract
 
@@ -1367,9 +1410,10 @@ Normal CI does not execute them. The test jobs reach the suite through
 `make build`, which is only `uv sync --group dev`; nothing builds
 `cuprum._rust_backend_native`, so those cases are skipped rather than run.
 Issue `#258` tracks building the extension in the test jobs and adding a
-fail-loud guard so the skip cannot pass unnoticed, and issue `#265` tracks a
-pre-existing PyO3 defect — `OSError` crossing the boundary loses its `errno` —
-that currently fails one extension-enabled test.
+fail-loud guard so the skip cannot pass unnoticed. Issue `#265` — `OSError`
+crossing the boundary lost its `errno`, failing one extension-enabled test —
+is resolved; see [Preserving the operating-system error
+code](#preserving-the-operating-system-error-code).
 
 So the `consume_stream_files` snapshots and properties are the coverage of the
 read-and-decode loop that actually executes on every commit. They do not

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1208,11 +1208,27 @@ with no `raw_os_error` — one synthesized in Rust rather than returned by a
 syscall — has no number to preserve, so PyO3's `ErrorKind` mapping remains the
 best available and is used unchanged.
 
-`cuprum/unittests/test_rust_errno.py` covers the Unix arm end to end. The
-Windows arm is verified only by cross-compilation (`cargo check --target
-x86_64-pc-windows-msvc`): wheels are built for Windows but no job runs the
-Python suite there, so those tests carry a `sys.platform == "win32"` skip
-rather than encoding both errno taxonomies.
+`cuprum/unittests/test_rust_errno.py` covers both arms, with each set of
+assertions scoped to the platform whose taxonomy it names — the POSIX cases
+name an `errno` and the subclass CPython derives from it, the Windows case
+names a `winerror` and the `errno` CPython derives from *that*. The Windows
+case does not hard-code either expectation: it reads them back from an
+`OSError` it builds from the observed `winerror`, so it pins the derivation
+without depending on which Win32 code the failure happens to raise.
+
+What actually executes is narrower than what is written, so do not read a
+green run as coverage of both arms:
+
+- **POSIX** — the cases run natively on Linux whenever the extension is built,
+  so a local `make test` preceded by `maturin develop` executes them. Without
+  that build the `rust_streams` fixture skips them rather than failing, which
+  is what CI does today. Making CI build the extension and fail loudly without
+  it is `#258`, in flight as pull request `#269`.
+- **Windows** — the `#[cfg(windows)]` arm is compiled natively on
+  `windows-2022` by the wheel build (`.github/workflows/build-wheels.yml`,
+  reached from `ci.yml`), which catches a Windows arm that does not build or
+  type-check. No job runs the Python suite on Windows, so nothing executes the
+  `winerror` assertions; that gap is tracked by `#277`.
 
 ## Rust FD-borrow ownership contract
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1247,8 +1247,11 @@ resolution has no effect.
 
 ### Rust stream error handling (internal)
 
-An I/O failure inside either helper raises an `OSError` that behaves like one
-raised by Python itself, so it can be handled the same way:
+Not every I/O failure reaches the caller: `rust_pump_stream` treats a broken
+pipe or connection reset as the expected result of a downstream stage exiting
+early, so it drains the reader and returns successfully. When either helper
+*does* propagate a failure, it raises an `OSError` that behaves like one raised
+by Python itself, so it can be handled the same way:
 
 - `errno` is populated, so failures are told apart by number rather than by
   matching message text — which is not a stable interface.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1264,6 +1264,8 @@ by Python itself, so it can be handled the same way:
 ```python
 import errno
 
+from cuprum._streams_rs import rust_consume_stream
+
 try:
     text = rust_consume_stream(fd)
 except IsADirectoryError:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1245,6 +1245,40 @@ The backend is resolved once on first use and the result is cached for the
 lifetime of the process. Changing the environment variable after the first
 resolution has no effect.
 
+### Rust stream error handling (internal)
+
+An I/O failure inside either helper raises an `OSError` that behaves like one
+raised by Python itself, so it can be handled the same way:
+
+- `errno` is populated, so failures are told apart by number rather than by
+  matching message text — which is not a stable interface.
+- `strerror` carries the system's description on its own. Rust renders a raw OS
+  error as `"Bad file descriptor (os error 9)"`; that trailing `(os error N)` is
+  removed, so the number is stated once, by Python's own `[Errno N]` prefix.
+- The exception is the **subclass** the error implies, not a bare `OSError`, so
+  `except BrokenPipeError:` and `except IsADirectoryError:` work as expected.
+
+```python
+import errno
+
+try:
+    text = rust_consume_stream(fd)
+except IsADirectoryError:
+    text = ""  # the descriptor was a directory
+except OSError as exc:
+    if exc.errno != errno.EBADF:
+        raise
+    text = ""  # the descriptor was already closed
+```
+
+On Windows the native code is a Win32 error rather than an `errno`, so it is
+carried in `winerror`; `errno` and the subclass are derived from it. Branch on
+`winerror` for Windows-specific codes.
+
+Failures that never reached the operating system — an internal overflow or
+bounds condition — surface as a plain `OSError` with a descriptive message and
+no `errno`, because there is no system code to report.
+
 ### Rust stream observability (internal)
 
 Both internal helpers emit `tracing` diagnostics; the crate installs no

--- a/rust/cuprum-rust/src/errors.rs
+++ b/rust/cuprum-rust/src/errors.rs
@@ -60,15 +60,54 @@ impl PumpError {
 impl From<PumpError> for PyErr {
     fn from(err: PumpError) -> Self {
         match err {
-            // Delegate to PyO3's conversion so I/O failures keep their
-            // specific Python exception subclasses (e.g. ``BrokenPipeError``,
-            // ``FileNotFoundError``) instead of collapsing to a base
-            // ``OSError``.
-            PumpError::Io(io_err) => io_err.into(),
+            PumpError::Io(io_err) => io_error_to_py_err(io_err),
             other @ (PumpError::LengthOverflow | PumpError::BufferRangeExceeded) => {
                 PyOSError::new_err(other.py_os_error_message().unwrap_or("stream pump failed"))
             }
         }
+    }
+}
+
+/// Strip the `" (os error N)"` suffix Rust appends to a raw OS error.
+///
+/// `io::Error`'s `Display` renders a raw OS error as `"{strerror} (os error
+/// {code})"`. Passing that whole string as `strerror` would render as
+/// `"[Errno 9] Bad file descriptor (os error 9)"`, stating the number twice.
+/// If the format ever changes the suffix simply will not match and the full
+/// message is used, so this degrades to the previous wording rather than
+/// mangling it.
+fn strip_os_error_suffix(message: &str, code: i32) -> String {
+    let suffix = format!(" (os error {code})");
+    message.strip_suffix(&suffix).unwrap_or(message).to_owned()
+}
+
+/// Convert an [`io::Error`] into a Python exception that keeps its `errno`.
+///
+/// `PyO3`'s own `From<io::Error> for PyErr` picks the exception *type* from
+/// `io::ErrorKind`, then constructs it with a single argument — the error's
+/// `Display` string. Python only populates `OSError.errno` and
+/// `OSError.strerror` when it receives **two or more** arguments, so a
+/// single-argument construction leaves `errno` as `None`: the number survives
+/// in the message text but not anywhere a caller can branch on. Callers are
+/// then forced to parse English to tell `EBADF` from `EPIPE`, and message text
+/// is not a stable interface.
+///
+/// Constructing `OSError(code, strerror)` instead fixes both halves at once,
+/// because `CPython` maps the errno to the matching subclass itself:
+/// `OSError(32, ...)` *is* a `BrokenPipeError`. That is the same subclass
+/// selection `PyO3` was reaching for through `ErrorKind`, obtained from the
+/// authoritative source rather than a parallel table.
+///
+/// An `io::Error` with no `raw_os_error` — one synthesized in Rust rather than
+/// returned by a syscall — has no number to preserve, so `PyO3`'s `ErrorKind`
+/// mapping remains the best available and is used unchanged.
+fn io_error_to_py_err(err: io::Error) -> PyErr {
+    match err.raw_os_error() {
+        Some(code) => {
+            let strerror = strip_os_error_suffix(&err.to_string(), code);
+            PyOSError::new_err((code, strerror))
+        }
+        None => err.into(),
     }
 }
 
@@ -77,6 +116,7 @@ mod tests {
     //! Unit tests for the canonical `PumpError` taxonomy: variant mapping,
     //! the non-fatal write predicate, and stable display messages.
     use super::PumpError;
+    use rstest::rstest;
     use std::io;
 
     #[test]
@@ -137,6 +177,30 @@ mod tests {
         assert_eq!(
             PumpError::from(io::Error::other("boom")).py_os_error_message(),
             None,
+        );
+    }
+
+    #[rstest]
+    #[case::raw_os_error("Bad file descriptor (os error 9)", 9, "Bad file descriptor")]
+    #[case::other_code("Broken pipe (os error 32)", 32, "Broken pipe")]
+    #[case::no_suffix("something went wrong", 9, "something went wrong")]
+    #[case::mismatched_code(
+        "Bad file descriptor (os error 9)",
+        22,
+        "Bad file descriptor (os error 9)"
+    )]
+    fn strip_os_error_suffix_removes_only_its_own_code(
+        #[case] message: &str,
+        #[case] code: i32,
+        #[case] expected: &str,
+    ) {
+        // A mismatched code must leave the message intact rather than trimming
+        // a suffix that belongs to a different error: the `strerror` a caller
+        // reads should never be silently truncated.
+        assert_eq!(
+            super::strip_os_error_suffix(message, code),
+            expected,
+            "stripping must be anchored to this error's own code",
         );
     }
 }

--- a/rust/cuprum-rust/src/errors.rs
+++ b/rust/cuprum-rust/src/errors.rs
@@ -81,32 +81,56 @@ fn strip_os_error_suffix(message: &str, code: i32) -> String {
     message.strip_suffix(&suffix).unwrap_or(message).to_owned()
 }
 
-/// Convert an [`io::Error`] into a Python exception that keeps its `errno`.
+/// Build a Python `OSError` from a POSIX `errno` and its message.
+///
+/// The two-argument form is what makes the number reachable: Python populates
+/// `OSError.errno` and `OSError.strerror` only when it receives **two or more**
+/// arguments. It also fixes the exception type, because `CPython` maps the
+/// errno to the matching subclass itself — `OSError(32, ...)` *is* a
+/// `BrokenPipeError`. That is the same subclass selection `PyO3` reaches for
+/// through `io::ErrorKind`, taken from the authoritative source rather than a
+/// parallel table.
+#[cfg(unix)]
+fn os_error_to_py_err(code: i32, strerror: String) -> PyErr {
+    PyOSError::new_err((code, strerror))
+}
+
+/// Build a Python `OSError` from a Win32 error code and its message.
+///
+/// On Windows `raw_os_error` carries a `GetLastError` code, not an `errno`.
+/// Passing it where Python expects an `errno` would assign an unrelated number
+/// — `ERROR_INVALID_HANDLE` is 6, which as an `errno` is `ENXIO` — leave
+/// `winerror` unset, and select the subclass from that wrong number.
+///
+/// The five-argument form `OSError(errno, strerror, filename, winerror,
+/// filename2)` is the one that carries a native code. Given a `winerror`,
+/// `CPython` ignores the `errno` argument, derives `errno` from the Win32 code
+/// itself, and then selects the subclass from the derived value, so all three
+/// fields agree. The leading zero is therefore a placeholder, and the two
+/// `None`s are the absent filenames.
+#[cfg(windows)]
+fn os_error_to_py_err(code: i32, strerror: String) -> PyErr {
+    PyOSError::new_err((0, strerror, None::<String>, code, None::<String>))
+}
+
+/// Convert an [`io::Error`] into a Python exception that keeps its OS code.
 ///
 /// `PyO3`'s own `From<io::Error> for PyErr` picks the exception *type* from
 /// `io::ErrorKind`, then constructs it with a single argument — the error's
-/// `Display` string. Python only populates `OSError.errno` and
-/// `OSError.strerror` when it receives **two or more** arguments, so a
-/// single-argument construction leaves `errno` as `None`: the number survives
-/// in the message text but not anywhere a caller can branch on. Callers are
-/// then forced to parse English to tell `EBADF` from `EPIPE`, and message text
-/// is not a stable interface.
+/// `Display` string. A single-argument construction leaves `errno` as `None`:
+/// the number survives in the message text but not anywhere a caller can
+/// branch on. Callers are then forced to parse English to tell `EBADF` from
+/// `EPIPE`, and message text is not a stable interface.
 ///
-/// Constructing `OSError(code, strerror)` instead fixes both halves at once,
-/// because `CPython` maps the errno to the matching subclass itself:
-/// `OSError(32, ...)` *is* a `BrokenPipeError`. That is the same subclass
-/// selection `PyO3` was reaching for through `ErrorKind`, obtained from the
-/// authoritative source rather than a parallel table.
+/// The platform decides how the number must be handed over, so the
+/// construction itself lives in the `cfg`-selected [`os_error_to_py_err`].
 ///
 /// An `io::Error` with no `raw_os_error` — one synthesized in Rust rather than
 /// returned by a syscall — has no number to preserve, so `PyO3`'s `ErrorKind`
 /// mapping remains the best available and is used unchanged.
 fn io_error_to_py_err(err: io::Error) -> PyErr {
     match err.raw_os_error() {
-        Some(code) => {
-            let strerror = strip_os_error_suffix(&err.to_string(), code);
-            PyOSError::new_err((code, strerror))
-        }
+        Some(code) => os_error_to_py_err(code, strip_os_error_suffix(&err.to_string(), code)),
         None => err.into(),
     }
 }
@@ -202,5 +226,92 @@ mod tests {
             expected,
             "stripping must be anchored to this error's own code",
         );
+    }
+
+    mod properties {
+        //! Generated coverage for [`super::super::strip_os_error_suffix`].
+        //!
+        //! The `rstest` cases above fix four hand-picked messages. They cannot
+        //! show that stripping is anchored to *this* error's code for every
+        //! message and every `i32`, which is the whole point of the helper: it
+        //! must never truncate a `strerror` a caller reads, and must never
+        //! leave the number stated twice.
+
+        use proptest::prelude::*;
+
+        /// Messages shaped like the ones this helper meets, plus near-misses.
+        ///
+        /// An unconstrained `".*"` almost never produces a string ending in
+        /// `)`, so it cannot tell a correct implementation from one that trims
+        /// trailing punctuation off messages it does not recognise. The arms
+        /// are: a plain `strerror`, one already carrying a rendered suffix, and
+        /// one that merely ends the way a suffix does.
+        fn os_error_message() -> impl Strategy<Value = String> {
+            prop_oneof![
+                "[^()]*",
+                ("[^()]*", any::<i32>())
+                    .prop_map(|(text, code)| format!("{text} (os error {code})")),
+                "[^()]*\\)",
+            ]
+        }
+
+        proptest! {
+            /// Stripping undoes appending, for any message and any code.
+            ///
+            /// This is the case that actually occurs: `io::Error` renders a raw
+            /// OS error as exactly `"{strerror} (os error {code})"`, so the
+            /// helper must recover `strerror` whatever the two contain.
+            #[test]
+            fn stripping_undoes_appending_the_matching_suffix(
+                message in os_error_message(),
+                code in any::<i32>(),
+            ) {
+                let rendered = format!("{message} (os error {code})");
+                prop_assert_eq!(
+                    super::super::strip_os_error_suffix(&rendered, code),
+                    message,
+                    "the rendered form must strip back to the bare strerror",
+                );
+            }
+
+            /// A suffix bearing a different code is left in place.
+            ///
+            /// Trimming it would hand the caller a truncated `strerror`, and
+            /// would hide that the message came from another error entirely.
+            #[test]
+            fn a_mismatched_code_leaves_the_message_untouched(
+                message in os_error_message(),
+                code in any::<i32>(),
+                other in any::<i32>(),
+            ) {
+                prop_assume!(code != other);
+                let rendered = format!("{message} (os error {other})");
+                prop_assert_eq!(
+                    super::super::strip_os_error_suffix(&rendered, code),
+                    rendered.clone(),
+                    "only this error's own suffix may be removed",
+                );
+            }
+
+            /// The result is never longer than the input, and only ever shrinks
+            /// by the exact suffix.
+            ///
+            /// Nothing above rules out the helper *rewriting* a message it does
+            /// not recognise; this pins that it either returns the input
+            /// verbatim or removes precisely one known suffix.
+            #[test]
+            fn the_message_is_returned_verbatim_or_minus_its_own_suffix(
+                message in os_error_message(),
+                code in any::<i32>(),
+            ) {
+                let stripped = super::super::strip_os_error_suffix(&message, code);
+                let removed = format!(" (os error {code})");
+                prop_assert!(
+                    stripped == message
+                        || format!("{stripped}{removed}") == message,
+                    "unrecognised messages must pass through unchanged",
+                );
+            }
+        }
     }
 }

--- a/rust/cuprum-rust/src/errors.rs
+++ b/rust/cuprum-rust/src/errors.rs
@@ -288,7 +288,7 @@ mod tests {
                 let rendered = format!("{message} (os error {other})");
                 prop_assert_eq!(
                     super::super::strip_os_error_suffix(&rendered, code),
-                    rendered.clone(),
+                    rendered,
                     "only this error's own suffix may be removed",
                 );
             }

--- a/rust/cuprum-rust/src/errors.rs
+++ b/rust/cuprum-rust/src/errors.rs
@@ -129,10 +129,27 @@ fn os_error_to_py_err(code: i32, strerror: String) -> PyErr {
 /// returned by a syscall — has no number to preserve, so `PyO3`'s `ErrorKind`
 /// mapping remains the best available and is used unchanged.
 fn io_error_to_py_err(err: io::Error) -> PyErr {
-    match err.raw_os_error() {
-        Some(code) => os_error_to_py_err(code, strip_os_error_suffix(&err.to_string(), code)),
+    match raw_os_error_parts(&err) {
+        Some((code, strerror)) => os_error_to_py_err(code, strerror),
         None => err.into(),
     }
+}
+
+/// Split a syscall failure into the code and message handed to Python.
+///
+/// `None` means the error carries no operating-system number and the caller
+/// must fall back to `PyO3`'s `ErrorKind` mapping. Every `io::Error` built in
+/// Rust rather than returned by a syscall lands here, including the
+/// `ErrorKind::WriteZero` the write paths raise when a write makes no progress.
+///
+/// The decision is split out from [`io_error_to_py_err`] so it can be tested
+/// directly. Inspecting the built `PyErr` instead would need a live
+/// interpreter, and this crate is compiled with `pyo3/extension-module`, which
+/// deliberately leaves the Python symbols to be resolved by the host process —
+/// so no `cargo test` binary can link one.
+fn raw_os_error_parts(err: &io::Error) -> Option<(i32, String)> {
+    let code = err.raw_os_error()?;
+    Some((code, strip_os_error_suffix(&err.to_string(), code)))
 }
 
 #[cfg(test)]
@@ -225,6 +242,54 @@ mod tests {
             super::strip_os_error_suffix(message, code),
             expected,
             "stripping must be anchored to this error's own code",
+        );
+    }
+
+    /// A syscall failure surrenders its code and its message without the
+    /// suffix `io::Error` appends.
+    ///
+    /// The expected `strerror` is not spelled out, so the case holds whatever
+    /// the platform calls this code: it asserts that putting the suffix back
+    /// reproduces `Display` exactly, which pins that the helper removes the
+    /// suffix and nothing else and returns the code unaltered.
+    #[test]
+    fn a_raw_os_error_yields_its_code_and_bare_strerror() {
+        let code = 9;
+        let err = io::Error::from_raw_os_error(code);
+        let rendered = err.to_string();
+
+        let Some((reported, strerror)) = super::raw_os_error_parts(&err) else {
+            panic!("a raw OS error must report its code, found none for {err:?}")
+        };
+
+        assert_eq!(reported, code, "the code must survive unaltered");
+        assert_eq!(
+            rendered,
+            format!("{strerror} (os error {code})"),
+            "the message must lose exactly the suffix Rust appended",
+        );
+    }
+
+    /// An error built in Rust has no number, so the conversion falls back.
+    ///
+    /// This is the arm that hands the error to `PyO3` unchanged. It is not
+    /// hypothetical: the write paths in `io_utils` raise
+    /// `ErrorKind::WriteZero` in exactly this way when a write makes no
+    /// progress, so a regression that fabricated a code for an error that has
+    /// none would reach production. Both `io::Error` representations are
+    /// covered — one carrying a custom payload, one built from a bare kind.
+    #[rstest]
+    #[case::write_zero_from_the_write_paths(io::Error::new(
+        io::ErrorKind::WriteZero,
+        "failed to write whole buffer",
+    ))]
+    #[case::other_with_a_message(io::Error::other("boom"))]
+    #[case::bare_kind(io::Error::from(io::ErrorKind::BrokenPipe))]
+    fn a_synthesized_error_has_no_code_to_preserve(#[case] err: io::Error) {
+        assert!(
+            super::raw_os_error_parts(&err).is_none(),
+            "an error with no raw_os_error must select PyO3's ErrorKind mapping \
+             rather than a fabricated code: {err:?}",
         );
     }
 


### PR DESCRIPTION
## Summary

`OSError`s raised by the extension carried `errno = None`, even when the failure was a real OS error whose number appeared in the message. Callers could not branch on the kind of failure; the only route left was matching message text, which is not a stable interface.

Closes #265.

## Cause

PyO3's `From<io::Error> for PyErr` picks the exception *type* from `io::ErrorKind`, then constructs it with a **single** argument — the error's `Display` string:

```rust
_ => exceptions::PyOSError::new_err(err),   // PyErrArguments -> self.to_string()
```

Python populates `errno` and `strerror` only for `OSError(errno, strerror)`, two arguments or more:

```
OSError('Bad file descriptor (os error 9)',)  -> OSError            errno=None
OSError(9, 'Bad file descriptor')             -> OSError            errno=9
OSError(32, 'Broken pipe')                    -> BrokenPipeError    errno=32
```

I confirmed the number survives intact as far as `PumpError::Io` (`raw_os_error = Some(9)`), so the loss is entirely at the final conversion.

## Fix

Construct the exception at our boundary with `(code, strerror)`. This fixes both halves at once, because **CPython maps the errno to the matching subclass itself** — the same subclass selection PyO3 reached for through `ErrorKind`, taken from the authoritative source rather than a parallel table. Reading a directory now raises `IsADirectoryError`, as it should.

Rust's `" (os error N)"` suffix is stripped, which would otherwise render as `"[Errno 9] Bad file descriptor (os error 9)"`. An `io::Error` with no `raw_os_error` has no number to preserve, so PyO3's mapping stays in use for it.

## Tests

The existing assertion in `test_rust_pump_stream_propagates_io_errors` is unchanged and now passes. It reaches the conversion through the pump, which treats a broken pipe as non-fatal and drains — so most interesting errnos never propagate that way. `cuprum/unittests/test_rust_errno.py` isolates the conversion through the exported entry points and pins the subclass selection and message shape as well as the number. `strip_os_error_suffix` has Rust-side unit tests, including a mismatched-code case so a suffix belonging to a different error is never trimmed.

Mutation-verified: restoring PyO3's single-argument conversion fails five tests; leaving the Rust suffix in place fails one.

## Validation

`make check-fmt`, `make lint`, `make typecheck`, `make test` all pass; `cs delta` reports no issues.

> [!NOTE]
> Stacked on #241. Review that first.
