### PR TITLE
Build the Rust extension in CI and fail loudly without it (#258)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,12 +356,15 @@ jobs:
             local prefix="$2"
             pushd "${workspace}" >/dev/null
 
-            make build
-            UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run python \
-              -m ensurepip --upgrade
-            UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run maturin develop \
-              --release \
-              --manifest-path rust/cuprum-rust/Cargo.toml
+            # `make develop` is the one definition of the extension build:
+            # `make build`, then `ensurepip --upgrade`, then `maturin
+            # develop`. The ratchet must measure an optimized build, and that
+            # is the only thing it needs differently, so it passes the flag
+            # instead of restating the sequence. This runs after `pushd
+            # "${workspace}"`, so the target's relative UV_CACHE_DIR and
+            # UV_TOOL_DIR resolve against the same directory the inline
+            # commands used.
+            make develop MATURIN_DEVELOP_FLAGS=--release
 
             UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools uv run python \
               benchmarks/pipeline_throughput.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,49 @@ jobs:
       - name: Run tests
         run: make test
 
+  extension-tests:
+    name: Extension-gated tests (Python/Rust boundary)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Prepare Cargo dependencies
+        run: cargo fetch --locked --manifest-path rust/cuprum-rust/Cargo.toml
+
+      # `make build` only syncs dependencies; `make develop` compiles the PyO3
+      # extension into the same virtual environment. It is the target
+      # contributors run locally, so this job cannot drift from local setup.
+      - name: Build the native extension
+        run: make develop
+
+      # These modules are gated on `cuprum._rust_backend_native` being
+      # importable and skip silently without it, so before this job existed a
+      # green run was indistinguishable from one that never exercised the
+      # Python/Rust boundary. `CUPRUM_REQUIRE_RUST_EXTENSION` turns a missing
+      # extension into a failure, so the gate cannot close again unnoticed.
+      #
+      # This runs the gated modules rather than the whole suite on purpose.
+      # With the extension present, `test_pipeline.py` trips the FD close race
+      # tracked by issue #124 (roadmap 8.1.1) and aborts the interpreter, so
+      # widening this job must wait for that fix.
+      - name: Run extension-gated tests
+        env:
+          CUPRUM_REQUIRE_RUST_EXTENSION: '1'
+        run: |
+          uv run pytest -v \
+            cuprum/unittests/test_rust_streams.py \
+            cuprum/unittests/test_rust_streams_boundary_property.py \
+            cuprum/unittests/test_rust_extension.py \
+            cuprum/unittests/test_rust_splice.py \
+            cuprum/unittests/test_rust_errno.py \
+            cuprum/unittests/test_backend.py
+
   coverage:
     # Pull requests only. Pushes to main are handled by coverage-main.yml,
     # which also uploads the report to CodeScene; guarding here stops

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,12 +146,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
         with:
           enable-cache: true
+
+      # `make develop` compiles the extension, so this job needs the same
+      # pinned toolchain the other Rust-touching jobs use rather than whatever
+      # the runner image happens to ship.
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install 1.85.0 --profile minimal
+          rustup default 1.85.0
 
       - name: Prepare Cargo dependencies
         run: cargo fetch --locked --manifest-path rust/cuprum-rust/Cargo.toml
@@ -172,6 +185,13 @@ jobs:
       # With the extension present, `test_pipeline.py` trips the FD close race
       # tracked by issue #124 (roadmap 8.1.1) and aborts the interpreter, so
       # widening this job must wait for that fix.
+      #
+      # The behavioural modules are listed too: without an extension the
+      # `rust_streams` fixture skips their consumer-facing scenarios, the
+      # dispatcher scenarios skip on `requires_rust_backend`, and
+      # test_rust_extension_behaviour returns before comparing against the
+      # installed native module — so they were never boundary coverage in the
+      # ordinary test jobs either.
       - name: Run extension-gated tests
         env:
           CUPRUM_REQUIRE_RUST_EXTENSION: '1'
@@ -182,7 +202,11 @@ jobs:
             cuprum/unittests/test_rust_extension.py \
             cuprum/unittests/test_rust_splice.py \
             cuprum/unittests/test_rust_errno.py \
-            cuprum/unittests/test_backend.py
+            cuprum/unittests/test_backend.py \
+            cuprum/unittests/test_extension_requirement_guard.py \
+            tests/behaviour/test_rust_streams_behaviour.py \
+            tests/behaviour/test_rust_extension_behaviour.py \
+            tests/behaviour/test_stream_backend_pipeline.py
 
   coverage:
     # Pull requests only. Pushes to main are handled by coverage-main.yml,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,16 @@ jobs:
       - name: Run lint
         run: make lint
 
+      # The Windows wheel build compiles this arm but without `-D warnings`,
+      # so it catches a Windows arm that fails to build and nothing else. This
+      # step is what holds the `#[cfg(windows)]` and `#[cfg(unix)]` branches to
+      # the same warnings posture as the host.
+      - name: Install the Windows target standard library
+        run: rustup target add x86_64-pc-windows-msvc
+
+      - name: Lint the Windows cfg branches
+        run: make lint-windows
+
   typecheck-test:
     name: Typecheck and test (Python ${{ matrix.python-label }})
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          # This job compiles and runs repository code, so the checkout token
+          # must not stay in .git/config where that code could reach it.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -181,32 +185,20 @@ jobs:
       # Python/Rust boundary. `CUPRUM_REQUIRE_RUST_EXTENSION` turns a missing
       # extension into a failure, so the gate cannot close again unnoticed.
       #
-      # This runs the gated modules rather than the whole suite on purpose.
-      # With the extension present, `test_pipeline.py` trips the FD close race
-      # tracked by issue #124 (roadmap 8.1.1) and aborts the interpreter, so
-      # widening this job must wait for that fix.
-      #
-      # The behavioural modules are listed too: without an extension the
+      # The behavioural modules are covered too: without an extension the
       # `rust_streams` fixture skips their consumer-facing scenarios, the
       # dispatcher scenarios skip on `requires_rust_backend`, and
       # test_rust_extension_behaviour returns before comparing against the
       # installed native module — so they were never boundary coverage in the
       # ordinary test jobs either.
+      #
+      # The module list itself lives in the Makefile's EXTENSION_TEST_TARGETS,
+      # so this job and the documented local command cannot drift apart. It is
+      # deliberately not the whole suite: with the extension present,
+      # `test_pipeline.py` trips the FD close race tracked by issue #124
+      # (roadmap 8.1.1) and aborts the interpreter.
       - name: Run extension-gated tests
-        env:
-          CUPRUM_REQUIRE_RUST_EXTENSION: '1'
-        run: |
-          uv run pytest -v \
-            cuprum/unittests/test_rust_streams.py \
-            cuprum/unittests/test_rust_streams_boundary_property.py \
-            cuprum/unittests/test_rust_extension.py \
-            cuprum/unittests/test_rust_splice.py \
-            cuprum/unittests/test_rust_errno.py \
-            cuprum/unittests/test_backend.py \
-            cuprum/unittests/test_extension_requirement_guard.py \
-            tests/behaviour/test_rust_streams_behaviour.py \
-            tests/behaviour/test_rust_extension_behaviour.py \
-            tests/behaviour/test_stream_backend_pipeline.py
+        run: make test-extension
 
   coverage:
     # Pull requests only. Pushes to main are handled by coverage-main.yml,

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,20 @@ PYTEST_TARGETS ?= cuprum/unittests/test_*.py \
   tests/behaviour/test_[a-h]*.py \
   tests/behaviour/test_[i-r]*.py \
   tests/behaviour/test_[s-z]*.py
+# The modules gated on the compiled extension. Deliberately not the whole
+# suite: with the extension installed, test_pipeline.py trips the descriptor
+# close race in issue #124 and aborts the interpreter. One definition here,
+# consumed by both the extension-tests CI job and the documented local command.
+EXTENSION_TEST_TARGETS ?= cuprum/unittests/test_rust_streams.py \
+  cuprum/unittests/test_rust_streams_boundary_property.py \
+  cuprum/unittests/test_rust_extension.py \
+  cuprum/unittests/test_rust_splice.py \
+  cuprum/unittests/test_rust_errno.py \
+  cuprum/unittests/test_backend.py \
+  cuprum/unittests/test_extension_requirement_guard.py \
+  tests/behaviour/test_rust_streams_behaviour.py \
+  tests/behaviour/test_rust_extension_behaviour.py \
+  tests/behaviour/test_stream_backend_pipeline.py
 shell_quote = '$(subst ','"'"',$(1))'
 TYPOS_VERSION ?= 1.48.0
 TYPOS := uv tool run typos@$(TYPOS_VERSION)
@@ -49,6 +63,7 @@ PYLINT = $(UV_RUN_ENV) uv tool run --python $(PYLINT_PYTHON) \
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
         markdownlint spelling spelling-helper-test nixie test typecheck \
+        test-extension develop \
         benchmark-micro benchmark-e2e \
         $(TOOLS) $(VENV_TOOLS)
 
@@ -162,6 +177,11 @@ test: build uv $(VENV_TOOLS) ## Run tests
 	  echo "cargo-nextest not found; falling back to cargo test." >&2; \
 	  cd $(RUST_DIR) && CARGO_BUILD_JOBS="$(TEST_CARGO_BUILD_JOBS)" RUSTFLAGS="$(TEST_RUSTFLAGS)" $(CARGO) test $(TEST_FLAGS) $(BUILD_JOBS); \
 	fi
+
+# Run `make develop` first. Without the extension the guard fails the run with
+# a message naming that command, which is the intended diagnostic.
+test-extension: build uv $(VENV_TOOLS) ## Run the extension-gated tests, requiring the extension
+	CUPRUM_REQUIRE_RUST_EXTENSION=1 $(PYTEST) -v $(EXTENSION_TEST_TARGETS)
 
 benchmark-micro: build uv ## Run pytest-benchmark microbenchmarks
 	mkdir -p dist/benchmarks

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ TEST_FLAGS ?= $(CARGO_FLAGS) --jobs 1
 TEST_RUSTFLAGS ?= $(RUST_FLAGS) -C codegen-units=1
 WHITAKER_CARGO_FLAGS ?= $(CARGO_FLAGS) --jobs 1
 WHITAKER_RUSTFLAGS ?= $(RUST_FLAGS) -C codegen-units=1
+# Extra flags for the `maturin develop` invocation in the `develop` target.
+# Empty by default: a debug build is what contributors and the extension-tests
+# job want. The benchmark ratchet needs an optimized build, and an optimized
+# build is the *only* thing it needs differently, so it passes `--release`
+# here rather than restating the three-step build sequence inline.
+MATURIN_DEVELOP_FLAGS ?=
 # The Windows arm of the extension's `cfg` branches. `make lint` only ever sees
 # the host's arm, and the Windows wheel build compiles without `-D warnings`,
 # so warn-level regressions behind `#[cfg(windows)]` — dead code left by a
@@ -90,7 +96,7 @@ build: uv .venv ## Build virtual-env and install deps
 # extension for tests" in docs/developers-guide.md.
 develop: build ## Build the native extension into the dev virtual-env
 	$(UV_RUN_ENV) uv run python -m ensurepip --upgrade
-	$(UV_RUN_ENV) uv run maturin develop --manifest-path $(RUST_DIR)/cuprum-rust/Cargo.toml
+	$(UV_RUN_ENV) uv run maturin develop $(MATURIN_DEVELOP_FLAGS) --manifest-path $(RUST_DIR)/cuprum-rust/Cargo.toml
 
 build-release: ## Build artefacts (sdist & wheel)
 	python -m build --sdist --wheel

--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,8 @@ all: build check-fmt lint typecheck test
 build: uv .venv ## Build virtual-env and install deps
 	$(UV_RUN_ENV) uv sync --group dev
 
-# `build` only syncs dependencies and never compiles the PyO3 extension, so
-# the extension-gated Python tests skip without this target. `ensurepip` comes
-# first because maturin resolves its own script through the interpreter's
-# sysconfig scheme, which needs pip present. See "Building the extension for
-# tests" in docs/developers-guide.md.
+# Why this exists and why `ensurepip` comes first: see "Building the
+# extension for tests" in docs/developers-guide.md.
 develop: build ## Build the native extension into the dev virtual-env
 	$(UV_RUN_ENV) uv run python -m ensurepip --upgrade
 	$(UV_RUN_ENV) uv run maturin develop --manifest-path $(RUST_DIR)/cuprum-rust/Cargo.toml

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,12 @@ all: build check-fmt lint typecheck test
 build: uv .venv ## Build virtual-env and install deps
 	$(UV_RUN_ENV) uv sync --group dev
 
+# `build` only syncs dependencies and never compiles the PyO3 extension, so
+# the extension-gated Python tests skip without this target. `ensurepip` comes
+# first because maturin resolves its own script through the interpreter's
+# sysconfig scheme, which needs pip present. See "Building the extension for
+# tests" in docs/developers-guide.md.
 develop: build ## Build the native extension into the dev virtual-env
-	# `build` only syncs dependencies; it never compiles the PyO3 extension,
-	# so the extension-gated Python tests skip without this. One definition
-	# here keeps the local and CI invocations identical.
-	# maturin resolves its own script through the interpreter's sysconfig
-	# scheme, which needs pip present in the environment; the benchmark job
-	# already proved this ordering necessary on a fresh venv.
 	$(UV_RUN_ENV) uv run python -m ensurepip --upgrade
 	$(UV_RUN_ENV) uv run maturin develop --manifest-path $(RUST_DIR)/cuprum-rust/Cargo.toml
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,15 @@ TEST_FLAGS ?= $(CARGO_FLAGS) --jobs 1
 TEST_RUSTFLAGS ?= $(RUST_FLAGS) -C codegen-units=1
 WHITAKER_CARGO_FLAGS ?= $(CARGO_FLAGS) --jobs 1
 WHITAKER_RUSTFLAGS ?= $(RUST_FLAGS) -C codegen-units=1
+# The Windows arm of the extension's `cfg` branches. `make lint` only ever sees
+# the host's arm, and the Windows wheel build compiles without `-D warnings`,
+# so warn-level regressions behind `#[cfg(windows)]` — dead code left by a
+# `#[cfg(unix)]` gate, most of all — would reach main unremarked.
+WINDOWS_TARGET ?= x86_64-pc-windows-msvc
+# PyO3 cannot probe an interpreter for the target platform, so the ABI version
+# must be stated. Keep it in step with the `python-version` the Windows job in
+# .github/workflows/build-wheels.yml builds against.
+WINDOWS_PYTHON_VERSION ?= 3.13
 PYTEST_CARGO_BUILD_JOBS ?= 1
 PYTEST_RUSTFLAGS ?= -C codegen-units=1
 TEST_CARGO_BUILD_JOBS ?= 1
@@ -61,7 +70,7 @@ PYLINT_VERSION ?= 4.0.5
 PYLINT = $(UV_RUN_ENV) uv tool run --python $(PYLINT_PYTHON) \
   --from '$(PYLINT_PYPY_SHIM)' --with 'pylint==$(PYLINT_VERSION)' pylint-pypy
 
-.PHONY: help all clean build build-release lint fmt check-fmt \
+.PHONY: help all clean build build-release lint lint-windows fmt check-fmt \
         markdownlint spelling spelling-helper-test nixie test typecheck \
         test-extension develop \
         benchmark-micro benchmark-e2e \
@@ -137,6 +146,15 @@ lint: ruff uv ## Run linters (Ruff, pylint, Clippy, Whitaker)
 	@if ! $(LOCAL_TOOL_ENV) command -v $(WHITAKER) >/dev/null 2>&1; then echo "whitaker is required for linting. Install it before running this target." >&2; exit 1; fi
 	cd $(RUST_DIR) && $(LOCAL_TOOL_ENV) RUSTFLAGS="$(WHITAKER_RUSTFLAGS)" $(WHITAKER) --all -- $(WHITAKER_CARGO_FLAGS)
 	+$(MAKE) spelling
+
+lint-windows: ## Lint the Rust extension's Windows cfg branches (cross-target)
+	@if ! rustup target list --installed | grep -qx '$(WINDOWS_TARGET)'; then \
+	  echo "The $(WINDOWS_TARGET) standard library is required." >&2; \
+	  echo "Install it with: rustup target add $(WINDOWS_TARGET)" >&2; \
+	  exit 1; \
+	fi
+	cd $(RUST_DIR) && PYO3_CROSS_PYTHON_VERSION=$(WINDOWS_PYTHON_VERSION) \
+	  $(CARGO) clippy --target $(WINDOWS_TARGET) $(CLIPPY_FLAGS)
 
 typecheck: build ## Run typechecking
 	$(UV_RUN_ENV) uv sync --group dev

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,16 @@ all: build check-fmt lint typecheck test
 build: uv .venv ## Build virtual-env and install deps
 	$(UV_RUN_ENV) uv sync --group dev
 
+develop: build ## Build the native extension into the dev virtual-env
+	# `build` only syncs dependencies; it never compiles the PyO3 extension,
+	# so the extension-gated Python tests skip without this. One definition
+	# here keeps the local and CI invocations identical.
+	# maturin resolves its own script through the interpreter's sysconfig
+	# scheme, which needs pip present in the environment; the benchmark job
+	# already proved this ordering necessary on a fresh venv.
+	$(UV_RUN_ENV) uv run python -m ensurepip --upgrade
+	$(UV_RUN_ENV) uv run maturin develop --manifest-path $(RUST_DIR)/cuprum-rust/Cargo.toml
+
 build-release: ## Build artefacts (sdist & wheel)
 	python -m build --sdist --wheel
 

--- a/conftest.py
+++ b/conftest.py
@@ -18,40 +18,50 @@ import pytest
 
 from cuprum import _rust_backend
 from cuprum._backend import _check_rust_available, get_stream_backend
+from tests.helpers.extension_requirement import (
+    REQUIRE_EXTENSION_ENV,
+    missing_extension_message,
+)
 
 if typ.TYPE_CHECKING:
     from types import ModuleType
 
 
-_REQUIRE_EXTENSION_ENV = "CUPRUM_REQUIRE_RUST_EXTENSION"
-
-
 def pytest_configure(config: pytest.Config) -> None:
     """Fail the run when the extension is required but absent.
 
-    The extension-gated modules skip when `cuprum._rust_backend_native` cannot
-    be imported, which is right locally — most contributors do not build the
-    native extension for every change. In CI it is the wrong default: a job
-    that never builds the extension reports a green run indistinguishable from
-    one that exercised the whole Python/Rust boundary.
+    Parameters
+    ----------
+    config : pytest.Config
+        The session configuration. Unused; the decision depends only on the
+        environment and on whether the extension is importable.
 
-    Setting `CUPRUM_REQUIRE_RUST_EXTENSION=1` makes that silence fatal. One
-    session-level check covers every gated module regardless of how each one
-    gates — fixture, module-level guard, or availability probe — so a new
-    module cannot opt out of the requirement by skipping differently.
+    Raises
+    ------
+    pytest.UsageError
+        If ``CUPRUM_REQUIRE_RUST_EXTENSION`` is set to a non-empty value and
+        the native extension is unavailable.
+
+    Notes
+    -----
+    The extension-gated modules skip when the native extension is unavailable,
+    which is right locally — most contributors do not build it for every
+    change. In CI it is the wrong default: a job that never builds the
+    extension reports a green run indistinguishable from one that exercised
+    the whole Python/Rust boundary.
+
+    Setting the variable makes that silence fatal. One session-level check
+    covers every gated module regardless of how each one gates — fixture,
+    module-level guard, or availability probe — so a new module cannot opt out
+    of the requirement by skipping differently.
     """
     del config
-    if not os.environ.get(_REQUIRE_EXTENSION_ENV):
-        return
-    if _rust_backend.is_available():
-        return
-    msg = (
-        f"{_REQUIRE_EXTENSION_ENV} is set, but cuprum._rust_backend_native "
-        "could not be imported, so every extension-gated test would skip "
-        "silently. Build it with `make develop` before running the suite. "
-        "Unset the variable to allow skipping."
+    message = missing_extension_message(
+        required=bool(os.environ.get(REQUIRE_EXTENSION_ENV)),
+        available=_rust_backend.is_available(),
     )
-    raise pytest.UsageError(msg)
+    if message is not None:
+        raise pytest.UsageError(message)
 
 
 @pytest.fixture(name="rust_streams")

--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,7 @@ def test_pumps_bytes(rust_streams):
 
 from __future__ import annotations
 
+import os
 import typing as typ
 
 import pytest
@@ -20,6 +21,37 @@ from cuprum._backend import _check_rust_available, get_stream_backend
 
 if typ.TYPE_CHECKING:
     from types import ModuleType
+
+
+_REQUIRE_EXTENSION_ENV = "CUPRUM_REQUIRE_RUST_EXTENSION"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Fail the run when the extension is required but absent.
+
+    The extension-gated modules skip when `cuprum._rust_backend_native` cannot
+    be imported, which is right locally — most contributors do not build the
+    native extension for every change. In CI it is the wrong default: a job
+    that never builds the extension reports a green run indistinguishable from
+    one that exercised the whole Python/Rust boundary.
+
+    Setting `CUPRUM_REQUIRE_RUST_EXTENSION=1` makes that silence fatal. One
+    session-level check covers every gated module regardless of how each one
+    gates — fixture, module-level guard, or availability probe — so a new
+    module cannot opt out of the requirement by skipping differently.
+    """
+    del config
+    if not os.environ.get(_REQUIRE_EXTENSION_ENV):
+        return
+    if _rust_backend.is_available():
+        return
+    msg = (
+        f"{_REQUIRE_EXTENSION_ENV} is set, but cuprum._rust_backend_native "
+        "could not be imported, so every extension-gated test would skip "
+        "silently. Build it with `make develop` before running the suite. "
+        "Unset the variable to allow skipping."
+    )
+    raise pytest.UsageError(msg)
 
 
 @pytest.fixture(name="rust_streams")

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -87,6 +87,7 @@
       'cuprum/unittests/test_cqrs_hook_behaviour.py',
       'cuprum/unittests/test_env_context.py',
       'cuprum/unittests/test_env_context_properties.py',
+      'cuprum/unittests/test_extension_requirement_guard.py',
       'cuprum/unittests/test_fetch_main_benchmark_baseline.py',
       'cuprum/unittests/test_fixture_generation.py',
       'cuprum/unittests/test_folded_ranking_property.py',

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -88,6 +88,7 @@
       'cuprum/unittests/test_env_context.py',
       'cuprum/unittests/test_env_context_properties.py',
       'cuprum/unittests/test_extension_build_contract.py',
+      'cuprum/unittests/test_extension_ci_contract.py',
       'cuprum/unittests/test_extension_requirement_guard.py',
       'cuprum/unittests/test_fetch_main_benchmark_baseline.py',
       'cuprum/unittests/test_fixture_generation.py',

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -87,6 +87,7 @@
       'cuprum/unittests/test_cqrs_hook_behaviour.py',
       'cuprum/unittests/test_env_context.py',
       'cuprum/unittests/test_env_context_properties.py',
+      'cuprum/unittests/test_extension_build_contract.py',
       'cuprum/unittests/test_extension_requirement_guard.py',
       'cuprum/unittests/test_fetch_main_benchmark_baseline.py',
       'cuprum/unittests/test_fixture_generation.py',

--- a/cuprum/unittests/test_extension_build_contract.py
+++ b/cuprum/unittests/test_extension_build_contract.py
@@ -1,0 +1,384 @@
+"""Contract tests for the extension build wiring in the Makefile and CI.
+
+`make test-extension` and the `extension-tests` job are the only things that
+turn a silently-skipped extension into a failure, and both are configuration
+rather than code. Nothing else in the suite notices when the guard variable
+leaves the recipe, a module falls out of ``EXTENSION_TEST_TARGETS``, or the CI
+job stops building the extension before running the gated tests: every one of
+those changes leaves a green run behind. These tests read the wiring back and
+assert the contract it must uphold.
+
+The Makefile side is read through ``make --dry-run`` rather than by parsing
+the file: that is the command line the target actually runs, with every
+variable expanded, so an assertion about the guard variable is an assertion
+about what CI executes rather than about text sitting near it.
+
+``EXTENSION_TEST_TARGETS`` is pinned by two independent properties, neither
+implying the other — ``_SKIP_SIGNALS`` derives the gated modules from the
+suite itself so a *new* one cannot be forgotten, and ``_COMPANION_TARGETS``
+names the modules that are in the job for reasons no scan can derive. What
+each property does and does not catch is set out under "Building the
+extension for tests" in docs/developers-guide.md; this module keeps a pointer
+rather than repeating it.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import pathlib as pth
+import re
+import subprocess  # noqa: S404 - reads the repository's own Makefile recipes.
+import typing as typ
+
+import pytest
+import yaml
+
+from tests.helpers.docs import repo_root
+from tests.helpers.extension_requirement import REQUIRE_EXTENSION_ENV
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+CI_WORKFLOW = ".github/workflows/ci.yml"
+
+#: Where test modules live. Any of them could gate on the extension, so all
+#: are scanned, not only the directories holding gated modules today.
+_TEST_MODULE_GLOBS: typ.Final = (
+    "cuprum/unittests/test_*.py",
+    "tests/test_*.py",
+    "tests/behaviour/test_*.py",
+)
+
+#: Textual signals that a module's outcome depends on the compiled extension,
+#: each mapped to the reason it counts. Keep the reasons readable: they are
+#: quoted verbatim in the failure that asks for a module to be added.
+_SKIP_SIGNALS: typ.Final[dict[str, re.Pattern[str]]] = {
+    "requests the root conftest's `rust_streams` fixture, which skips the "
+    "test when the extension is absent": re.compile(r"\brust_streams\b"),
+    "skips with the shared 'Rust extension is not installed' reason": re.compile(
+        r"Rust extension is not installed"
+    ),
+    "names `cuprum._rust_backend_native`, so what it asserts depends on the "
+    "real extension": re.compile(r"\b_rust_backend_native\b"),
+}
+
+#: Targets that no scan can derive, because they do not gate on the extension
+#: at all, mapped to why the extension-tests job runs them anyway.
+_COMPANION_TARGETS: typ.Final[dict[str, str]] = {
+    "cuprum/unittests/test_extension_requirement_guard.py": (
+        "the guard's own tests; running them in the guarded job is what "
+        "proves the guard stays silent when the extension is present, rather "
+        "than only that it fires when the extension is absent"
+    ),
+}
+
+
+@functools.cache
+def _dry_run(*goals: str) -> str:
+    """Return what ``make --dry-run`` prints for `goals`, recipes expanded."""
+    # MAKEFLAGS leaks in when pytest is itself launched from `make test`, and
+    # an inherited jobserver flag makes this nested make warn about it.
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"MAKEFLAGS", "MAKELEVEL", "MFLAGS"}
+    }
+    completed = subprocess.run(  # noqa: S603 - fixed argument vector.
+        ["make", "--dry-run", *goals],  # noqa: S607 - `make` resolved from PATH.
+        capture_output=True,
+        check=True,
+        cwd=repo_root(),
+        env=environment,
+        text=True,
+    )
+    return completed.stdout
+
+
+def _sole_line_containing(text: str, needle: str, *, subject: str) -> str:
+    """Return the single line of `text` holding `needle`, or fail naming it."""
+    matches = [line for line in text.splitlines() if needle in line]
+    assert len(matches) == 1, (
+        f"expected exactly one {subject} line containing {needle!r}, found "
+        f"{len(matches)}"
+    )
+    return matches[0]
+
+
+@functools.cache
+def _guarded_pytest_command() -> str:
+    """Return the `test-extension` recipe line that sets the guard variable."""
+    return _sole_line_containing(
+        _dry_run("test-extension"),
+        f"{REQUIRE_EXTENSION_ENV}=1",
+        subject="test-extension recipe",
+    )
+
+
+@functools.cache
+def _declared_targets() -> tuple[str, ...]:
+    """Return the module paths `make test-extension` hands to pytest."""
+    targets = tuple(
+        word for word in _guarded_pytest_command().split() if word.endswith(".py")
+    )
+    assert targets, (
+        "the guarded `make test-extension` command line names no test "
+        "modules, so the job would run nothing"
+    )
+    return targets
+
+
+@functools.cache
+def _scanned_sources() -> dict[str, str]:
+    """Return the source of every test module the signal scan considers.
+
+    This module is excluded: it quotes every signal, so scanning it would
+    match each one against its own definition.
+    """
+    root = repo_root()
+    this_module = pth.Path(__file__).resolve().relative_to(root).as_posix()
+    return {
+        relative: path.read_text(encoding="utf-8")
+        for glob in _TEST_MODULE_GLOBS
+        for path in sorted(root.glob(glob))
+        if (relative := path.relative_to(root).as_posix()) != this_module
+    }
+
+
+def _gated_modules() -> dict[str, str]:
+    """Map each extension-gated test module to the signal that found it."""
+    gated: dict[str, str] = {}
+    for module, source in _scanned_sources().items():
+        reason = next(
+            (
+                reason
+                for reason, pattern in _SKIP_SIGNALS.items()
+                if pattern.search(source)
+            ),
+            None,
+        )
+        if reason is not None:
+            gated[module] = reason
+    return gated
+
+
+@functools.cache
+def _workflow() -> dict[str, typ.Any]:
+    """Parse the CI workflow."""
+    parsed = yaml.safe_load((repo_root() / CI_WORKFLOW).read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict), f"{CI_WORKFLOW} must parse to a mapping"
+    return parsed
+
+
+def _job_steps(job_name: str) -> list[dict[str, typ.Any]]:
+    """Return the steps of a named CI job."""
+    jobs = _workflow().get("jobs")
+    assert isinstance(jobs, dict), f"{CI_WORKFLOW} must declare a jobs mapping"
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), (
+        f"{CI_WORKFLOW} must declare a {job_name!r} job; found {sorted(jobs)}"
+    )
+    steps = job.get("steps")
+    assert isinstance(steps, list), f"the {job_name!r} job must declare steps"
+    return steps
+
+
+def _run_scripts() -> cabc.Iterator[tuple[str, str]]:
+    """Yield the job name and script of every ``run:`` step in the workflow."""
+    for job_name, job in (_workflow().get("jobs") or {}).items():
+        for step in (job or {}).get("steps") or []:
+            script = step.get("run")
+            if isinstance(script, str):
+                yield job_name, script
+
+
+def _step_index_running(command: str, *, job_name: str) -> int:
+    """Return the index of the first step in `job_name` running `command`."""
+    for index, step in enumerate(_job_steps(job_name)):
+        script = step.get("run")
+        if isinstance(script, str) and command in script:
+            return index
+    pytest.fail(f"no step in the {job_name!r} job runs {command!r}")
+
+
+def test_the_test_extension_recipe_sets_the_guard_variable() -> None:
+    """`make test-extension` must require the extension, not merely run tests.
+
+    Without the variable the recipe is an ordinary pytest run, which is the
+    exact silent pass the target exists to prevent.
+    """
+    recipe = _dry_run("test-extension")
+
+    assert f"{REQUIRE_EXTENSION_ENV}=1" in recipe, (
+        f"the test-extension recipe must set {REQUIRE_EXTENSION_ENV}=1, or a "
+        "run without the extension skips every gated module and still passes"
+    )
+    assert "uv run pytest" in _guarded_pytest_command(), (
+        f"{REQUIRE_EXTENSION_ENV} must be set on the pytest invocation "
+        "itself, not on some other command in the recipe"
+    )
+
+
+def test_every_declared_target_exists() -> None:
+    """Each declared module must be on disk, so a rename cannot go stale."""
+    root = repo_root()
+    missing = [target for target in _declared_targets() if not (root / target).exists()]
+
+    assert not missing, (
+        "EXTENSION_TEST_TARGETS names modules that do not exist, so "
+        f"`make test-extension` cannot collect them: {missing}"
+    )
+
+
+def test_every_extension_gated_module_is_a_declared_target() -> None:
+    """A module gated on the extension must run in the guarded job.
+
+    Outside the list it skips wherever it runs and is never reached by the one
+    job that requires the extension, so it stops covering the boundary.
+    """
+    declared = set(_declared_targets())
+    missing = {
+        module: reason
+        for module, reason in _gated_modules().items()
+        if module not in declared
+    }
+
+    assert not missing, (
+        "these test modules gate on the compiled extension but are not in "
+        "the Makefile's EXTENSION_TEST_TARGETS, so nothing ever runs them "
+        f"with the extension present: {missing}"
+    )
+
+
+def test_every_skip_signal_still_identifies_a_module() -> None:
+    """Each signal must match something, or the derivation has gone dead.
+
+    The check above passes trivially when the scan finds nothing, so a renamed
+    fixture would otherwise empty it rather than fail it.
+    """
+    sources = _scanned_sources().values()
+    dead = [
+        reason
+        for reason, pattern in _SKIP_SIGNALS.items()
+        if not any(pattern.search(source) for source in sources)
+    ]
+
+    assert not dead, (
+        "these extension-gating signals no longer match any test module, so "
+        "they have stopped pinning anything; update them to the idiom now in "
+        f"use: {dead}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "reason"),
+    [
+        pytest.param(module, reason, id=module.rsplit("/", maxsplit=1)[-1])
+        for module, reason in _COMPANION_TARGETS.items()
+    ],
+)
+def test_the_always_run_companions_stay_declared(module: str, reason: str) -> None:
+    """Modules in the job for reasons no scan can derive must stay listed."""
+    assert module in set(_declared_targets()), (
+        f"{module} must stay in EXTENSION_TEST_TARGETS: {reason}"
+    )
+
+
+def test_the_ci_job_builds_the_extension_before_running_the_gated_tests() -> None:
+    """`extension-tests` must run `make develop` first.
+
+    `make build` only syncs dependencies, so this ordering is the whole reason
+    the job can pass at all, and nothing else asserts it.
+    """
+    build = _step_index_running("make develop", job_name="extension-tests")
+    tests = _step_index_running("make test-extension", job_name="extension-tests")
+
+    assert build < tests, (
+        "the extension-tests job must build the extension with `make "
+        "develop` before `make test-extension` runs; found the build at step "
+        f"{build} and the tests at step {tests}"
+    )
+
+
+def test_the_develop_target_installs_pip_before_building() -> None:
+    """`develop` must run `ensurepip` before `maturin develop`.
+
+    maturin resolves its own script through the interpreter's `sysconfig`
+    scheme, which needs pip present. Owning that ordering here is what lets
+    every caller inherit it.
+    """
+    lines = _dry_run("develop").splitlines()
+    ensurepip = next(
+        index for index, line in enumerate(lines) if "ensurepip --upgrade" in line
+    )
+    develop = next(
+        index for index, line in enumerate(lines) if "maturin develop" in line
+    )
+
+    assert ensurepip < develop, (
+        "`make develop` must run `ensurepip --upgrade` before `maturin "
+        "develop`, or maturin cannot resolve its own script"
+    )
+
+
+def test_the_develop_target_defaults_to_a_debug_build() -> None:
+    """Builds run on every change stay unoptimized unless asked otherwise."""
+    command = _sole_line_containing(
+        _dry_run("develop"), "maturin develop", subject="develop recipe"
+    )
+
+    assert "--release" not in command, (
+        "`make develop` must default to a debug build; MATURIN_DEVELOP_FLAGS "
+        "is how a caller asks for an optimized one"
+    )
+
+
+def test_the_develop_target_forwards_the_release_flag() -> None:
+    """`MATURIN_DEVELOP_FLAGS` must reach the `maturin develop` invocation.
+
+    The benchmark ratchet shares this target instead of restating the build,
+    and it can only do that if the flag it passes actually takes effect.
+    """
+    command = _sole_line_containing(
+        _dry_run("develop", "MATURIN_DEVELOP_FLAGS=--release"),
+        "maturin develop",
+        subject="develop recipe",
+    )
+
+    assert "--release" in command, (
+        "`make develop MATURIN_DEVELOP_FLAGS=--release` must pass --release "
+        "through to maturin, or the benchmark ratchet measures a debug build"
+    )
+
+
+def test_the_benchmark_job_builds_through_the_develop_target() -> None:
+    """`benchmark-ratchet` must reach an optimized build via `make develop`.
+
+    Its numbers mean nothing against a debug build, so the flag matters as
+    much as the shared target does.
+    """
+    index = _step_index_running("make develop", job_name="benchmark-ratchet")
+    script = _job_steps("benchmark-ratchet")[index]["run"]
+
+    assert "make develop MATURIN_DEVELOP_FLAGS=--release" in script, (
+        "the benchmark-ratchet job must build with `make develop "
+        "MATURIN_DEVELOP_FLAGS=--release`; without the flag the ratchet "
+        "compares debug builds and its thresholds mean nothing"
+    )
+
+
+def test_no_ci_step_invokes_maturin_develop_directly() -> None:
+    """`make develop` must be the only definition of the extension build.
+
+    A second copy of the three-step sequence is how the two drift: the copy
+    stops matching the target, and whichever job owns it quietly builds
+    something nobody maintains.
+    """
+    offenders = sorted({
+        job_name for job_name, script in _run_scripts() if "maturin develop" in script
+    })
+
+    assert not offenders, (
+        "these CI jobs invoke `maturin develop` directly instead of going "
+        f"through `make develop`: {offenders}"
+    )

