### PR TITLE
Add property coverage for redirect and Rust contracts (#275)

### DIFF
--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -181,6 +181,7 @@
       'cuprum/unittests/test_pump_stream_dispatch_rust_settlement.py',
       'cuprum/unittests/test_pump_stream_dispatch_selection.py',
       'cuprum/unittests/test_ratchet_ratio_properties.py',
+      'cuprum/unittests/test_rust_availability_resolver_property.py',
       'cuprum/unittests/test_rust_consume_integration_guard.py',
       'cuprum/unittests/test_rust_consume_stream.py',
       'cuprum/unittests/test_rust_errno.py',

--- a/cuprum/unittests/test_fetch_main_benchmark_redirects.py
+++ b/cuprum/unittests/test_fetch_main_benchmark_redirects.py
@@ -162,7 +162,19 @@ def test_redirect_arguments_support_mixed_binding(
 def test_redirect_arguments_bind_every_valid_mixed_call(
     mixed_call: tuple[io.BytesIO, int, str, http.client.HTTPMessage, str, int],
 ) -> None:
-    """Every valid positional-or-keyword split retains the supplied values."""
+    """Verify that generated valid calls preserve their bound values.
+
+    Parameters
+    ----------
+    mixed_call
+        Generated redirect values and a positional argument count from zero
+        through five.
+
+    Notes
+    -----
+    Every valid positional-or-keyword split must bind the five callback
+    arguments without changing their values or runtime types.
+    """
     fp, code, msg, headers, newurl, positional_argument_count = mixed_call
     values: tuple[object, ...] = (fp, code, msg, headers, newurl)
     names = ("fp", "code", "msg", "headers", "newurl")
@@ -286,7 +298,18 @@ def test_redirect_arguments_reject_invalid_types(
 def test_redirect_arguments_reject_every_generated_invalid_field_type(
     field_and_value: tuple[str, object],
 ) -> None:
-    """Each type-checked redirect field rejects arbitrary invalid values."""
+    """Verify that generated invalid field values are rejected.
+
+    Parameters
+    ----------
+    field_and_value
+        Generated field name and value whose runtime type violates that
+        field's redirect-binding contract.
+
+    Notes
+    -----
+    The binder must raise ``TypeError`` for every generated invalid value.
+    """
     field, invalid_value = field_and_value
     _assert_redirect_arguments_reject_invalid_field_type(field, invalid_value)
 
@@ -295,7 +318,19 @@ def test_redirect_arguments_reject_every_generated_invalid_field_type(
 def test_redirect_arguments_reject_generated_malformed_arity(
     args: tuple[object, ...],
 ) -> None:
-    """Incomplete and excessive positional calls always fail binding."""
+    """Verify that generated malformed positional calls are rejected.
+
+    Parameters
+    ----------
+    args
+        Generated positional arguments with fewer than five or more than five
+        values.
+
+    Notes
+    -----
+    Calls with malformed positional arity must raise ``TypeError`` during
+    redirect argument binding.
+    """
     with pytest.raises(TypeError):
         _redirect_request_arguments(args, {})
 

--- a/cuprum/unittests/test_fetch_main_benchmark_redirects.py
+++ b/cuprum/unittests/test_fetch_main_benchmark_redirects.py
@@ -1,4 +1,10 @@
-"""Unit tests for benchmark artefact redirect argument and header policy."""
+"""Properties and examples for benchmark artefact redirect policy.
+
+The redirect argument binder accepts every valid positional-or-keyword split
+of urllib's five callback arguments, while rejecting malformed call shapes and
+values that violate its runtime type contract. These properties cover those
+open-ended input domains; the finite tests retain readable protocol examples.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +15,8 @@ import urllib.request
 from unittest import mock
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from benchmarks._github_http import (
     _ArtefactArchiveRedirectHandler,
@@ -19,6 +27,38 @@ from benchmarks._github_http import (
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
+
+
+_REDIRECT_CODES = st.sampled_from((301, 302, 303, 307, 308))
+_REDIRECT_TEXT = st.text(max_size=64)
+_REDIRECT_HEADERS = st.builds(http.client.HTTPMessage)
+_REDIRECT_FILE_POINTERS = st.builds(io.BytesIO, st.binary(max_size=256))
+_REDIRECT_POSITIONAL_COUNTS = st.integers(min_value=0, max_value=5)
+_INVALID_REDIRECT_FIELD_VALUES = st.one_of(
+    st.tuples(st.just("code"), st.one_of(st.booleans(), st.none(), _REDIRECT_TEXT)),
+    st.tuples(
+        st.just("msg"),
+        st.one_of(st.none(), st.integers(), st.binary(max_size=64)),
+    ),
+    st.tuples(
+        st.just("headers"),
+        st.one_of(
+            st.none(),
+            st.integers(),
+            st.dictionaries(_REDIRECT_TEXT, _REDIRECT_TEXT, max_size=4),
+        ),
+    ),
+    st.tuples(
+        st.just("newurl"),
+        st.one_of(st.none(), st.integers(), st.binary(max_size=64)),
+    ),
+)
+_MALFORMED_POSITIONAL_ARGUMENTS = st.one_of(
+    st.lists(st.one_of(st.none(), st.integers(), _REDIRECT_TEXT), max_size=4),
+    st.lists(
+        st.one_of(st.none(), st.integers(), _REDIRECT_TEXT), min_size=6, max_size=10
+    ),
+).map(tuple)
 
 
 def _make_github_artefact_request() -> urllib.request.Request:
@@ -110,6 +150,51 @@ def test_redirect_arguments_support_mixed_binding(
     assert actual == values, "Mixed redirect arguments were bound incorrectly"
 
 
+@given(
+    fp=_REDIRECT_FILE_POINTERS,
+    code=_REDIRECT_CODES,
+    msg=_REDIRECT_TEXT,
+    headers=_REDIRECT_HEADERS,
+    newurl=_REDIRECT_TEXT,
+    positional_argument_count=_REDIRECT_POSITIONAL_COUNTS,
+)
+def test_redirect_arguments_bind_every_valid_mixed_call(
+    fp: io.BytesIO,
+    code: int,
+    msg: str,
+    headers: http.client.HTTPMessage,
+    newurl: str,
+    positional_argument_count: int,
+) -> None:
+    """Every valid positional-or-keyword split retains the supplied values."""
+    values: tuple[object, ...] = (fp, code, msg, headers, newurl)
+    names = ("fp", "code", "msg", "headers", "newurl")
+    kwargs = dict(
+        zip(
+            names[positional_argument_count:],
+            values[positional_argument_count:],
+            strict=True,
+        )
+    )
+
+    actual = _redirect_request_arguments(
+        values[:positional_argument_count],
+        kwargs,
+    )
+
+    assert actual[0] is fp, "The response stream should be retained"
+    assert actual[1] == code, "The redirect status code should be retained"
+    assert actual[2] == msg, "The redirect message should be retained"
+    assert actual[3] is headers, "The redirect headers should be retained"
+    assert actual[4] == newurl, "The redirect URL should be retained"
+    assert isinstance(actual[1], int), "The status code should remain an integer"
+    assert isinstance(actual[2], str), "The message should remain a string"
+    assert isinstance(actual[3], http.client.HTTPMessage), (
+        "The headers should remain an HTTPMessage"
+    )
+    assert isinstance(actual[4], str), "The redirect URL should remain a string"
+
+
 @pytest.mark.parametrize(
     ("args", "kwargs"),
     [
@@ -190,6 +275,34 @@ def test_redirect_arguments_reject_invalid_types(
 
     with pytest.raises(TypeError):
         _redirect_request_arguments((), kwargs)
+
+
+@given(field_and_value=_INVALID_REDIRECT_FIELD_VALUES)
+def test_redirect_arguments_reject_every_generated_invalid_field_type(
+    field_and_value: tuple[str, object],
+) -> None:
+    """Each type-checked redirect field rejects arbitrary invalid values."""
+    field, invalid_value = field_and_value
+    kwargs: dict[str, object] = {
+        "fp": io.BytesIO(),
+        "code": 302,
+        "msg": "Found",
+        "headers": http.client.HTTPMessage(),
+        "newurl": "https://example.com/archive.zip",
+    }
+    kwargs[field] = invalid_value
+
+    with pytest.raises(TypeError):
+        _redirect_request_arguments((), kwargs)
+
+
+@given(args=_MALFORMED_POSITIONAL_ARGUMENTS)
+def test_redirect_arguments_reject_generated_malformed_arity(
+    args: tuple[object, ...],
+) -> None:
+    """Incomplete and excessive positional calls always fail binding."""
+    with pytest.raises(TypeError):
+        _redirect_request_arguments(args, {})
 
 
 @pytest.mark.parametrize(

--- a/cuprum/unittests/test_fetch_main_benchmark_redirects.py
+++ b/cuprum/unittests/test_fetch_main_benchmark_redirects.py
@@ -34,6 +34,14 @@ _REDIRECT_TEXT = st.text(max_size=64)
 _REDIRECT_HEADERS = st.builds(http.client.HTTPMessage)
 _REDIRECT_FILE_POINTERS = st.builds(io.BytesIO, st.binary(max_size=256))
 _REDIRECT_POSITIONAL_COUNTS = st.integers(min_value=0, max_value=5)
+_VALID_REDIRECT_MIXED_CALLS = st.tuples(
+    _REDIRECT_FILE_POINTERS,
+    _REDIRECT_CODES,
+    _REDIRECT_TEXT,
+    _REDIRECT_HEADERS,
+    _REDIRECT_TEXT,
+    _REDIRECT_POSITIONAL_COUNTS,
+)
 _INVALID_REDIRECT_FIELD_VALUES = st.one_of(
     st.tuples(st.just("code"), st.one_of(st.booleans(), st.none(), _REDIRECT_TEXT)),
     st.tuples(
@@ -150,23 +158,12 @@ def test_redirect_arguments_support_mixed_binding(
     assert actual == values, "Mixed redirect arguments were bound incorrectly"
 
 
-@given(
-    fp=_REDIRECT_FILE_POINTERS,
-    code=_REDIRECT_CODES,
-    msg=_REDIRECT_TEXT,
-    headers=_REDIRECT_HEADERS,
-    newurl=_REDIRECT_TEXT,
-    positional_argument_count=_REDIRECT_POSITIONAL_COUNTS,
-)
+@given(mixed_call=_VALID_REDIRECT_MIXED_CALLS)
 def test_redirect_arguments_bind_every_valid_mixed_call(
-    fp: io.BytesIO,
-    code: int,
-    msg: str,
-    headers: http.client.HTTPMessage,
-    newurl: str,
-    positional_argument_count: int,
+    mixed_call: tuple[io.BytesIO, int, str, http.client.HTTPMessage, str, int],
 ) -> None:
     """Every valid positional-or-keyword split retains the supplied values."""
+    fp, code, msg, headers, newurl, positional_argument_count = mixed_call
     values: tuple[object, ...] = (fp, code, msg, headers, newurl)
     names = ("fp", "code", "msg", "headers", "newurl")
     kwargs = dict(
@@ -249,6 +246,24 @@ def test_redirect_arguments_reject_invalid_binding_shapes(
         _redirect_request_arguments(args, kwargs)
 
 
+def _assert_redirect_arguments_reject_invalid_field_type(
+    field: str,
+    invalid_value: object,
+) -> None:
+    """Assert invalid redirect field types are rejected."""
+    kwargs: dict[str, object] = {
+        "fp": io.BytesIO(),
+        "code": 302,
+        "msg": "Found",
+        "headers": http.client.HTTPMessage(),
+        "newurl": "https://example.com/archive.zip",
+    }
+    kwargs[field] = invalid_value
+
+    with pytest.raises(TypeError):
+        _redirect_request_arguments((), kwargs)
+
+
 @pytest.mark.parametrize(
     ("name", "invalid_value"),
     [
@@ -264,17 +279,7 @@ def test_redirect_arguments_reject_invalid_types(
     invalid_value: object,
 ) -> None:
     """Redirect argument binding should retain its runtime type contract."""
-    kwargs: dict[str, object] = {
-        "fp": io.BytesIO(),
-        "code": 302,
-        "msg": "Found",
-        "headers": http.client.HTTPMessage(),
-        "newurl": "https://example.com/archive.zip",
-    }
-    kwargs[name] = invalid_value
-
-    with pytest.raises(TypeError):
-        _redirect_request_arguments((), kwargs)
+    _assert_redirect_arguments_reject_invalid_field_type(name, invalid_value)
 
 
 @given(field_and_value=_INVALID_REDIRECT_FIELD_VALUES)
@@ -283,17 +288,7 @@ def test_redirect_arguments_reject_every_generated_invalid_field_type(
 ) -> None:
     """Each type-checked redirect field rejects arbitrary invalid values."""
     field, invalid_value = field_and_value
-    kwargs: dict[str, object] = {
-        "fp": io.BytesIO(),
-        "code": 302,
-        "msg": "Found",
-        "headers": http.client.HTTPMessage(),
-        "newurl": "https://example.com/archive.zip",
-    }
-    kwargs[field] = invalid_value
-
-    with pytest.raises(TypeError):
-        _redirect_request_arguments((), kwargs)
+    _assert_redirect_arguments_reject_invalid_field_type(field, invalid_value)
 
 
 @given(args=_MALFORMED_POSITIONAL_ARGUMENTS)

--- a/cuprum/unittests/test_rust_availability_resolver_property.py
+++ b/cuprum/unittests/test_rust_availability_resolver_property.py
@@ -23,7 +23,7 @@ _NON_BOOLEAN_RESOLVER_VALUES = st.one_of(
     st.text(max_size=64),
     st.lists(st.integers(), max_size=4),
     st.dictionaries(st.text(max_size=8), st.integers(), max_size=4),
-).filter(lambda value: not isinstance(value, bool))
+)
 
 
 @given(availability=_NON_BOOLEAN_RESOLVER_VALUES)

--- a/cuprum/unittests/test_rust_availability_resolver_property.py
+++ b/cuprum/unittests/test_rust_availability_resolver_property.py
@@ -1,0 +1,59 @@
+"""Properties for the public Rust-availability resolver boundary.
+
+``is_rust_available()`` preserves both Boolean resolver answers exactly and
+rejects every generated non-Boolean answer with ``TypeError``. The resolver is
+patched at the public boundary's imported dependency, so the properties test
+the runtime contract without changing global backend configuration.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from cuprum import rust as rust_api
+
+_NON_BOOLEAN_RESOLVER_VALUES = st.one_of(
+    st.none(),
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.text(max_size=64),
+    st.lists(st.integers(), max_size=4),
+    st.dictionaries(st.text(max_size=8), st.integers(), max_size=4),
+).filter(lambda value: not isinstance(value, bool))
+
+
+@given(availability=_NON_BOOLEAN_RESOLVER_VALUES)
+def test_rust_availability_rejects_every_non_boolean_resolver_value(
+    availability: object,
+) -> None:
+    """The public resolver rejects every non-Boolean runtime result."""
+    with (
+        mock.patch.object(
+            rust_api,
+            "_check_rust_available",
+            return_value=availability,
+        ) as resolver,
+        pytest.raises(TypeError, match="Rust availability resolver"),
+    ):
+        rust_api.is_rust_available()
+
+    resolver.assert_called_once_with()
+
+
+@given(availability=st.booleans())
+def test_rust_availability_preserves_boolean_resolver_values(
+    availability: bool,  # noqa: FBT001 - property input, not a flag.
+) -> None:
+    """The public resolver returns each valid Boolean answer unchanged."""
+    with mock.patch.object(
+        rust_api,
+        "_check_rust_available",
+        return_value=availability,
+    ) as resolver:
+        assert rust_api.is_rust_available() is availability
+
+    resolver.assert_called_once_with()

--- a/tests/behaviour/test_rust_extension_behaviour.py
+++ b/tests/behaviour/test_rust_extension_behaviour.py
@@ -23,6 +23,14 @@ def test_rust_extension_availability() -> None:
     """Behavioural coverage for the Rust availability probe."""
 
 
+@scenario(
+    "../features/rust_extension.feature",
+    "Rust availability rejects a non-boolean resolver result",
+)
+def test_rust_extension_availability_rejects_non_boolean_result() -> None:
+    """Behavioural coverage for invalid Rust availability results."""
+
+
 @pytest.mark.parametrize(
     "invalid_availability",
     [
@@ -61,6 +69,17 @@ def given_probe() -> cabc.Callable[[], bool]:
     return c.is_rust_available
 
 
+@given("a Rust availability resolver returning a non-boolean value")
+def given_invalid_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Override the resolver with a non-Boolean result for this scenario."""
+
+    def _invalid_resolver() -> object:
+        """Return a deliberately invalid availability value."""
+        return "available"
+
+    monkeypatch.setattr(rust_api, "_check_rust_available", _invalid_resolver)
+
+
 @when(
     "I check whether the Rust extension is available",
     target_fixture="availability",
@@ -81,10 +100,27 @@ def when_check_availability(probe: cabc.Callable[[], bool]) -> bool:
     return probe()
 
 
+@when(
+    "I check the invalid Rust availability result",
+    target_fixture="availability_error",
+)
+def when_check_invalid_availability() -> TypeError:
+    """Capture the runtime contract violation raised by the public probe."""
+    with pytest.raises(TypeError) as error:
+        c.is_rust_available()
+    return error.value
+
+
 @then("the probe returns a boolean")
 def then_probe_returns_boolean(availability: object) -> None:
     """Assert the availability probe returns a boolean value."""
     assert isinstance(availability, bool), "Expected isinstance(availability, bool)"
+
+
+@then("the probe rejects the result with TypeError")
+def then_probe_rejects_invalid_result(availability_error: Exception) -> None:
+    """Assert the public probe rejects the invalid resolver result."""
+    assert isinstance(availability_error, TypeError), "Expected a TypeError"
 
 
 @then("the probe agrees with the native module when it is installed")

--- a/tests/features/rust_extension.feature
+++ b/tests/features/rust_extension.feature
@@ -8,3 +8,8 @@ Feature: Optional Rust extension availability
     When I check whether the Rust extension is available
     Then the probe returns a boolean
     And the probe agrees with the native module when it is installed
+
+  Scenario: Rust availability rejects a non-boolean resolver result
+    Given a Rust availability resolver returning a non-boolean value
+    When I check the invalid Rust availability result
+    Then the probe rejects the result with TypeError


### PR DESCRIPTION
## Summary

This branch adds Hypothesis coverage for the broad redirect-binding and Rust
availability-result contracts identified in #275. It retains PR #266's finite
examples and adds a behavioural scenario for the public rejection path.

Closes #275.

## Review walkthrough

- Start with [the redirect properties](https://github.com/leynos/cuprum/blob/issue-275-add-property-coverage-for-redirect-binding-and-rust-availability-contracts/cuprum/unittests/test_fetch_main_benchmark_redirects.py#L153), which generate every valid positional-or-keyword split and invalid arity and field types.
- Then review [the Rust resolver properties](https://github.com/leynos/cuprum/blob/issue-275-add-property-coverage-for-redirect-binding-and-rust-availability-contracts/cuprum/unittests/test_rust_availability_resolver_property.py#L1), which prove Boolean values pass unchanged and non-Boolean results raise `TypeError`.
- Finish with [the behavioural feature](https://github.com/leynos/cuprum/blob/issue-275-add-property-coverage-for-redirect-binding-and-rust-availability-contracts/tests/features/rust_extension.feature#L12) and [the wheel snapshot](https://github.com/leynos/cuprum/blob/issue-275-add-property-coverage-for-redirect-binding-and-rust-availability-contracts/cuprum/unittests/__snapshots__/test_maturin_build.ambr#L184).

## Validation

- `uv run pytest cuprum/unittests/test_rust_availability_resolver_property.py cuprum/unittests/test_backend.py cuprum/unittests/test_fetch_main_benchmark_baseline.py cuprum/unittests/test_fetch_main_benchmark_redirects.py tests/behaviour/test_rust_extension_behaviour.py`: 66 passed
- `make check-fmt`, `make lint`, `make typecheck`: passed
- `make test`: 1,255 passed, 56 skipped; 38 behaviour tests passed; 104 Rust tests passed
- `make markdownlint`, `make nixie`: passed
- `coderabbit review --agent`: zero findings

## Notes

The production binder and Rust type guard already landed with PR #266 and now
live in the extracted GitHub HTTP adapter. This branch adds property coverage
at those current boundaries without changing production behaviour.

## References

- [Originating PR #266](https://github.com/leynos/cuprum/pull/266)
- [Issue #275](https://github.com/leynos/cuprum/issues/275)
- [Lody session](https://lody.ai/leynos/sessions/6e1d0160-4664-41b2-9f6e-12e3554dd5a6)

## Summary by Sourcery

Strengthen redirect binding and Rust availability contract coverage with property-based and behavioural tests.

Enhancements:
- Expand redirect argument binding coverage to include all valid positional/keyword combinations, malformed arity, and invalid field types.
- Add property-based coverage for the Rust availability resolver’s Boolean result contract, including rejection of non-Boolean values.

Tests:
- Add behavioural coverage verifying that the public Rust availability probe rejects non-Boolean resolver results.