### PR TITLE
Align Dependabot coverage with the estate baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
     labels:
       - "dependencies"
       - "python"
+      - "uv"
     schedule:
       interval: "daily"
     cooldown:


### PR DESCRIPTION
## Summary

This branch applies Wave 1 of the Rust estate baseline remediation
(Operation Parabellum, phase 2). It aligns
[.github/dependabot.yml](https://github.com/leynos/cuprum/blob/parabellum-wave-1/.github/dependabot.yml)
with the canonical Dependabot reference: one update stanza per package
ecosystem the repository uses (`cargo`, `uv`, `github-actions`), each stanza
labelled `dependencies` plus its channel label, and GitHub Actions updates
batched into a single pull request via a wildcard group.

## Review walkthrough

- Start with
  [.github/dependabot.yml](https://github.com/leynos/cuprum/blob/parabellum-wave-1/.github/dependabot.yml)
  for the ecosystem coverage and labels.

## Validation

- Audited the amended tree with the Concordat rule packages
  `dependabot-baseline` and `rust-dev-fast-baseline`: `dependabot-baseline`
  compliant, `rust-dev-fast-baseline` indeterminate.
- The one-line change proved identical under the rebase onto `main`
  (`git range-diff` reports `1: … = 1: …`), and all 478 files that `main`
  changed relative to the merge base are byte-identical to `main`.
- All six commit gates pass on the rebased head: `check-fmt`, `lint`,
  `typecheck`, `test`, `markdownlint`, and `nixie`.

## Notes

- The canonical labels (including the Dependabot channel labels this
  configuration references) were created on the repository ahead of this
  pull request, so no stanza names a missing label.
- Rebased onto `main` at `a97d0a8b`; the branch carries a single commit.

## Summary by Sourcery

Align Dependabot configuration with the repository estate baseline and enforce its coverage through contract tests.

Bug Fixes:
- Add the missing `uv` channel label to Python Dependabot updates so dependency pull requests match the estate baseline.

Enhancements:
- Add contract tests that validate Dependabot schema, ecosystem coverage, manifest paths, labels, pull-request limits, and GitHub Actions batching.

Tests:
- Add automated coverage for the repository's Dependabot configuration and its required update policies.

- Add the `uv` ecosystem label to Python dependency updates in Dependabot
  configuration to match baseline labelling.

## References

- [Lody session](https://lody.ai/leynos/sessions/1cb44fc9-588f-4b94-abf7-ea57046ec086)