--- a/cuprum/unittests/test_extension_build_contract.py
+++ b/cuprum/unittests/test_extension_build_contract.py
@@ -1,17 +1,19 @@
-"""Contract tests for the extension build wiring in the Makefile and CI.
+"""Contract tests for the extension build wiring in the Makefile.
 
-`make test-extension` and the `extension-tests` job are the only things that
-turn a silently-skipped extension into a failure, and both are configuration
-rather than code. Nothing else in the suite notices when the guard variable
-leaves the recipe, a module falls out of ``EXTENSION_TEST_TARGETS``, or the CI
-job stops building the extension before running the gated tests: every one of
-those changes leaves a green run behind. These tests read the wiring back and
-assert the contract it must uphold.
+`make test-extension` is the only thing that turns a silently-skipped
+extension into a failure, and it is configuration rather than code. Nothing
+else in the suite notices when the guard variable leaves the recipe or a
+module falls out of ``EXTENSION_TEST_TARGETS``: either change leaves a green
+run behind. These tests read the wiring back and assert the contract it must
+uphold. The CI half of the same contract — that a job builds the extension
+before running against it — lives in `test_extension_ci_contract.py`.
 
-The Makefile side is read through ``make --dry-run`` rather than by parsing
-the file: that is the command line the target actually runs, with every
-variable expanded, so an assertion about the guard variable is an assertion
-about what CI executes rather than about text sitting near it.
+The Makefile is read through ``make --dry-run`` rather than by parsing the
+file: that is the command line the target actually runs, with every variable
+expanded, so an assertion about the guard variable is an assertion about what
+CI executes rather than about text sitting near it. That nested ``make`` runs
+against a scrubbed environment, because otherwise it would report the caller's
+configuration as though it were the repository's — see ``_caller_owned_names``.
 
 ``EXTENSION_TEST_TARGETS`` is pinned by two independent properties, neither
 implying the other — ``_SKIP_SIGNALS`` derives the gated modules from the
@@ -32,15 +34,9 @@ import subprocess  # noqa: S404 - reads the repository's own Makefile recipes.
 import typing as typ
 
 import pytest
-import yaml
 
 from tests.helpers.docs import repo_root
 from tests.helpers.extension_requirement import REQUIRE_EXTENSION_ENV
-
-if typ.TYPE_CHECKING:
-    import collections.abc as cabc
-
-CI_WORKFLOW = ".github/workflows/ci.yml"
 
 #: Where test modules live. Any of them could gate on the extension, so all
 #: are scanned, not only the directories holding gated modules today.
@@ -74,25 +70,57 @@ _COMPANION_TARGETS: typ.Final[dict[str, str]] = {
 }
 
 
+#: Matches a Makefile variable declared with ``?=``, which assigns only when
+#: the name is not already defined — and a name present in the environment
+#: counts as defined. ``make`` exports each of its own command-line overrides
+#: under that name, so a suite run as ``make test EXTENSION_TEST_TARGETS=…``
+#: would otherwise have the nested ``make`` below report the caller's list as
+#: though the Makefile declared it. Stripping ``MAKEFLAGS`` does not prevent
+#: that: the override travels under its own name as well.
+_CONDITIONAL_ASSIGNMENT: typ.Final = re.compile(
+    r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\?=", re.MULTILINE
+)
+
+#: ``make``'s own bookkeeping, which leaks in when pytest is itself launched
+#: from ``make test``; an inherited jobserver flag makes the nested ``make``
+#: warn about it.
+_MAKE_BOOKKEEPING: typ.Final = frozenset({"MAKEFLAGS", "MAKELEVEL", "MFLAGS"})
+
+
 @functools.cache
-def _dry_run(*goals: str) -> str:
+def _caller_owned_names() -> frozenset[str]:
+    """Return environment names that would redefine a Makefile variable.
+
+    Derived from the Makefile rather than listed here, so a variable gaining
+    or losing its ``?=`` cannot leave the scrub quietly out of date.
+    """
+    makefile = (repo_root() / "Makefile").read_text(encoding="utf-8")
+    overridable = frozenset(_CONDITIONAL_ASSIGNMENT.findall(makefile))
+    assert overridable, (
+        "no `?=` assignments were found in the Makefile, so this scrub has "
+        "stopped protecting anything; check the pattern still matches"
+    )
+    return overridable | _MAKE_BOOKKEEPING
+
+
+def _make_dry_run(*goals: str) -> str:
     """Return what ``make --dry-run`` prints for `goals`, recipes expanded."""
-    # MAKEFLAGS leaks in when pytest is itself launched from `make test`, and
-    # an inherited jobserver flag makes this nested make warn about it.
-    environment = {
-        key: value
-        for key, value in os.environ.items()
-        if key not in {"MAKEFLAGS", "MAKELEVEL", "MFLAGS"}
-    }
+    ignored = _caller_owned_names()
     completed = subprocess.run(  # noqa: S603 - fixed argument vector.
         ["make", "--dry-run", *goals],  # noqa: S607 - `make` resolved from PATH.
         capture_output=True,
         check=True,
         cwd=repo_root(),
-        env=environment,
+        env={key: value for key, value in os.environ.items() if key not in ignored},
         text=True,
     )
     return completed.stdout
+
+
+@functools.cache
+def _dry_run(*goals: str) -> str:
+    """Cache `_make_dry_run`: nothing it reads changes during a session."""
+    return _make_dry_run(*goals)
 
 
 def _sole_line_containing(text: str, needle: str, *, subject: str) -> str:
@@ -160,45 +188,6 @@ def _gated_modules() -> dict[str, str]:
         if reason is not None:
             gated[module] = reason
     return gated
-
-
-@functools.cache
-def _workflow() -> dict[str, typ.Any]:
-    """Parse the CI workflow."""
-    parsed = yaml.safe_load((repo_root() / CI_WORKFLOW).read_text(encoding="utf-8"))
-    assert isinstance(parsed, dict), f"{CI_WORKFLOW} must parse to a mapping"
-    return parsed
-
-
-def _job_steps(job_name: str) -> list[dict[str, typ.Any]]:
-    """Return the steps of a named CI job."""
-    jobs = _workflow().get("jobs")
-    assert isinstance(jobs, dict), f"{CI_WORKFLOW} must declare a jobs mapping"
-    job = jobs.get(job_name)
-    assert isinstance(job, dict), (
-        f"{CI_WORKFLOW} must declare a {job_name!r} job; found {sorted(jobs)}"
-    )
-    steps = job.get("steps")
-    assert isinstance(steps, list), f"the {job_name!r} job must declare steps"
-    return steps
-
-
-def _run_scripts() -> cabc.Iterator[tuple[str, str]]:
-    """Yield the job name and script of every ``run:`` step in the workflow."""
-    for job_name, job in (_workflow().get("jobs") or {}).items():
-        for step in (job or {}).get("steps") or []:
-            script = step.get("run")
-            if isinstance(script, str):
-                yield job_name, script
-
-
-def _step_index_running(command: str, *, job_name: str) -> int:
-    """Return the index of the first step in `job_name` running `command`."""
-    for index, step in enumerate(_job_steps(job_name)):
-        script = step.get("run")
-        if isinstance(script, str) and command in script:
-            return index
-    pytest.fail(f"no step in the {job_name!r} job runs {command!r}")
 
 
 def test_the_test_extension_recipe_sets_the_guard_variable() -> None:
@@ -284,19 +273,25 @@ def test_the_always_run_companions_stay_declared(module: str, reason: str) -> No
     )
 
 
-def test_the_ci_job_builds_the_extension_before_running_the_gated_tests() -> None:
-    """`extension-tests` must run `make develop` first.
+def test_a_caller_variable_cannot_reach_the_nested_make(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An inherited override must not become what these tests read back.
 
-    `make build` only syncs dependencies, so this ordering is the whole reason
-    the job can pass at all, and nothing else asserts it.
+    Otherwise the contract holds or breaks according to how the suite was
+    invoked: `make test EXTENSION_TEST_TARGETS=…` exports that name into
+    pytest's environment, the Makefile's `?=` yields to it, and every
+    assertion below reports on the caller instead of the repository.
     """
-    build = _step_index_running("make develop", job_name="extension-tests")
-    tests = _step_index_running("make test-extension", job_name="extension-tests")
+    intruder = "caller_owned_module.py"
+    monkeypatch.setenv("EXTENSION_TEST_TARGETS", intruder)
 
-    assert build < tests, (
-        "the extension-tests job must build the extension with `make "
-        "develop` before `make test-extension` runs; found the build at step "
-        f"{build} and the tests at step {tests}"
+    recipe = _make_dry_run("test-extension")
+
+    assert intruder not in recipe, (
+        "an inherited EXTENSION_TEST_TARGETS reached the nested make, so "
+        "these tests would assert about whoever ran them rather than about "
+        "the Makefile"
     )
 
 
@@ -348,37 +343,4 @@ def test_the_develop_target_forwards_the_release_flag() -> None:
     assert "--release" in command, (
         "`make develop MATURIN_DEVELOP_FLAGS=--release` must pass --release "
         "through to maturin, or the benchmark ratchet measures a debug build"
-    )
-
-
-def test_the_benchmark_job_builds_through_the_develop_target() -> None:
-    """`benchmark-ratchet` must reach an optimized build via `make develop`.
-
-    Its numbers mean nothing against a debug build, so the flag matters as
-    much as the shared target does.
-    """
-    index = _step_index_running("make develop", job_name="benchmark-ratchet")
-    script = _job_steps("benchmark-ratchet")[index]["run"]
-
-    assert "make develop MATURIN_DEVELOP_FLAGS=--release" in script, (
-        "the benchmark-ratchet job must build with `make develop "
-        "MATURIN_DEVELOP_FLAGS=--release`; without the flag the ratchet "
-        "compares debug builds and its thresholds mean nothing"
-    )
-
-
-def test_no_ci_step_invokes_maturin_develop_directly() -> None:
-    """`make develop` must be the only definition of the extension build.
-
-    A second copy of the three-step sequence is how the two drift: the copy
-    stops matching the target, and whichever job owns it quietly builds
-    something nobody maintains.
-    """
-    offenders = sorted({
-        job_name for job_name, script in _run_scripts() if "maturin develop" in script
-    })
-
-    assert not offenders, (
-        "these CI jobs invoke `maturin develop` directly instead of going "
-        f"through `make develop`: {offenders}"
     )

--- a/cuprum/unittests/test_extension_ci_contract.py
+++ b/cuprum/unittests/test_extension_ci_contract.py
@@ -1,0 +1,153 @@
+"""Contract tests for how CI builds the extension before testing against it.
+
+`make develop` is the one definition of the extension build, and nothing else
+in the suite notices when a CI job stops going through it: remove the build
+step from `extension-tests` and the gated modules quietly skip, drop
+`--release` from `benchmark-ratchet` and the ratchet compares debug builds
+against optimized baselines. Both are declarative configuration, so
+these tests parse `ci.yml` and assert the contract it must uphold.
+
+The Makefile half of the same contract — the guard variable the recipe sets
+and the module list it hands to pytest — lives in
+`test_extension_build_contract.py`.
+
+`yaml.safe_load` returns `typing.Any`, which erases every mistake an assertion
+can make about the shape it reads: a misspelled key yields `None`, and the
+assertion above it then passes or fails for a reason unrelated to the
+contract. The shapes below declare the keys these tests reach for, so a typo
+is a type error. Their *values* stay `object`, because they come from a file
+this suite does not control and so are narrowed where they are read rather
+than assumed at the boundary.
+"""
+
+from __future__ import annotations
+
+import functools
+import typing as typ
+
+import pytest
+import yaml
+
+from tests.helpers.docs import repo_root
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+CI_WORKFLOW = ".github/workflows/ci.yml"
+
+
+class Step(typ.TypedDict, total=False):
+    """One step of a job, declaring only the keys these tests read."""
+
+    run: object
+
+
+class Job(typ.TypedDict, total=False):
+    """One job of a workflow, declaring only the keys these tests read."""
+
+    steps: list[Step]
+
+
+class Workflow(typ.TypedDict, total=False):
+    """A parsed workflow file, declaring only the keys these tests read."""
+
+    jobs: dict[str, Job]
+
+
+@functools.cache
+def _workflow() -> Workflow:
+    """Parse the CI workflow."""
+    parsed = yaml.safe_load((repo_root() / CI_WORKFLOW).read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict), f"{CI_WORKFLOW} must parse to a mapping"
+    return typ.cast("Workflow", parsed)
+
+
+def _jobs() -> dict[str, Job]:
+    """Return the workflow's jobs, keyed by name."""
+    jobs = _workflow().get("jobs")
+    assert isinstance(jobs, dict), f"{CI_WORKFLOW} must declare a jobs mapping"
+    return jobs
+
+
+def _job_steps(job_name: str) -> list[Step]:
+    """Return the steps of a named CI job."""
+    jobs = _jobs()
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), (
+        f"{CI_WORKFLOW} must declare a {job_name!r} job; found {sorted(jobs)}"
+    )
+    steps = job.get("steps")
+    assert isinstance(steps, list), f"the {job_name!r} job must declare steps"
+    return steps
+
+
+def _script_of(step: Step) -> str | None:
+    """Return a step's ``run:`` script, or None when it runs no script."""
+    script = step.get("run")
+    return script if isinstance(script, str) else None
+
+
+def _run_scripts() -> cabc.Iterator[tuple[str, str]]:
+    """Yield the job name and script of every ``run:`` step in the workflow."""
+    for job_name, job in _jobs().items():
+        # A job that calls a reusable workflow declares `uses:` and no steps.
+        for step in job.get("steps") or []:
+            if (script := _script_of(step)) is not None:
+                yield job_name, script
+
+
+def _first_step_running(command: str, *, job_name: str) -> tuple[int, str]:
+    """Return the position and script of the first step running `command`."""
+    for index, step in enumerate(_job_steps(job_name)):
+        script = _script_of(step)
+        if script is not None and command in script:
+            return index, script
+    pytest.fail(f"no step in the {job_name!r} job runs {command!r}")
+
+
+def test_the_ci_job_builds_the_extension_before_running_the_gated_tests() -> None:
+    """`extension-tests` must run `make develop` first.
+
+    `make build` only syncs dependencies, so this ordering is the whole reason
+    the job can pass at all, and nothing else asserts it.
+    """
+    build, _ = _first_step_running("make develop", job_name="extension-tests")
+    tests, _ = _first_step_running("make test-extension", job_name="extension-tests")
+
+    assert build < tests, (
+        "the extension-tests job must build the extension with `make "
+        "develop` before `make test-extension` runs; found the build at step "
+        f"{build} and the tests at step {tests}"
+    )
+
+
+def test_the_benchmark_job_builds_through_the_develop_target() -> None:
+    """`benchmark-ratchet` must reach an optimized build via `make develop`.
+
+    Its numbers mean nothing against a debug build, so the flag matters
+    as much as the shared target does.
+    """
+    _, script = _first_step_running("make develop", job_name="benchmark-ratchet")
+
+    assert "make develop MATURIN_DEVELOP_FLAGS=--release" in script, (
+        "the benchmark-ratchet job must build with `make develop "
+        "MATURIN_DEVELOP_FLAGS=--release`; without the flag the ratchet "
+        "compares debug builds and its thresholds mean nothing"
+    )
+
+
+def test_no_ci_step_invokes_maturin_develop_directly() -> None:
+    """`make develop` must be the only definition of the extension build.
+
+    A second copy of the three-step sequence is how the two drift: the copy
+    stops matching the target, and whichever job owns it quietly builds
+    something nobody maintains.
+    """
+    offenders = sorted({
+        job_name for job_name, script in _run_scripts() if "maturin develop" in script
+    })
+
+    assert not offenders, (
+        "these CI jobs invoke `maturin develop` directly instead of going "
+        f"through `make develop`: {offenders}"
+    )

--- a/cuprum/unittests/test_extension_requirement_guard.py
+++ b/cuprum/unittests/test_extension_requirement_guard.py
@@ -75,7 +75,9 @@ def test_the_message_does_not_claim_the_import_failed() -> None:
     """
     message = missing_extension_message(required=True, available=False)
 
-    assert message is not None
+    assert message is not None, (
+        "a required, unavailable extension must produce a message to inspect"
+    )
     assert "could not be imported" not in message, (
         f"the message must not attribute the failure to an import: {message!r}"
     )
@@ -130,7 +132,7 @@ def test_the_hook_aborts_the_session_when_the_extension_is_required(
         root_conftest.pytest_configure(typ.cast("pytest.Config", None))
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class _SilentCase:
     """A variable/availability pair the guard must not act on.
 

--- a/cuprum/unittests/test_extension_requirement_guard.py
+++ b/cuprum/unittests/test_extension_requirement_guard.py
@@ -1,0 +1,174 @@
+"""The CI guard that turns a silently-skipped extension into a failure.
+
+`CUPRUM_REQUIRE_RUST_EXTENSION` exists because the extension-gated modules skip
+when the native extension is absent, so a CI job that never built it reports a
+green run indistinguishable from one that exercised the whole Python/Rust
+boundary. A guard whose own failure path went untested would reintroduce
+exactly that problem, so these tests cover the decision directly and then prove
+the `pytest_configure` hook acts on it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import typing as typ
+
+import pytest
+
+from cuprum import _rust_backend
+from tests.helpers.extension_requirement import (
+    REQUIRE_EXTENSION_ENV,
+    missing_extension_message,
+)
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+    from types import ModuleType
+
+
+@pytest.mark.parametrize(
+    ("required", "available"),
+    [
+        pytest.param(False, False, id="not-required-and-absent"),
+        pytest.param(False, True, id="not-required-and-present"),
+        pytest.param(True, True, id="required-and-present"),
+    ],
+)
+def test_the_run_proceeds_unless_a_required_extension_is_absent(
+    *,
+    required: bool,
+    available: bool,
+) -> None:
+    """Only the required-but-absent combination is a failure.
+
+    The guard must stay silent locally, where contributors routinely run the
+    suite without building the extension.
+    """
+    assert missing_extension_message(required=required, available=available) is None, (
+        f"required={required}, available={available} must not fail the run"
+    )
+
+
+def test_a_required_but_absent_extension_reports_how_to_fix_it() -> None:
+    """The one failing combination names the variable and the remedy.
+
+    A bare "extension missing" would leave a CI reader guessing whether the
+    build step or the variable was at fault.
+    """
+    message = missing_extension_message(required=True, available=False)
+
+    assert message is not None, "a required, unavailable extension must fail the run"
+    assert REQUIRE_EXTENSION_ENV in message, (
+        f"the message must name the variable that caused the failure: {message!r}"
+    )
+    assert "make develop" in message, (
+        f"the message must name the command that builds the extension: {message!r}"
+    )
+
+
+def test_the_message_does_not_claim_the_import_failed() -> None:
+    """`is_available` covers more than an `ImportError`.
+
+    The extension can import and still report itself unusable, so wording that
+    asserts an import failure would misdescribe that case.
+    """
+    message = missing_extension_message(required=True, available=False)
+
+    assert message is not None
+    assert "could not be imported" not in message, (
+        f"the message must not attribute the failure to an import: {message!r}"
+    )
+    assert "unavailable" in message, (
+        f"the message must describe the extension as unavailable: {message!r}"
+    )
+
+
+@pytest.fixture(name="root_conftest")
+def fixture_root_conftest(pytestconfig: pytest.Config) -> ModuleType:
+    """Return the repository-root ``conftest`` module that applies the guard.
+
+    A plain ``import conftest`` reaches ``cuprum/unittests/conftest.py``, which
+    shadows the root one, so the module is located through the plugin manager
+    that already loaded it.
+    """
+    root = pathlib.Path(str(pytestconfig.rootpath)) / "conftest.py"
+    for plugin in pytestconfig.pluginmanager.get_plugins():
+        module_file = getattr(plugin, "__file__", None)
+        if module_file and pathlib.Path(module_file) == root:
+            return typ.cast("ModuleType", plugin)
+    pytest.fail(f"the root conftest at {root} is not a registered plugin")
+
+
+@pytest.fixture(name="declare_extension")
+def fixture_declare_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> cabc.Callable[..., None]:
+    """Return a helper that fixes what the backend reports about itself."""
+
+    def declare(*, available: bool) -> None:
+        """Make the backend report `available` for the rest of the test."""
+        monkeypatch.setattr(_rust_backend, "is_available", lambda: available)
+
+    return declare
+
+
+def test_the_hook_aborts_the_session_when_the_extension_is_required(
+    monkeypatch: pytest.MonkeyPatch,
+    declare_extension: cabc.Callable[..., None],
+    root_conftest: ModuleType,
+) -> None:
+    """`pytest_configure` raises, rather than merely computing a message.
+
+    `UsageError` is the failure that stops the session before collection, so
+    the guard cannot be reduced to a warning nobody reads.
+    """
+    monkeypatch.setenv(REQUIRE_EXTENSION_ENV, "1")
+    declare_extension(available=False)
+
+    with pytest.raises(pytest.UsageError, match=REQUIRE_EXTENSION_ENV):
+        root_conftest.pytest_configure(typ.cast("pytest.Config", None))
+
+
+@dataclasses.dataclass(frozen=True)
+class _SilentCase:
+    """A variable/availability pair the guard must not act on.
+
+    Attributes
+    ----------
+    env_value : str or None
+        The value of ``CUPRUM_REQUIRE_RUST_EXTENSION``; ``None`` leaves it
+        unset.
+    available : bool
+        What the backend reports about the native extension.
+    """
+
+    env_value: str | None
+    available: bool
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(_SilentCase(None, available=False), id="unset-and-absent"),
+        pytest.param(_SilentCase("", available=False), id="empty-and-absent"),
+        pytest.param(_SilentCase("1", available=True), id="set-and-present"),
+    ],
+)
+def test_the_hook_stays_silent_otherwise(
+    monkeypatch: pytest.MonkeyPatch,
+    declare_extension: cabc.Callable[..., None],
+    root_conftest: ModuleType,
+    case: _SilentCase,
+) -> None:
+    """An unset or empty variable leaves the run alone.
+
+    The empty case matters: a workflow that sets the variable to `''` must not
+    fail a job that never intended to require the extension.
+    """
+    monkeypatch.delenv(REQUIRE_EXTENSION_ENV, raising=False)
+    if case.env_value is not None:
+        monkeypatch.setenv(REQUIRE_EXTENSION_ENV, case.env_value)
+    declare_extension(available=case.available)
+
+    root_conftest.pytest_configure(typ.cast("pytest.Config", None))

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1650,6 +1650,14 @@ present in the environment. CI's `extension-tests` job runs the same target, so
 a local run and a CI run build the extension identically. The Makefile keeps
 only a pointer to this section rather than repeating the reasoning.
 
+Every extension build in CI goes through this target. The `benchmark-ratchet`
+job needs an optimized build, and that is the only thing it needs differently,
+so it passes `make develop MATURIN_DEVELOP_FLAGS=--release` rather than
+restating the three-step sequence. Keep it that way: a second copy of the
+sequence is how the two drift, and the ratchet then measures a build nobody
+maintains. `MATURIN_DEVELOP_FLAGS` is empty by default, because a debug build
+is what contributors and the `extension-tests` job want.
+
 Without it these modules skip rather than fail, which is the right default
 locally — most changes do not need the native path rebuilt — and the wrong one
 in CI, where a job that never built the extension reports a green run

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1676,6 +1676,36 @@ constraint below — so `make test-extension` runs only the gated modules. Their
 list lives in one place, the Makefile's `EXTENSION_TEST_TARGETS`, which the CI
 job consumes too, so the two cannot drift apart.
 
+None of that wiring is exercised by ordinary tests — drop the guard variable
+and the suite still passes — so `test_extension_build_contract.py` reads it
+back and asserts the contract: that the recipe sets the guard variable, that
+the `extension-tests` job runs `make develop` before `make test-extension`,
+and that `benchmark-ratchet` builds through the same target. It reads the
+Makefile with `make --dry-run` rather than by parsing the file, because the
+expanded recipe is the command line CI actually runs.
+
+`EXTENSION_TEST_TARGETS` gets two separate checks, because neither implies the
+other:
+
+- A scan derives the extension-gated modules from the suite itself — those
+  requesting the root `rust_streams` fixture, skipping with the shared "Rust
+  extension is not installed" reason, or naming `cuprum._rust_backend_native`
+  — and requires each one to be a declared target. This is the check that
+  notices a *new* gated module being forgotten, which a hard-coded copy of
+  today's list never would. The scan is textual and deliberately narrow, so it
+  is a lower bound: a module gating through some other idiom goes unnoticed. A
+  companion check fails when a signal stops matching anything, so a renamed
+  fixture cannot quietly empty the scan instead of failing it.
+- Modules that do not gate at all, but belong in the job anyway, are named
+  explicitly alongside the reason. `test_extension_requirement_guard.py` is
+  one: running it inside the guarded job is what proves the guard stays silent
+  when the extension is present, rather than only that it fires when the
+  extension is absent.
+
+So add a newly gated module to `EXTENSION_TEST_TARGETS`. If it is boundary
+coverage that never skips, add it to the companion list with its reason
+instead.
+
 Running `make test-extension` without having built the extension is safe: the
 guard fails the run with a message naming `make develop`, which is the whole
 point of it.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1618,12 +1618,24 @@ target, so a local run and a CI run build the extension identically.
 Without it these modules skip rather than fail, which is the right default
 locally — most changes do not need the native path rebuilt — and the wrong one
 in CI, where a job that never built the extension reports a green run
-indistinguishable from one that exercised the whole boundary. Set
-`CUPRUM_REQUIRE_RUST_EXTENSION=1` to make that silence fatal:
+indistinguishable from one that exercised the whole boundary. `make
+test-extension` sets `CUPRUM_REQUIRE_RUST_EXTENSION=1` to make that silence
+fatal:
 
 ```bash
-CUPRUM_REQUIRE_RUST_EXTENSION=1 make test
+make develop
+make test-extension
 ```
+
+Run that rather than `CUPRUM_REQUIRE_RUST_EXTENSION=1 make test`. Once the
+extension is installed the full suite aborts the interpreter — see the `#124`
+constraint below — so `make test-extension` runs only the gated modules. Their
+list lives in one place, the Makefile's `EXTENSION_TEST_TARGETS`, which the CI
+job consumes too, so the two cannot drift apart.
+
+Running `make test-extension` without having built the extension is safe: the
+guard fails the run with a message naming `make develop`, which is the whole
+point of it.
 
 The check runs once per session in `conftest.py`, so it covers every gated
 module regardless of how each one gates — fixture, module-level guard, or

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1627,8 +1627,10 @@ make develop
 
 That runs `maturin develop` against `rust/cuprum-rust/Cargo.toml` in the
 project virtual environment, preceded by `ensurepip` because maturin resolves
-its own script through the interpreter's `sysconfig` scheme. CI runs the same
-target, so a local run and a CI run build the extension identically.
+its own script through the interpreter's `sysconfig` scheme, which needs pip
+present in the environment. CI's `extension-tests` job runs the same target, so
+a local run and a CI run build the extension identically. The Makefile keeps
+only a pointer to this section rather than repeating the reasoning.
 
 Without it these modules skip rather than fail, which is the right default
 locally — most changes do not need the native path rebuilt — and the wrong one

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1300,18 +1300,36 @@ green run as coverage of both arms:
   the Python suite on Windows, so nothing executes the `winerror` assertions;
   that gap is tracked by `#277`.
 
-Compiling that arm locally needs no Windows machine, which is worth knowing
-before changing it:
+That wheel build is a plain `maturin build`, so it compiles the Windows arm
+without `-D warnings`. It therefore catches a Windows arm that fails to
+compile, and only that. Warn-level regressions pass it — and the cheapest way
+to introduce one is to gate a helper on `#[cfg(unix)]` incorrectly, which makes
+it dead code on Windows rather than a compile error. `make lint-windows` closes
+that gap by running Clippy for the Windows target with the same `-D warnings`
+posture the host gate uses:
 
 ```bash
 rustup target add x86_64-pc-windows-msvc
-PYO3_CROSS=1 PYO3_CROSS_PYTHON_VERSION=3.13 \
-  cargo check --manifest-path rust/Cargo.toml \
-  -p cuprum-rust --target x86_64-pc-windows-msvc
+make lint-windows
 ```
 
-`PYO3_CROSS_PYTHON_VERSION` is required: PyO3 cannot probe an interpreter for
-the target platform, so the ABI version has to be stated explicitly.
+No Windows machine is needed: Clippy type-checks without linking, so the target
+standard library is sufficient. `PYO3_CROSS_PYTHON_VERSION` is required and the
+Makefile sets it, because PyO3 cannot probe an interpreter for the target
+platform and so the ABI version has to be stated explicitly; keep the
+`WINDOWS_PYTHON_VERSION` variable in step with the `python-version` the Windows
+wheel job builds against.
+
+`make lint-windows` is deliberately not part of `make lint`. It hard-fails when
+the target standard library is absent rather than skipping, and requiring every
+contributor to install a second standard library before any lint run is a poor
+trade for a check this narrow. CI's `lint-test` job installs the target and
+runs it on every pull request, which is where it has to hold.
+
+This is the only check in the repository that reads the `#[cfg(windows)]`
+branches with warnings denied. A trybuild case cannot substitute for it:
+trybuild compiles its fixtures for the host target, so on a Linux runner it
+sees the `#[cfg(unix)]` arm and never the Windows one.
 
 ## Rust FD-borrow ownership contract
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1600,7 +1600,6 @@ case that produces it and leaves no snapshot files to review or prune. Accept a
 deliberate change by editing the inline literal; `cargo insta` is not required
 for the inline form.
 
-
 ### Building the extension for tests
 
 Several test modules exercise the compiled PyO3 extension and are gated on it
@@ -1629,6 +1628,11 @@ CUPRUM_REQUIRE_RUST_EXTENSION=1 make test
 The check runs once per session in `conftest.py`, so it covers every gated
 module regardless of how each one gates — fixture, module-level guard, or
 availability probe — and a new module cannot opt out by skipping differently.
+The decision itself lives in `tests/helpers/extension_requirement.py` rather
+than in the root `conftest.py`, because a root conftest is shadowed by the
+per-package one and so cannot be imported by name from a test module;
+`test_extension_requirement_guard.py` covers it, and reaches the hook through
+the plugin manager to check that it actually raises.
 
 CI runs these in a dedicated `extension-tests` job rather than folding the
 extension into `typecheck-test`. That is a deliberate constraint, not tidiness:
@@ -1648,6 +1652,16 @@ Table 1: modules gated on the compiled extension
 | `test_rust_splice.py` | the Linux `splice` fast path |
 | `test_rust_errno.py` | `OSError.errno` and subclass selection across the boundary |
 | `test_backend.py` | the extension-dependent backend-selection cases |
+| `test_extension_requirement_guard.py` | the fail-loud guard itself |
+| `tests/behaviour/test_rust_streams_behaviour.py` | the consumer-facing pump and consume scenarios |
+| `tests/behaviour/test_rust_extension_behaviour.py` | availability agreeing with the installed native module |
+| `tests/behaviour/test_stream_backend_pipeline.py` | pipelines dispatched through the Rust backend |
+
+The behavioural modules are listed for the same reason as the unit ones: their
+extension-dependent scenarios skip in the ordinary test jobs, so they were
+never boundary coverage there either. Confirm with `pytest -rs` against a
+virtual environment that has no extension — four scenarios report `Rust
+extension is not installed`.
 
 Kani harnesses are reserved for bounded verification of small, high-value state
 spaces. Gate Kani-only modules and helpers with `#[cfg(kani)]`, and share pure

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1581,26 +1581,73 @@ boundary, invalid UTF-8, and an incomplete trailing sequence — and each one
 calls `rust_consume_stream` and compares the result against Python's own
 replacement decoding, `payload.decode("utf-8", errors="replace")`.
 
-Normal CI does not execute them. The test jobs reach the suite through
-`make build`, which is only `uv sync --group dev`; nothing builds
-`cuprum._rust_backend_native`, so those cases are skipped rather than run.
-Issue `#258` tracks building the extension in the test jobs and adding a
-fail-loud guard so the skip cannot pass unnoticed. Issue `#265` — `OSError`
-crossing the boundary lost its `errno`, failing one extension-enabled test —
-is resolved; see [Preserving the operating-system error
+Those cases do now execute in CI — see [Building the extension for
+tests](#building-the-extension-for-tests) — but they did not until `#258` was
+resolved, because `make build` only runs `uv sync --group dev` and never
+compiled `cuprum._rust_backend_native`. Running them also surfaced `#265`,
+where an `OSError` crossing the boundary lost its `errno`; that is fixed too,
+under [Preserving the operating-system error
 code](#preserving-the-operating-system-error-code).
 
-So the `consume_stream_files` snapshots and properties are the coverage of the
-read-and-decode loop that actually executes on every commit. They do not
-replace executed Python/Rust boundary coverage, and are not a reason to leave
-`#258` unresolved: the two verify different things, one the loop and the other
-the exported surface.
+The two layers verify different things and neither replaces the other: the
+snapshots and properties cover the `consume_stream_files` read-and-decode loop,
+while `TestRustConsumeStream` covers the exported surface a caller actually
+touches. Keep both when changing either.
 
 Those snapshots are written inline with `insta::assert_snapshot!(value, @"...")`
 rather than as separate `.snap` files, which keeps the expected text beside the
 case that produces it and leaves no snapshot files to review or prune. Accept a
 deliberate change by editing the inline literal; `cargo insta` is not required
 for the inline form.
+
+
+### Building the extension for tests
+
+Several test modules exercise the compiled PyO3 extension and are gated on it
+being importable. `make build` does not build it — that target only syncs
+dependencies — so build it explicitly:
+
+```bash
+make develop
+```
+
+That runs `maturin develop` against `rust/cuprum-rust/Cargo.toml` in the
+project virtual environment, preceded by `ensurepip` because maturin resolves
+its own script through the interpreter's `sysconfig` scheme. CI runs the same
+target, so a local run and a CI run build the extension identically.
+
+Without it these modules skip rather than fail, which is the right default
+locally — most changes do not need the native path rebuilt — and the wrong one
+in CI, where a job that never built the extension reports a green run
+indistinguishable from one that exercised the whole boundary. Set
+`CUPRUM_REQUIRE_RUST_EXTENSION=1` to make that silence fatal:
+
+```bash
+CUPRUM_REQUIRE_RUST_EXTENSION=1 make test
+```
+
+The check runs once per session in `conftest.py`, so it covers every gated
+module regardless of how each one gates — fixture, module-level guard, or
+availability probe — and a new module cannot opt out by skipping differently.
+
+CI runs these in a dedicated `extension-tests` job rather than folding the
+extension into `typecheck-test`. That is a deliberate constraint, not tidiness:
+with the extension present, `test_pipeline.py` trips the file-descriptor close
+race tracked by issue `#124` (roadmap 8.1.1) and aborts the interpreter part
+way through the suite, reproducibly. Until that is fixed, the extension must
+not be installed for the general test run. Widening the job is the natural
+follow-up once `#124` lands.
+
+Table 1: modules gated on the compiled extension
+
+| Module | Covers |
+| --- | --- |
+| `test_rust_streams.py` | pump and consume entry points, including the four `TestRustConsumeStream` replacement scenarios that are the end-to-end regression coverage for `#105` |
+| `test_rust_streams_boundary_property.py` | randomized payloads across the boundary |
+| `test_rust_extension.py` | extension availability and module surface |
+| `test_rust_splice.py` | the Linux `splice` fast path |
+| `test_rust_errno.py` | `OSError.errno` and subclass selection across the boundary |
+| `test_backend.py` | the extension-dependent backend-selection cases |
 
 Kani harnesses are reserved for bounded verification of small, high-value state
 spaces. Gate Kani-only modules and helpers with `#[cfg(kani)]`, and share pure

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1288,15 +1288,30 @@ What actually executes is narrower than what is written, so do not read a
 green run as coverage of both arms:
 
 - **POSIX** — the cases run natively on Linux whenever the extension is built,
-  so a local `make test` preceded by `maturin develop` executes them. Without
-  that build the `rust_streams` fixture skips them rather than failing, which
-  is what CI does today. Making CI build the extension and fail loudly without
-  it is `#258`, in flight as pull request `#269`.
+  so a local `make develop` followed by `make test-extension` executes them.
+  `cuprum/unittests/test_rust_errno.py` is one of the `EXTENSION_TEST_TARGETS`,
+  so CI's `extension-tests` job runs them with
+  `CUPRUM_REQUIRE_RUST_EXTENSION=1`: a build that never produced the extension
+  fails rather than skipping quietly (`#258`).
 - **Windows** — the `#[cfg(windows)]` arm is compiled natively on
   `windows-2022` by the wheel build (`.github/workflows/build-wheels.yml`,
-  reached from `ci.yml`), which catches a Windows arm that does not build or
-  type-check. No job runs the Python suite on Windows, so nothing executes the
-  `winerror` assertions; that gap is tracked by `#277`.
+  reached unconditionally from `ci.yml`, so it runs on every pull request),
+  which catches a Windows arm that does not build or type-check. No job runs
+  the Python suite on Windows, so nothing executes the `winerror` assertions;
+  that gap is tracked by `#277`.
+
+Compiling that arm locally needs no Windows machine, which is worth knowing
+before changing it:
+
+```bash
+rustup target add x86_64-pc-windows-msvc
+PYO3_CROSS=1 PYO3_CROSS_PYTHON_VERSION=3.13 \
+  cargo check --manifest-path rust/Cargo.toml \
+  -p cuprum-rust --target x86_64-pc-windows-msvc
+```
+
+`PYO3_CROSS_PYTHON_VERSION` is required: PyO3 cannot probe an interpreter for
+the target platform, so the ABI version has to be stated explicitly.
 
 ## Rust FD-borrow ownership contract
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1650,13 +1650,19 @@ present in the environment. CI's `extension-tests` job runs the same target, so
 a local run and a CI run build the extension identically. The Makefile keeps
 only a pointer to this section rather than repeating the reasoning.
 
-Every extension build in CI goes through this target. The `benchmark-ratchet`
-job needs an optimized build, and that is the only thing it needs differently,
-so it passes `make develop MATURIN_DEVELOP_FLAGS=--release` rather than
-restating the three-step sequence. Keep it that way: a second copy of the
-sequence is how the two drift, and the ratchet then measures a build nobody
-maintains. `MATURIN_DEVELOP_FLAGS` is empty by default, because a debug build
-is what contributors and the `extension-tests` job want.
+Every CI job that installs the extension and then runs against it goes through
+this target — `extension-tests` and `benchmark-ratchet`, and no others. The
+wheel build is not one of them: `.github/workflows/build-wheels.yml` runs
+`maturin build` to produce a distributable artefact rather than installing it
+into a virtual environment, so it neither uses nor needs this target.
+
+The `benchmark-ratchet` job needs an optimized build, and that is the only
+thing it needs differently, so it passes
+`make develop MATURIN_DEVELOP_FLAGS=--release` rather than restating the
+three-step sequence. Keep it that way: a second copy of the sequence is how
+the two drift, and the ratchet then measures a build nobody maintains.
+`MATURIN_DEVELOP_FLAGS` is empty by default, because a debug build is what
+contributors and the `extension-tests` job want.
 
 Without it these modules skip rather than fail, which is the right default
 locally — most changes do not need the native path rebuilt — and the wrong one
@@ -1677,12 +1683,28 @@ list lives in one place, the Makefile's `EXTENSION_TEST_TARGETS`, which the CI
 job consumes too, so the two cannot drift apart.
 
 None of that wiring is exercised by ordinary tests — drop the guard variable
-and the suite still passes — so `test_extension_build_contract.py` reads it
-back and asserts the contract: that the recipe sets the guard variable, that
-the `extension-tests` job runs `make develop` before `make test-extension`,
-and that `benchmark-ratchet` builds through the same target. It reads the
-Makefile with `make --dry-run` rather than by parsing the file, because the
-expanded recipe is the command line CI actually runs.
+and the suite still passes — so two contract modules read it back, split by
+what they read rather than by what they assert.
+
+`test_extension_build_contract.py` covers the Makefile: that the recipe sets
+the guard variable, and what `EXTENSION_TEST_TARGETS` must contain. It reads
+the Makefile with `make --dry-run` rather than by parsing the file, because
+the expanded recipe is the command line CI actually runs. It scrubs the
+Makefile's `?=` variables from that nested `make`'s environment first. `make`
+exports each of its command-line overrides under its own name, and a `?=`
+assignment yields to a name already in the environment, so without the scrub
+a run of `make test EXTENSION_TEST_TARGETS=…` would have the contract report
+on whoever invoked it rather than on the repository — passing or failing
+according to the command line rather than the wiring. Stripping `MAKEFLAGS`
+alone does not prevent that, because the override travels under its own name
+as well.
+
+`test_extension_ci_contract.py` covers `ci.yml`: that the `extension-tests`
+job runs `make develop` before `make test-extension`, that `benchmark-ratchet`
+builds through the same target with `--release`, and that no job reintroduces
+a second copy of the build sequence. It declares the workflow shapes it reads
+— jobs, steps, and a step's `run:` — so that a misspelled key is a type error
+rather than a `None` that quietly satisfies the assertion above it.
 
 `EXTENSION_TEST_TARGETS` gets two separate checks, because neither implies the
 other:

--- a/rust/cuprum-rust/src/io_utils/mod.rs
+++ b/rust/cuprum-rust/src/io_utils/mod.rs
@@ -41,11 +41,18 @@ pub(crate) fn write_retry_count() -> u64 {
 }
 
 /// Increment the current operation's read-path `EINTR` retry counter.
+///
+/// Only the Unix read path retries on `EINTR`; Windows has no equivalent, so
+/// this would otherwise be dead code there.
+#[cfg(unix)]
 fn record_read_retry() {
     READ_RETRIES.with(|counter| counter.set(counter.get().saturating_add(1)));
 }
 
 /// Increment the current operation's write-path `EINTR` retry counter.
+///
+/// Unix-only for the same reason as [`record_read_retry`].
+#[cfg(unix)]
 fn record_write_retry() {
     WRITE_RETRIES.with(|counter| counter.set(counter.get().saturating_add(1)));
 }

--- a/tests/helpers/extension_requirement.py
+++ b/tests/helpers/extension_requirement.py
@@ -13,7 +13,9 @@ one and cannot be imported by name from a test module.
 
 from __future__ import annotations
 
-REQUIRE_EXTENSION_ENV = "CUPRUM_REQUIRE_RUST_EXTENSION"
+import typing as typ
+
+REQUIRE_EXTENSION_ENV: typ.Final[str] = "CUPRUM_REQUIRE_RUST_EXTENSION"
 
 
 def missing_extension_message(*, required: bool, available: bool) -> str | None:

--- a/tests/helpers/extension_requirement.py
+++ b/tests/helpers/extension_requirement.py
@@ -1,0 +1,56 @@
+"""Decide whether a missing native extension should fail the test session.
+
+The extension-gated test modules skip when `cuprum._rust_backend_native` is
+unavailable. That is right locally — most contributors do not build the native
+extension for every change — but wrong in CI, where a job that never built it
+reports a green run indistinguishable from one that exercised the whole
+Python/Rust boundary.
+
+The decision lives here, apart from the root ``conftest.py`` that applies it,
+so it can be tested directly: a root conftest is shadowed by the per-package
+one and cannot be imported by name from a test module.
+"""
+
+from __future__ import annotations
+
+REQUIRE_EXTENSION_ENV = "CUPRUM_REQUIRE_RUST_EXTENSION"
+
+
+def missing_extension_message(*, required: bool, available: bool) -> str | None:
+    """Return the failure message when the extension is required but absent.
+
+    Parameters
+    ----------
+    required : bool
+        Whether ``CUPRUM_REQUIRE_RUST_EXTENSION`` is set to a non-empty value.
+    available : bool
+        Whether the native Rust extension is usable, per
+        ``cuprum._rust_backend.is_available``.
+
+    Returns
+    -------
+    str or None
+        The message explaining the failure, or ``None`` when the run may
+        proceed — either because the extension was not required, or because it
+        is present.
+
+    Examples
+    --------
+    >>> missing_extension_message(required=False, available=False) is None
+    True
+    >>> missing_extension_message(required=True, available=True) is None
+    True
+    >>> "make develop" in missing_extension_message(
+    ...     required=True, available=False
+    ... )
+    True
+    """
+    if not required or available:
+        return None
+    return (
+        f"{REQUIRE_EXTENSION_ENV} is set, but the native Rust extension "
+        "(cuprum._rust_backend_native) is unavailable, so every "
+        "extension-gated test would skip silently. Build it with "
+        "`make develop` before running the suite. Unset the variable to allow "
+        "skipping."
+    )


### PR DESCRIPTION
## Summary

The modules covering the Python/Rust boundary are gated on `cuprum._rust_backend_native` being importable, and no CI job built it. The test jobs reach the suite through `make build`, which is only `uv sync --group dev`, so those modules have skipped on **every run since they were written** — a green build was indistinguishable from one that never exercised the boundary.

Closes #258.

## What changed

**`make develop`** is now the single definition of the extension build, used by contributors and CI alike so the two cannot drift. It runs `ensurepip` before `maturin develop`, the ordering the `benchmark-ratchet` job already proved necessary on a fresh virtual environment.

**`CUPRUM_REQUIRE_RUST_EXTENSION`** turns a missing extension into a failure rather than a skip. The check is session-level in `conftest.py` rather than per-module, because the gated modules gate three different ways — fixture, module-level guard, availability probe — and a new module should not be able to opt out of the requirement by skipping differently.

**A dedicated `extension-tests` job** builds the extension and runs the gated modules with the guard set.

## Why a separate job, not `typecheck-test`

This is forced, not stylistic, and it is the main thing to review.

With the extension present, `cuprum/unittests/test_pipeline.py::test_pipeline_run_sync_failure_semantics` trips the file-descriptor close race tracked by **#124** (roadmap 8.1.1, still unchecked) and **aborts the interpreter**:

```
Fatal Python error: Aborted
  File ".../cuprum/_streams_rs.py", line 92 in rust_pump_stream
  File ".../concurrent/futures/thread.py", line 59 in run
```

Measured 6 aborts in 8 runs. Installing the extension for the general test run would therefore break CI outright. Until #124 lands, the general run must stay extension-free; widening this job is the natural follow-up.

## Results

All six gated modules pass under the new job — **70 tests, none skipped**:

`test_rust_streams.py`, `test_rust_streams_boundary_property.py`, `test_rust_extension.py`, `test_rust_splice.py`, `test_rust_errno.py`, and the extension-dependent `test_backend.py` cases.

That includes the four `TestRustConsumeStream` replacement scenarios, which remain the end-to-end regression coverage for #105.

Guard behaviour verified both ways: without the extension the run fails with an actionable message; with it built, everything passes.

## Validation

`make check-fmt`, `make lint`, `make typecheck`, `make test` all pass in a clean (extension-free) environment; `mbake validate Makefile` and `markdownlint` clean; `cs delta` reports no issues.

> [!NOTE]
> Stacked on #268, which is stacked on #241. #268 fixes the one gated test that would otherwise fail this job.
