### PR TITLE
Validate GitHub Actions workflows (#313)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,3 +1,4 @@
+---
 name: Build Wheels
 
 on:
@@ -13,7 +14,8 @@ permissions:
 env:
   # Keep in sync with .github/actions/build-wheels/action.yml and pyproject.toml.
   MATURIN_VERSION: "1.13.3"
-  MANYLINUX_AARCH64_CONTAINER: ghcr.io/rust-cross/manylinux_2_28-cross@sha256:4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e # ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
+  MANYLINUX_AARCH64_CONTAINER: >- # ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
+    ghcr.io/rust-cross/manylinux_2_28-cross@sha256:4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e
 
 jobs:
   # Deliberately uncached. Its only work is `uv build`, which resolves the
@@ -86,7 +88,9 @@ jobs:
             ~/.cache/pip
             ~/.cargo/registry
             ~/.cargo/git
-          key: cuprum-wheel-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-${{ env.MATURIN_VERSION }}-${{ hashFiles('rust/Cargo.lock') }}
+          key: >-
+            ${{ format('cuprum-wheel-{0}-{1}-{2}-{3}-{4}', runner.os, runner.arch,
+            matrix.target, env.MATURIN_VERSION, hashFiles('rust/Cargo.lock')) }}
           restore-keys: |
             cuprum-wheel-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-${{ env.MATURIN_VERSION }}-
       - name: Build manylinux wheels (Linux x86_64)
@@ -114,7 +118,9 @@ jobs:
             ~/.cache/pip
             ~/.cargo/registry
             ~/.cargo/git
-          key: cuprum-wheel-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-${{ env.MATURIN_VERSION }}-${{ hashFiles('rust/Cargo.lock') }}
+          key: >-
+            ${{ format('cuprum-wheel-{0}-{1}-{2}-{3}-{4}', runner.os, runner.arch,
+            matrix.target, env.MATURIN_VERSION, hashFiles('rust/Cargo.lock')) }}
           restore-keys: |
             cuprum-wheel-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-${{ env.MATURIN_VERSION }}-
       - name: Build manylinux wheels (Linux aarch64)
@@ -241,7 +247,16 @@ jobs:
           (
             cd "${VERIFY_DIR}"
             echo "=== Listing installed cuprum package ==="
-            python -c "import cuprum; import os; pkg_dir = os.path.dirname(cuprum.__file__); print(f'Package at: {pkg_dir}'); import subprocess; subprocess.run(['ls', '-la', pkg_dir])"
+            python - <<'PY'
+          import os
+          import subprocess
+
+          import cuprum
+
+          pkg_dir = os.path.dirname(cuprum.__file__)
+          print(f"Package at: {pkg_dir}")
+          subprocess.run(["ls", "-la", pkg_dir], check=True)
+          PY
             echo "=== Testing Rust extension import ==="
             python - <<'PY'
           import cuprum as c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,8 @@ jobs:
           readonly ACTIONLINT_RELEASE_ROOT='https://github.com/rhysd/actionlint/releases/download'
           readonly ACTIONLINT_RELEASE_BASE="${ACTIONLINT_RELEASE_ROOT}/v${ACTIONLINT_VERSION}"
           readonly ACTIONLINT_RELEASE_URL="${ACTIONLINT_RELEASE_BASE}/${ACTIONLINT_ARCHIVE}"
-          ACTIONLINT_INSTALLER_PATH="$(mktemp)"
-          ACTIONLINT_ARCHIVE_PATH="$(mktemp)"
+          ACTIONLINT_INSTALLER_PATH=$(mktemp)
+          ACTIONLINT_ARCHIVE_PATH=$(mktemp)
           trap 'rm -f "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_ARCHIVE_PATH}"' EXIT
           # Feed the verified archive to the reviewed installer without a second download.
           curl() {
@@ -1070,10 +1070,11 @@ jobs:
             printf '| %s | %s | %s | %s |\n' \
               "${EVENT}" "${detector}" "${BENCH:-unknown}" "${decision}"
           } >> "${GITHUB_STEP_SUMMARY}"
-          printf '%s\n' \
-            "::notice title=benchmark-gate-decision::event_class=${event_class}"\
-            " detector_status=${detector_status}"\
-            " decision=${decision}"
+          notice_title='::notice title=benchmark-gate-decision::'
+          notice="${notice_title}event_class=${event_class}"
+          notice+=" detector_status=${detector_status}"
+          notice+=" decision=${decision}"
+          printf '%s\n' "${notice}"
 
   benchmark-ratchet:
     # The ratchet compares each scenario's within-run `rust_mean / python_mean`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on:
@@ -60,6 +61,10 @@ jobs:
       MBAKE_VERSION: '1.4.6'
       MDTABLEFIX_VERSION: '0.5.1'
       WHITAKER_INSTALLER_VERSION: '0.2.7'
+      UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
+      UV_TOOL_DIR: ${{ github.workspace }}/.uv-tools
+      UV_TOOL_BIN_DIR: ${{ github.workspace }}/.uv-bin
+      YAMLLINT_VERSION: '1.38.0'
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -118,6 +123,62 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+
+      - name: Cache yamllint
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            .uv-cache
+            .uv-tools
+            .uv-bin
+          key: yamllint-${{ runner.os }}-${{ runner.arch }}-${{ env.YAMLLINT_VERSION }}
+
+      - name: Install yamllint
+        run: |
+          uv tool install "yamllint==${YAMLLINT_VERSION}"
+          echo "${UV_TOOL_BIN_DIR}" >> "$GITHUB_PATH"
+
+      - name: Cache actionlint
+        id: cache_actionlint
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: actionlint
+          key: actionlint-${{ runner.os }}-${{ runner.arch }}-1.7.12
+
+      - name: Download actionlint
+        id: get_actionlint
+        if: steps.cache_actionlint.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          readonly ACTIONLINT_VERSION='1.7.12'
+          readonly ACTIONLINT_SHA256='8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'
+          readonly ACTIONLINT_INSTALLER_COMMIT='914e7df21a07ef503a81201c76d2b11c789d3fca'
+          readonly ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          readonly ACTIONLINT_RAW_BASE='https://raw.githubusercontent.com/rhysd/actionlint'
+          readonly ACTIONLINT_SCRIPT='scripts/download-actionlint.bash'
+          readonly ACTIONLINT_INSTALLER_URL="${ACTIONLINT_RAW_BASE}/${ACTIONLINT_INSTALLER_COMMIT}/${ACTIONLINT_SCRIPT}"
+          readonly ACTIONLINT_RELEASE_ROOT='https://github.com/rhysd/actionlint/releases/download'
+          readonly ACTIONLINT_RELEASE_BASE="${ACTIONLINT_RELEASE_ROOT}/v${ACTIONLINT_VERSION}"
+          readonly ACTIONLINT_RELEASE_URL="${ACTIONLINT_RELEASE_BASE}/${ACTIONLINT_ARCHIVE}"
+          ACTIONLINT_INSTALLER_PATH="$(mktemp)"
+          ACTIONLINT_ARCHIVE_PATH="$(mktemp)"
+          trap 'rm -f "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_ARCHIVE_PATH}"' EXIT
+          # Feed the verified archive to the reviewed installer without a second download.
+          curl() {
+            if [[ "${*: -1}" == "${ACTIONLINT_RELEASE_URL}" ]]; then
+              cat "${ACTIONLINT_ARCHIVE_PATH}"
+            else
+              command curl "$@"
+            fi
+          }
+          export -f curl
+          command curl --fail --location --show-error --output "${ACTIONLINT_INSTALLER_PATH}" \
+            "${ACTIONLINT_INSTALLER_URL}"
+          command curl --fail --location --show-error --output "${ACTIONLINT_ARCHIVE_PATH}" \
+            "${ACTIONLINT_RELEASE_URL}"
+          printf '%s  %s\n' "${ACTIONLINT_SHA256}" "${ACTIONLINT_ARCHIVE_PATH}" | sha256sum --check --
+          bash "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_VERSION}"
 
       - name: Cache npm CLI dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -212,7 +273,7 @@ jobs:
         run: make check-fmt
 
       - name: Run lint
-        run: make lint
+        run: /usr/bin/make ACTIONLINT="$GITHUB_WORKSPACE/actionlint" lint
 
       # The Windows wheel build compiles this arm but without `-D warnings`,
       # so it catches a Windows arm that fails to build and nothing else. This
@@ -1010,7 +1071,9 @@ jobs:
               "${EVENT}" "${detector}" "${BENCH:-unknown}" "${decision}"
           } >> "${GITHUB_STEP_SUMMARY}"
           printf '%s\n' \
-            "::notice title=benchmark-gate-decision::event_class=${event_class} detector_status=${detector_status} decision=${decision}"
+            "::notice title=benchmark-gate-decision::event_class=${event_class}"\
+            " detector_status=${detector_status}"\
+            " decision=${decision}"
 
   benchmark-ratchet:
     # The ratchet compares each scenario's within-run `rust_mean / python_mean`
@@ -1028,7 +1091,9 @@ jobs:
     # pipeline throughput. Successful pushes to main always run so the ratchet
     # baseline artifact is refreshed for every merge. A failed detector skips
     # every event, rather than spending paid-runner time on an ungated run.
-    if: needs.changes.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.bench == 'true')
+    if: >-
+      needs.changes.result == 'success' && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.bench == 'true')
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,12 @@ jobs:
           path: |
             ~/.local/bin/mdtablefix
             ~/.local/bin/mdtablefix.exe
-          key: mdtablefix-${{ runner.os }}-${{ runner.arch }}-${{ env.UBUNTU_RELEASE }}-${{ env.CACHE_GENERATION }}-${{ env.MDTABLEFIX_VERSION }}
+          key: >-
+            ${{ format(
+              'mdtablefix-{0}-{1}-{2}-{3}-{4}',
+              runner.os, runner.arch, env.UBUNTU_RELEASE,
+              env.CACHE_GENERATION, env.MDTABLEFIX_VERSION
+            ) }}
 
       - name: Install mdtablefix
         # The shared action accepts only releases with correct multi-platform

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,3 +1,4 @@
+---
 name: Coverage (main)
 
 # CodeScene accepts `cs-coverage upload` only for analysed branches, so

--- a/.github/workflows/delayed-pr-comment.yml
+++ b/.github/workflows/delayed-pr-comment.yml
@@ -1,3 +1,4 @@
+---
 name: delayed-pr-comment
 on:
   workflow_dispatch:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,3 +1,4 @@
+---
 name: dependabot-automerge
 
 # Uses pull_request_target to enable auto-merge with write permissions.

--- a/.github/workflows/get-codescene-sha.yml
+++ b/.github/workflows/get-codescene-sha.yml
@@ -1,3 +1,4 @@
+---
 name: Refresh CodeScene CLI SHA256
 
 on:
@@ -21,7 +22,7 @@ jobs:
           curl -fsSL "$url" -o install-cs-coverage-tool.sh
           echo "sha=$(sha256sum install-cs-coverage-tool.sh | awk '{print $1}')" >> "$GITHUB_OUTPUT"
       - name: Update repository variable
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v7
         with:
           script: |
             const sha = process.env.SHA

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,3 +1,4 @@
+---
 name: Mutation testing
 
 # Thin caller of the shared mutation-testing reusable workflow; caller
@@ -25,7 +26,7 @@ jobs:
   mutation-python:
     permissions:
       contents: read
-      id-token: write # OIDC workflow-source resolution
+      id-token: write  # OIDC workflow-source resolution
     uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
     with:
       # Flat layout: the mutable source is the cuprum/ package at the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: Release Wheels
 
 on:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -2,6 +2,9 @@
 extends: default
 
 rules:
+  document-start:
+    level: error
+    present: true
   line-length:
     max: 120
   truthy:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  truthy:
+    allowed-values: ['true', 'false']
+    check-keys: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,10 +189,15 @@ working on the Rust portions of the project:
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
     cargo clippy --all-targets --all-features -- -D warnings
     RUSTFLAGS="-D warnings" whitaker --all -- --all-targets --all-features
+    yamllint .github/workflows
+    actionlint
     ```
 
-    linting every target with all features enabled and denying all Clippy
-    warnings.
+    linting every target with all features enabled, denying all Clippy
+    warnings, and validating GitHub Actions workflows. Keep `.yamllint.yml`
+    compatible with GitHub's unquoted `on` trigger key. CI must install
+    yamllint with `uv tool` and use the pinned, checksum-verified actionlint
+    binary before invoking `make lint`.
   - `make test` executes `cargo nextest run` when `cargo-nextest` is available,
     otherwise:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,13 +189,14 @@ working on the Rust portions of the project:
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
     cargo clippy --all-targets --all-features -- -D warnings
     RUSTFLAGS="-D warnings" whitaker --all -- --all-targets --all-features
-    yamllint .github/workflows
+    yamllint --config-file .yamllint.yml .github/workflows
     actionlint
     ```
 
     linting every target with all features enabled, denying all Clippy
     warnings, and validating GitHub Actions workflows. Keep `.yamllint.yml`
-    compatible with GitHub's unquoted `on` trigger key. CI must install
+    compatible with GitHub's unquoted `on` trigger key and require each
+    workflow to begin with `---`. CI must install
     yamllint with `uv tool` and use the pinned, checksum-verified actionlint
     binary before invoking `make lint`.
   - `make test` executes `cargo nextest run` when `cargo-nextest` is available,

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 MDFORMAT_ALL ?= mdformat-all
-TOOLS = $(MDFORMAT_ALL) $(MDLINT) uv
+YAMLLINT ?= yamllint
+ACTIONLINT ?= actionlint
+TOOLS = $(MDFORMAT_ALL) $(MDLINT) $(YAMLLINT) $(ACTIONLINT) uv
 VENV_TOOLS = pytest ruff
 RUST_DIR ?= rust
 CARGO ?= cargo
@@ -124,6 +126,7 @@ AMBRLEAKS = $(UV_RUN_ENV) uv run --python $(DF12_PYTHON) ambrleaks
 MD_FILES_FIND = bash -o pipefail -c 'git ls-files -z -- "$$1" | while IFS= read -r -d "" markdown_file; do if [ -e "$$markdown_file" ]; then printf "%s\0" "$$markdown_file"; fi; done' -- '*.md'
 
 .PHONY: help all clean build build-release lint python-lint rust-lint \
+        github-actions-lint \
         lint-windows fmt check-fmt \
         markdownlint spelling spelling-config spelling-helper-test \
         _run_spelling_gate nixie test test-python test-rust typecheck \
@@ -210,7 +213,7 @@ test-markdown-format: ## Validate the Markdown formatter checker
 		python -m pytest scripts/tests/test_check_markdown_format.py -c /dev/null \
 		--rootdir=. -p no:cacheprovider
 
-lint: python-lint rust-lint ## Run Python and Rust linters
+lint: python-lint rust-lint github-actions-lint ## Run Python, Rust, and GitHub Actions linters
 
 python-lint: ruff uv ## Run Ruff, interrogate, pylint, df12-python-lints, and ambrleaks
 	$(RUFF) check && $(UV_RUN_ENV) uv run interrogate --fail-under 100 cuprum && $(PYLINT) $(PYLINT_TARGETS)
@@ -222,6 +225,10 @@ rust-lint: ## Run Rust documentation, Clippy, Whitaker, and spelling checks
 	@if ! $(LOCAL_TOOL_ENV) command -v $(WHITAKER) >/dev/null 2>&1; then echo "whitaker is required for linting. Install it before running this target." >&2; exit 1; fi
 	cd $(RUST_DIR) && $(LOCAL_TOOL_ENV) RUSTFLAGS="$(WHITAKER_RUSTFLAGS)" $(WHITAKER) --all -- $(WHITAKER_CARGO_FLAGS)
 	+$(MAKE) spelling
+
+github-actions-lint: $(YAMLLINT) $(ACTIONLINT) ## Validate GitHub Actions workflows
+	$(YAMLLINT) .github/workflows
+	$(ACTIONLINT)
 
 lint-windows: ## Lint the Rust extension's Windows cfg branches (cross-target)
 	@if ! rustup target list --installed | grep -qx '$(WINDOWS_TARGET)'; then \

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ rust-lint: ## Run Rust documentation, Clippy, Whitaker, and spelling checks
 	+$(MAKE) spelling
 
 github-actions-lint: $(YAMLLINT) $(ACTIONLINT) ## Validate GitHub Actions workflows
-	$(YAMLLINT) .github/workflows
+	$(YAMLLINT) --config-file .yamllint.yml .github/workflows
 	$(ACTIONLINT)
 
 lint-windows: ## Lint the Rust extension's Windows cfg branches (cross-target)

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -238,6 +238,7 @@
       'cuprum/unittests/test_tracing_span_lifecycle.py',
       'cuprum/unittests/test_tracing_span_stateful.py',
       'cuprum/unittests/test_validation.py',
+      'cuprum/unittests/test_verify_wheel_install.py',
       'cuprum/unittests/test_workflow_lint.py',
     ]),
     'generator': '1.13.3',

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -238,6 +238,7 @@
       'cuprum/unittests/test_tracing_span_lifecycle.py',
       'cuprum/unittests/test_tracing_span_stateful.py',
       'cuprum/unittests/test_validation.py',
+      'cuprum/unittests/test_workflow_lint.py',
     ]),
     'generator': '1.13.3',
     'metadata': dict({

--- a/cuprum/unittests/test_maturin_pins.py
+++ b/cuprum/unittests/test_maturin_pins.py
@@ -17,6 +17,7 @@ import re
 import typing as typ
 
 import pytest
+import yaml
 
 from cuprum.unittests._maturin_pin_support import (
     MANYLINUX_CONTAINER_SHA256_RE,
@@ -32,8 +33,8 @@ if typ.TYPE_CHECKING:
 
 _WORKFLOW_PIN_RE = re.compile(r'MATURIN_VERSION:\s*"(\d+\.\d+\.\d+)"')
 _ACTION_PIN_RE = re.compile(r'default:\s*"(\d+\.\d+\.\d+)"')
-_AARCH64_CONTAINER_PIN_RE = re.compile(
-    r"^\s*MANYLINUX_AARCH64_CONTAINER:\s*([^\s#]+)\s+#\s*\S.*$",
+_AARCH64_CONTAINER_COMMENT_RE = re.compile(
+    r"^\s*MANYLINUX_AARCH64_CONTAINER:\s*>-\s+#\s*\S.*$",
     re.MULTILINE,
 )
 _AARCH64_CONTAINER_USAGE_RE = re.compile(
@@ -65,13 +66,20 @@ def _read_maturin_pins(root: pth.Path) -> dict[str, str]:
 
 def _read_manylinux_aarch64_container_ref(root: pth.Path) -> str:
     """Read the pinned manylinux aarch64 container reference from the workflow."""
-    return require_pin_match(
-        _AARCH64_CONTAINER_PIN_RE.search(
-            read_text(root, ".github/workflows/build-wheels.yml"),
-        ),
-        ".github/workflows/build-wheels.yml",
-        subject="MANYLINUX_AARCH64_CONTAINER pin",
+    workflow_path = ".github/workflows/build-wheels.yml"
+    workflow_text = read_text(root, workflow_path)
+    assert _AARCH64_CONTAINER_COMMENT_RE.search(workflow_text), (
+        "MANYLINUX_AARCH64_CONTAINER must retain the source-tag comment"
     )
+    workflow = yaml.safe_load(workflow_text)
+    assert isinstance(workflow, dict), f"{workflow_path} must parse to a mapping"
+    environment = workflow.get("env")
+    assert isinstance(environment, dict), f"{workflow_path} must declare env"
+    container_ref = environment.get("MANYLINUX_AARCH64_CONTAINER")
+    assert isinstance(container_ref, str), (
+        "MANYLINUX_AARCH64_CONTAINER must be a scalar string"
+    )
+    return container_ref
 
 
 def _workflow_uses_manylinux_aarch64_container_ref(root: pth.Path) -> bool:
@@ -144,12 +152,12 @@ def test_manylinux_aarch64_container_ref_rejects_mutable_tag(
 def test_manylinux_aarch64_container_pin_regex_rejects_missing_comment() -> None:
     """Aarch64 manylinux container pins require the source-tag comment."""
     yaml_line = (
-        "MANYLINUX_AARCH64_CONTAINER: "
-        "ghcr.io/rust-cross/manylinux_2_28-cross@sha256:"
-        "4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e"
+        "MANYLINUX_AARCH64_CONTAINER: >-\n"
+        "  ghcr.io/rust-cross/manylinux_2_28-cross@sha256:"
+        "4864c3e931d790def6dba05cbf133b236b242d0c732f77546c68663c7923116e\n"
     )
 
-    assert _AARCH64_CONTAINER_PIN_RE.search(yaml_line) is None, (
+    assert _AARCH64_CONTAINER_COMMENT_RE.search(yaml_line) is None, (
         "the pin pattern must reject a digest carrying no trailing comment: "
         "the comment records which tag the digest came from, without which a "
         "reviewer cannot tell what a bump is bumping to"

--- a/cuprum/unittests/test_toolchain_pins.py
+++ b/cuprum/unittests/test_toolchain_pins.py
@@ -265,7 +265,7 @@ def test_mdtablefix_uses_its_pinned_prebuilt_installer() -> None:
         "UBUNTU_RELEASE",
         "CACHE_GENERATION",
     ):
-        assert f"${{{{ env.{name} }}}}" in cache_key, (
+        assert f"env.{name}" in cache_key, (
             f"the Cache mdtablefix CI mapping must include {name} in with.key"
         )
 

--- a/cuprum/unittests/test_verify_wheel_install.py
+++ b/cuprum/unittests/test_verify_wheel_install.py
@@ -1,0 +1,111 @@
+"""Regression coverage for the native-wheel package inspection step."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - executes checked-in workflow code.
+import sys
+import typing as typ
+
+import pytest
+import yaml
+
+from tests.helpers.docs import repo_root
+
+if typ.TYPE_CHECKING:
+    import pathlib as pth
+
+_WORKFLOW_PATH = ".github/workflows/build-wheels.yml"
+_LISTING_MARKER = 'echo "=== Listing installed cuprum package ==="\n'
+_LATER_CHECK_MARKER = 'echo "=== Testing Rust extension import ==="'
+
+
+def _package_listing_script() -> str:
+    """Extract the package-listing Python script from the wheel workflow."""
+    workflow = yaml.safe_load(
+        (repo_root() / _WORKFLOW_PATH).read_text(encoding="utf-8")
+    )
+    assert isinstance(workflow, dict), f"{_WORKFLOW_PATH} must parse to a mapping"
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), f"{_WORKFLOW_PATH} must declare jobs"
+    verify_job = jobs.get("verify-wheel-install")
+    assert isinstance(verify_job, dict), "build-wheels must verify installed wheels"
+    steps = verify_job.get("steps")
+    assert isinstance(steps, list), "verify-wheel-install must declare steps"
+    script = next(
+        (
+            step.get("run")
+            for step in steps
+            if isinstance(step, dict) and _LISTING_MARKER in str(step.get("run"))
+        ),
+        None,
+    )
+    assert isinstance(script, str), "verify-wheel-install must list its package"
+    listing_section = script.split(_LISTING_MARKER, maxsplit=1)[1]
+    listing_section = listing_section.split(_LATER_CHECK_MARKER, maxsplit=1)[0]
+    return listing_section.removeprefix("  python - <<'PY'\n").removesuffix("PY\n")
+
+
+def _write_failing_ls(directory: pth.Path) -> pth.Path:
+    """Write an ``ls`` replacement that records and fails its invocation."""
+    fake_ls = directory / "ls"
+    fake_ls.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "${LS_ARGUMENTS}"\nexit 23\n',
+        encoding="utf-8",
+    )
+    fake_ls.chmod(fake_ls.stat().st_mode | stat.S_IXUSR)
+    return fake_ls
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="The Linux wheel workflow executes its package check through Bash and ls.",
+)
+def test_package_listing_failure_stops_the_verify_wheel_step(
+    tmp_path: pth.Path,
+) -> None:
+    """A failed package listing prevents later wheel checks from running."""
+    package_root = tmp_path / "site-packages"
+    package_directory = package_root / "cuprum"
+    package_directory.mkdir(parents=True)
+    (package_directory / "__init__.py").write_text("", encoding="utf-8")
+    tools_directory = tmp_path / "tools"
+    tools_directory.mkdir()
+    _write_failing_ls(tools_directory)
+    later_check_marker = tmp_path / "later-check-ran"
+    ls_arguments = tmp_path / "ls-arguments"
+    environment = {
+        **os.environ,
+        "LATER_CHECK_MARKER": str(later_check_marker),
+        "LS_ARGUMENTS": str(ls_arguments),
+        "PATH": os.pathsep.join((str(tools_directory), os.defpath)),
+        "PYTHONPATH": str(package_root),
+    }
+    shell_script = "\n".join((
+        "set -euo pipefail",
+        "python - <<'PY'",
+        _package_listing_script(),
+        "PY",
+        "printf '%s\\n' reached > \"${LATER_CHECK_MARKER}\"",
+    ))
+    bash_path = shutil.which("bash", path=os.defpath)
+    assert bash_path is not None, "the Linux workflow test requires Bash"
+
+    completed = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - checked-in workflow code.
+        [bash_path, "-c", shell_script],
+        capture_output=True,
+        check=False,
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+    )
+
+    assert completed.returncode != 0, "a failing package listing unexpectedly passed"
+    assert f"Package at: {package_directory}" in completed.stdout
+    assert ls_arguments.read_text(encoding="utf-8").splitlines() == [
+        "-la",
+        str(package_directory),
+    ]
+    assert not later_check_marker.exists(), "later wheel checks ran after ls failed"

--- a/cuprum/unittests/test_workflow_lint.py
+++ b/cuprum/unittests/test_workflow_lint.py
@@ -24,6 +24,28 @@ if typ.TYPE_CHECKING:
 
 _CI_WORKFLOW = ".github/workflows/ci.yml"
 _WORKFLOW_DIRECTORY = ".github/workflows"
+_ACTIONLINT_INSTALLER_LINES = (
+    "readonly ACTIONLINT_VERSION='1.7.12'",
+    "readonly ACTIONLINT_SHA256="
+    "'8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'",
+    "readonly ACTIONLINT_INSTALLER_COMMIT='914e7df21a07ef503a81201c76d2b11c789d3fca'",
+    'readonly ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"',
+    "readonly ACTIONLINT_RAW_BASE='https://raw.githubusercontent.com/rhysd/actionlint'",
+    "readonly ACTIONLINT_SCRIPT='scripts/download-actionlint.bash'",
+    'readonly ACTIONLINT_INSTALLER_URL="${ACTIONLINT_RAW_BASE}/'
+    '${ACTIONLINT_INSTALLER_COMMIT}/${ACTIONLINT_SCRIPT}"',
+    "readonly ACTIONLINT_RELEASE_ROOT="
+    "'https://github.com/rhysd/actionlint/releases/download'",
+    'readonly ACTIONLINT_RELEASE_BASE="${ACTIONLINT_RELEASE_ROOT}/'
+    'v${ACTIONLINT_VERSION}"',
+    'readonly ACTIONLINT_RELEASE_URL="${ACTIONLINT_RELEASE_BASE}/'
+    '${ACTIONLINT_ARCHIVE}"',
+    "command curl --fail --location --show-error --output "
+    '"${ACTIONLINT_INSTALLER_PATH}"',
+    'command curl --fail --location --show-error --output "${ACTIONLINT_ARCHIVE_PATH}"',
+    "sha256sum --check --",
+    'bash "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_VERSION}"',
+)
 
 
 _Step = typ.TypedDict(
@@ -33,6 +55,7 @@ _Step = typ.TypedDict(
         "if": object,
         "name": object,
         "run": object,
+        "uses": object,
         "with": dict[str, object],
     },
     total=False,
@@ -47,7 +70,7 @@ class _LintJob(typ.TypedDict, total=False):
     steps: list[_Step]
 
 
-def _write_fake_tool(directory: pth.Path, tool: str) -> None:
+def _write_fake_tool(directory: pth.Path, tool: str, *, exit_code: int = 0) -> None:
     """Write an executable that records its name and arguments."""
     executable = directory / tool
     executable.write_text(
@@ -56,21 +79,30 @@ def _write_fake_tool(directory: pth.Path, tool: str) -> None:
         'for argument in "$@"; do\n'
         '  printf \'\\t%s\' "${argument}" >> "${LINT_INVOCATION_LOG}"\n'
         "done\n"
-        "printf '\\n' >> \"${LINT_INVOCATION_LOG}\"\n",
+        "printf '\\n' >> \"${LINT_INVOCATION_LOG}\"\n"
+        f"exit {exit_code}\n",
         encoding="utf-8",
     )
     executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
 
 
 def _make_environment(
-    tmp_path: pth.Path, *, tools: cabc.Iterable[str]
+    tmp_path: pth.Path,
+    *,
+    tools: cabc.Iterable[str],
+    exit_codes: cabc.Mapping[str, int] | None = None,
 ) -> tuple[dict[str, str], pth.Path]:
     """Create a Makefile environment with only the requested fake tools."""
     tool_directory = tmp_path / "tools"
     tool_directory.mkdir()
     invocation_log = tmp_path / "invocations.log"
+    expected_exit_codes = exit_codes or {}
     for tool in tools:
-        _write_fake_tool(tool_directory, tool)
+        _write_fake_tool(
+            tool_directory,
+            tool,
+            exit_code=expected_exit_codes.get(tool, 0),
+        )
     environment = {
         **os.environ,
         "HOME": str(tmp_path / "home"),
@@ -115,7 +147,70 @@ def _step_named(name: str) -> _Step:
     )
     return matches[0]
 
+def _assert_yamllint_provisioning() -> None:
+    """Assert that CI installs the pinned yamllint executable on PATH."""
+    environment = _lint_job().get("env")
+    assert isinstance(environment, dict), "lint-test must declare environment"
+    assert environment.get("YAMLLINT_VERSION") == "1.38.0"
 
+    yamllint_cache = _step_named("Cache yamllint")
+    assert yamllint_cache.get("uses") == (
+        "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
+    )
+    assert (
+        yamllint_cache.get("with", {}).get("path") == ".uv-cache\n.uv-tools\n.uv-bin\n"
+    )
+
+    yamllint_install = _step_named("Install yamllint").get("run")
+    assert isinstance(yamllint_install, str), "Install yamllint must run a script"
+    assert 'uv tool install "yamllint==${YAMLLINT_VERSION}"' in yamllint_install
+    assert 'echo "${UV_TOOL_BIN_DIR}" >> "$GITHUB_PATH"' in yamllint_install
+
+def _assert_actionlint_provisioning() -> None:
+    """Assert that CI verifies actionlint before its installer can run."""
+    actionlint_cache = _step_named("Cache actionlint")
+    assert actionlint_cache.get("id") == "cache_actionlint"
+    assert actionlint_cache.get("uses") == (
+        "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
+    )
+    assert actionlint_cache.get("with", {}).get("path") == "actionlint"
+    assert actionlint_cache.get("with", {}).get("key") == (
+        "actionlint-${{ runner.os }}-${{ runner.arch }}-1.7.12"
+    )
+
+    actionlint_download = _step_named("Download actionlint")
+    assert (
+        actionlint_download.get("if")
+        == "steps.cache_actionlint.outputs.cache-hit != 'true'"
+    )
+    download_script = actionlint_download.get("run")
+    assert isinstance(download_script, str), "Download actionlint must run a script"
+    assert actionlint_download.get("shell") == "bash"
+    for expected_script_line in _ACTIONLINT_INSTALLER_LINES:
+        assert expected_script_line in download_script
+    assert download_script.index("sha256sum --check --") < download_script.index(
+        'bash "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_VERSION}"'
+    )
+
+def _assert_linter_step_order() -> None:
+    """Assert that CI provisions both linters before invoking Make."""
+    step_names = [
+        "Install uv",
+        "Cache yamllint",
+        "Install yamllint",
+        "Cache actionlint",
+        "Download actionlint",
+        "Run lint",
+    ]
+    steps = _lint_job().get("steps")
+    assert isinstance(steps, list), "lint-test must declare a steps list"
+    positions = [
+        next(
+            position for position, step in enumerate(steps) if step.get("name") == name
+        )
+        for name in step_names
+    ]
+    assert positions == sorted(positions)
 def test_the_workflow_lint_target_runs_both_linters(tmp_path: pth.Path) -> None:
     """The target validates YAML policy before GitHub Actions semantics."""
     environment, invocation_log = _make_environment(
@@ -126,7 +221,7 @@ def test_the_workflow_lint_target_runs_both_linters(tmp_path: pth.Path) -> None:
 
     assert completed.returncode == 0, completed.stderr
     assert invocation_log.read_text(encoding="utf-8").splitlines() == [
-        f"yamllint\t{_WORKFLOW_DIRECTORY}",
+        f"yamllint\t--config-file\t.yamllint.yml\t{_WORKFLOW_DIRECTORY}",
         "actionlint",
     ]
 
@@ -142,12 +237,49 @@ def test_the_workflow_lint_target_rejects_a_missing_linter(tmp_path: pth.Path) -
     assert "Error: 'yamllint' is required, but not installed" in completed.stderr
     assert not invocation_log.exists(), "actionlint ran after yamllint was missing"
 
+def test_the_workflow_lint_target_rejects_actionlint_failure(
+    tmp_path: pth.Path,
+) -> None:
+    """Actionlint failure makes the workflow lint target fail after yamllint."""
+    environment, invocation_log = _make_environment(
+        tmp_path,
+        tools=("yamllint", "actionlint"),
+        exit_codes={"actionlint": 31},
+    )
 
+    completed = _run_make("github-actions-lint", environment=environment)
+
+    assert completed.returncode == 2
+    assert "Error 31" in completed.stderr
+    assert invocation_log.read_text(encoding="utf-8").splitlines() == [
+        f"yamllint\t--config-file\t.yamllint.yml\t{_WORKFLOW_DIRECTORY}",
+        "actionlint",
+    ]
+
+def test_all_workflows_declare_yaml_document_starts() -> None:
+    """The shared YAML policy has a compatible marker in every workflow."""
+    workflow_paths = sorted((repo_root() / _WORKFLOW_DIRECTORY).glob("*.yml"))
+
+    assert workflow_paths, "expected at least one GitHub Actions workflow"
+    for workflow_path in workflow_paths:
+        assert workflow_path.read_text(encoding="utf-8").startswith("---\n"), (
+            f"{workflow_path.relative_to(repo_root())} must begin with a YAML "
+            "document start"
+        )
 def test_ci_provisions_the_pinned_workflow_linters() -> None:
     """CI caches and verifies the exact linters used by its trusted Make run."""
-    policy = (repo_root() / ".yamllint.yml").read_text(encoding="utf-8")
-    assert "allowed-values: ['true', 'false']" in policy
-    assert "check-keys: false" in policy
+    policy = yaml.safe_load((repo_root() / ".yamllint.yml").read_text(encoding="utf-8"))
+    assert policy == {
+        "extends": "default",
+        "rules": {
+            "document-start": {"level": "error", "present": True},
+            "line-length": {"max": 120},
+            "truthy": {
+                "allowed-values": ["true", "false"],
+                "check-keys": False,
+            },
+        },
+    }
     actionlint_policy = yaml.safe_load(
         (repo_root() / ".github/actionlint.yaml").read_text(encoding="utf-8")
     )
@@ -156,43 +288,9 @@ def test_ci_provisions_the_pinned_workflow_linters() -> None:
         "config-variables": ["CODESCENE_CLI_SHA256"],
     }
 
-    environment = _lint_job().get("env")
-    assert isinstance(environment, dict), "lint-test must declare environment"
-    assert environment.get("YAMLLINT_VERSION") == "1.38.0"
-
-    yamllint_cache = _step_named("Cache yamllint")
-    assert (
-        yamllint_cache.get("with", {}).get("path") == ".uv-cache\n.uv-tools\n.uv-bin\n"
-    )
-
-    yamllint_install = _step_named("Install yamllint").get("run")
-    assert isinstance(yamllint_install, str), "Install yamllint must run a script"
-    assert 'uv tool install "yamllint==${YAMLLINT_VERSION}"' in yamllint_install
-    assert 'echo "${UV_TOOL_BIN_DIR}" >> "$GITHUB_PATH"' in yamllint_install
-
-    actionlint_cache = _step_named("Cache actionlint")
-    assert actionlint_cache.get("id") == "cache_actionlint"
-    assert actionlint_cache.get("with", {}).get("path") == "actionlint"
-    assert actionlint_cache.get("with", {}).get("key") == (
-        "actionlint-${{ runner.os }}-${{ runner.arch }}-1.7.12"
-    )
-
-    actionlint_download = _step_named("Download actionlint")
-    assert (
-        actionlint_download.get("if")
-        == "steps.cache_actionlint.outputs.cache-hit != 'true'"
-    )
-    download_script = actionlint_download.get("run")
-    assert isinstance(download_script, str), "Download actionlint must run a script"
-    assert "readonly ACTIONLINT_VERSION='1.7.12'" in download_script
-    assert (
-        "readonly ACTIONLINT_INSTALLER_COMMIT="
-        "'914e7df21a07ef503a81201c76d2b11c789d3fca'" in download_script
-    )
-    assert "sha256sum --check --" in download_script
-    assert (
-        'bash "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_VERSION}"' in download_script
-    )
+    _assert_yamllint_provisioning()
+    _assert_actionlint_provisioning()
+    _assert_linter_step_order()
 
     lint_command = _step_named("Run lint").get("run")
     assert (

--- a/cuprum/unittests/test_workflow_lint.py
+++ b/cuprum/unittests/test_workflow_lint.py
@@ -1,0 +1,200 @@
+"""Contract tests for GitHub Actions workflow validation.
+
+The repository's workflows are declarative configuration, so malformed YAML,
+invalid Actions expressions, and shell errors could otherwise reach CI before
+any project gate evaluates them. These tests cover the Makefile boundary that
+invokes both linters, its loud missing-tool failure, and the CI provisioning
+that makes the same checked binaries available to the lint job.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess  # noqa: S404 - runs fixed Makefile targets under test.
+import typing as typ
+
+import yaml
+
+from tests.helpers.docs import repo_root
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+    import pathlib as pth
+
+_CI_WORKFLOW = ".github/workflows/ci.yml"
+_WORKFLOW_DIRECTORY = ".github/workflows"
+
+
+_Step = typ.TypedDict(
+    "_Step",
+    {
+        "id": object,
+        "if": object,
+        "name": object,
+        "run": object,
+        "with": dict[str, object],
+    },
+    total=False,
+)
+"""The CI step fields this contract reads."""
+
+
+class _LintJob(typ.TypedDict, total=False):
+    """The lint job fields this contract reads."""
+
+    env: dict[str, object]
+    steps: list[_Step]
+
+
+def _write_fake_tool(directory: pth.Path, tool: str) -> None:
+    """Write an executable that records its name and arguments."""
+    executable = directory / tool
+    executable.write_text(
+        "#!/bin/sh\n"
+        'printf \'%s\' "${0##*/}" >> "${LINT_INVOCATION_LOG}"\n'
+        'for argument in "$@"; do\n'
+        '  printf \'\\t%s\' "${argument}" >> "${LINT_INVOCATION_LOG}"\n'
+        "done\n"
+        "printf '\\n' >> \"${LINT_INVOCATION_LOG}\"\n",
+        encoding="utf-8",
+    )
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+
+def _make_environment(
+    tmp_path: pth.Path, *, tools: cabc.Iterable[str]
+) -> tuple[dict[str, str], pth.Path]:
+    """Create a Makefile environment with only the requested fake tools."""
+    tool_directory = tmp_path / "tools"
+    tool_directory.mkdir()
+    invocation_log = tmp_path / "invocations.log"
+    for tool in tools:
+        _write_fake_tool(tool_directory, tool)
+    environment = {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "LINT_INVOCATION_LOG": str(invocation_log),
+        "PATH": f"{tool_directory}:{os.environ['PATH']}",
+    }
+    return environment, invocation_log
+
+
+def _run_make(
+    *targets: str, environment: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run fixed Makefile targets and capture their outcome."""
+    return subprocess.run(  # noqa: S603 - fixed Makefile test command.
+        ["make", *targets],  # noqa: S607 - `make` resolves from the test PATH.
+        capture_output=True,
+        check=False,
+        cwd=repo_root(),
+        env=environment,
+        text=True,
+    )
+
+
+def _lint_job() -> _LintJob:
+    """Return the CI lint job with the fields this contract requires."""
+    parsed = yaml.safe_load((repo_root() / _CI_WORKFLOW).read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict), f"{_CI_WORKFLOW} must parse to a mapping"
+    jobs = parsed.get("jobs")
+    assert isinstance(jobs, dict), f"{_CI_WORKFLOW} must declare jobs"
+    lint_job = jobs.get("lint-test")
+    assert isinstance(lint_job, dict), f"{_CI_WORKFLOW} must declare lint-test"
+    return typ.cast("_LintJob", lint_job)
+
+
+def _step_named(name: str) -> _Step:
+    """Return the named lint-job step, or report the declared step names."""
+    steps = _lint_job().get("steps")
+    assert isinstance(steps, list), "lint-test must declare a steps list"
+    matches = [step for step in steps if step.get("name") == name]
+    assert len(matches) == 1, (
+        f"expected one lint-test step named {name!r}, found {len(matches)}"
+    )
+    return matches[0]
+
+
+def test_the_workflow_lint_target_runs_both_linters(tmp_path: pth.Path) -> None:
+    """The target validates YAML policy before GitHub Actions semantics."""
+    environment, invocation_log = _make_environment(
+        tmp_path, tools=("yamllint", "actionlint")
+    )
+
+    completed = _run_make("github-actions-lint", environment=environment)
+
+    assert completed.returncode == 0, completed.stderr
+    assert invocation_log.read_text(encoding="utf-8").splitlines() == [
+        f"yamllint\t{_WORKFLOW_DIRECTORY}",
+        "actionlint",
+    ]
+
+
+def test_the_workflow_lint_target_rejects_a_missing_linter(tmp_path: pth.Path) -> None:
+    """A missing yamllint fails before Actionlint could make the target pass."""
+    environment, invocation_log = _make_environment(tmp_path, tools=("actionlint",))
+    environment["PATH"] = f"{tmp_path / 'tools'}:/usr/bin:/bin"
+
+    completed = _run_make("github-actions-lint", environment=environment)
+
+    assert completed.returncode != 0, "missing yamllint unexpectedly passed"
+    assert "Error: 'yamllint' is required, but not installed" in completed.stderr
+    assert not invocation_log.exists(), "actionlint ran after yamllint was missing"
+
+
+def test_ci_provisions_the_pinned_workflow_linters() -> None:
+    """CI caches and verifies the exact linters used by its trusted Make run."""
+    policy = (repo_root() / ".yamllint.yml").read_text(encoding="utf-8")
+    assert "allowed-values: ['true', 'false']" in policy
+    assert "check-keys: false" in policy
+    actionlint_policy = yaml.safe_load(
+        (repo_root() / ".github/actionlint.yaml").read_text(encoding="utf-8")
+    )
+    assert actionlint_policy == {
+        "self-hosted-runner": {"labels": ["ubicloud-standard-2"]},
+        "config-variables": ["CODESCENE_CLI_SHA256"],
+    }
+
+    environment = _lint_job().get("env")
+    assert isinstance(environment, dict), "lint-test must declare environment"
+    assert environment.get("YAMLLINT_VERSION") == "1.38.0"
+
+    yamllint_cache = _step_named("Cache yamllint")
+    assert (
+        yamllint_cache.get("with", {}).get("path") == ".uv-cache\n.uv-tools\n.uv-bin\n"
+    )
+
+    yamllint_install = _step_named("Install yamllint").get("run")
+    assert isinstance(yamllint_install, str), "Install yamllint must run a script"
+    assert 'uv tool install "yamllint==${YAMLLINT_VERSION}"' in yamllint_install
+    assert 'echo "${UV_TOOL_BIN_DIR}" >> "$GITHUB_PATH"' in yamllint_install
+
+    actionlint_cache = _step_named("Cache actionlint")
+    assert actionlint_cache.get("id") == "cache_actionlint"
+    assert actionlint_cache.get("with", {}).get("path") == "actionlint"
+    assert actionlint_cache.get("with", {}).get("key") == (
+        "actionlint-${{ runner.os }}-${{ runner.arch }}-1.7.12"
+    )
+
+    actionlint_download = _step_named("Download actionlint")
+    assert (
+        actionlint_download.get("if")
+        == "steps.cache_actionlint.outputs.cache-hit != 'true'"
+    )
+    download_script = actionlint_download.get("run")
+    assert isinstance(download_script, str), "Download actionlint must run a script"
+    assert "readonly ACTIONLINT_VERSION='1.7.12'" in download_script
+    assert (
+        "readonly ACTIONLINT_INSTALLER_COMMIT="
+        "'914e7df21a07ef503a81201c76d2b11c789d3fca'" in download_script
+    )
+    assert "sha256sum --check --" in download_script
+    assert (
+        'bash "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_VERSION}"' in download_script
+    )
+
+    lint_command = _step_named("Run lint").get("run")
+    assert (
+        lint_command == '/usr/bin/make ACTIONLINT="$GITHUB_WORKSPACE/actionlint" lint'
+    )

--- a/cuprum/unittests/test_workflow_lint.py
+++ b/cuprum/unittests/test_workflow_lint.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import os
 import stat
-import subprocess  # noqa: S404 - runs fixed Makefile targets under test.
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - fixed Makefile targets.
 import typing as typ
 
 import yaml
@@ -26,22 +26,34 @@ _CI_WORKFLOW = ".github/workflows/ci.yml"
 _WORKFLOW_DIRECTORY = ".github/workflows"
 _ACTIONLINT_INSTALLER_LINES = (
     "readonly ACTIONLINT_VERSION='1.7.12'",
-    "readonly ACTIONLINT_SHA256="
-    "'8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'",
+    (
+        "readonly ACTIONLINT_SHA256="
+        "'8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8'"
+    ),
     "readonly ACTIONLINT_INSTALLER_COMMIT='914e7df21a07ef503a81201c76d2b11c789d3fca'",
     'readonly ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"',
     "readonly ACTIONLINT_RAW_BASE='https://raw.githubusercontent.com/rhysd/actionlint'",
     "readonly ACTIONLINT_SCRIPT='scripts/download-actionlint.bash'",
-    'readonly ACTIONLINT_INSTALLER_URL="${ACTIONLINT_RAW_BASE}/'
-    '${ACTIONLINT_INSTALLER_COMMIT}/${ACTIONLINT_SCRIPT}"',
-    "readonly ACTIONLINT_RELEASE_ROOT="
-    "'https://github.com/rhysd/actionlint/releases/download'",
-    'readonly ACTIONLINT_RELEASE_BASE="${ACTIONLINT_RELEASE_ROOT}/'
-    'v${ACTIONLINT_VERSION}"',
-    'readonly ACTIONLINT_RELEASE_URL="${ACTIONLINT_RELEASE_BASE}/'
-    '${ACTIONLINT_ARCHIVE}"',
-    "command curl --fail --location --show-error --output "
-    '"${ACTIONLINT_INSTALLER_PATH}"',
+    (
+        'readonly ACTIONLINT_INSTALLER_URL="${ACTIONLINT_RAW_BASE}/'
+        '${ACTIONLINT_INSTALLER_COMMIT}/${ACTIONLINT_SCRIPT}"'
+    ),
+    (
+        "readonly ACTIONLINT_RELEASE_ROOT="
+        "'https://github.com/rhysd/actionlint/releases/download'"
+    ),
+    (
+        'readonly ACTIONLINT_RELEASE_BASE="${ACTIONLINT_RELEASE_ROOT}/'
+        'v${ACTIONLINT_VERSION}"'
+    ),
+    (
+        'readonly ACTIONLINT_RELEASE_URL="${ACTIONLINT_RELEASE_BASE}/'
+        '${ACTIONLINT_ARCHIVE}"'
+    ),
+    (
+        "command curl --fail --location --show-error --output "
+        '"${ACTIONLINT_INSTALLER_PATH}"'
+    ),
     'command curl --fail --location --show-error --output "${ACTIONLINT_ARCHIVE_PATH}"',
     "sha256sum --check --",
     'bash "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_VERSION}"',
@@ -116,8 +128,8 @@ def _run_make(
     *targets: str, environment: dict[str, str]
 ) -> subprocess.CompletedProcess[str]:
     """Run fixed Makefile targets and capture their outcome."""
-    return subprocess.run(  # noqa: S603 - fixed Makefile test command.
-        ["make", *targets],  # noqa: S607 - `make` resolves from the test PATH.
+    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - fixed command.
+        ["make", *targets],  # ruff: ignore[start-process-with-partial-path] - test PATH.
         capture_output=True,
         check=False,
         cwd=repo_root(),
@@ -147,6 +159,7 @@ def _step_named(name: str) -> _Step:
     )
     return matches[0]
 
+
 def _assert_yamllint_provisioning() -> None:
     """Assert that CI installs the pinned yamllint executable on PATH."""
     environment = _lint_job().get("env")
@@ -165,6 +178,7 @@ def _assert_yamllint_provisioning() -> None:
     assert isinstance(yamllint_install, str), "Install yamllint must run a script"
     assert 'uv tool install "yamllint==${YAMLLINT_VERSION}"' in yamllint_install
     assert 'echo "${UV_TOOL_BIN_DIR}" >> "$GITHUB_PATH"' in yamllint_install
+
 
 def _assert_actionlint_provisioning() -> None:
     """Assert that CI verifies actionlint before its installer can run."""
@@ -192,6 +206,7 @@ def _assert_actionlint_provisioning() -> None:
         'bash "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_VERSION}"'
     )
 
+
 def _assert_linter_step_order() -> None:
     """Assert that CI provisions both linters before invoking Make."""
     step_names = [
@@ -211,6 +226,8 @@ def _assert_linter_step_order() -> None:
         for name in step_names
     ]
     assert positions == sorted(positions)
+
+
 def test_the_workflow_lint_target_runs_both_linters(tmp_path: pth.Path) -> None:
     """The target validates YAML policy before GitHub Actions semantics."""
     environment, invocation_log = _make_environment(
@@ -237,6 +254,7 @@ def test_the_workflow_lint_target_rejects_a_missing_linter(tmp_path: pth.Path) -
     assert "Error: 'yamllint' is required, but not installed" in completed.stderr
     assert not invocation_log.exists(), "actionlint ran after yamllint was missing"
 
+
 def test_the_workflow_lint_target_rejects_actionlint_failure(
     tmp_path: pth.Path,
 ) -> None:
@@ -256,6 +274,7 @@ def test_the_workflow_lint_target_rejects_actionlint_failure(
         "actionlint",
     ]
 
+
 def test_all_workflows_declare_yaml_document_starts() -> None:
     """The shared YAML policy has a compatible marker in every workflow."""
     workflow_paths = sorted((repo_root() / _WORKFLOW_DIRECTORY).glob("*.yml"))
@@ -266,6 +285,8 @@ def test_all_workflows_declare_yaml_document_starts() -> None:
             f"{workflow_path.relative_to(repo_root())} must begin with a YAML "
             "document start"
         )
+
+
 def test_ci_provisions_the_pinned_workflow_linters() -> None:
     """CI caches and verifies the exact linters used by its trusted Make run."""
     policy = yaml.safe_load((repo_root() / ".yamllint.yml").read_text(encoding="utf-8"))

--- a/cuprum/unittests/test_workflow_lint.py
+++ b/cuprum/unittests/test_workflow_lint.py
@@ -119,17 +119,22 @@ def _make_environment(
         **os.environ,
         "HOME": str(tmp_path / "home"),
         "LINT_INVOCATION_LOG": str(invocation_log),
-        "PATH": f"{tool_directory}:{os.environ['PATH']}",
+        "PATH": os.pathsep.join((str(tool_directory), os.defpath)),
     }
     return environment, invocation_log
 
 
 def _run_make(
-    *targets: str, environment: dict[str, str]
+    *targets: str,
+    environment: dict[str, str],
+    makefiles: cabc.Iterable[pth.Path] = (),
 ) -> subprocess.CompletedProcess[str]:
     """Run fixed Makefile targets and capture their outcome."""
+    command = ["make"]
+    for makefile in makefiles:
+        command.extend(("-f", str(makefile)))
     return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - fixed command.
-        ["make", *targets],  # ruff: ignore[start-process-with-partial-path] - test PATH.
+        [*command, *targets],
         capture_output=True,
         check=False,
         cwd=repo_root(),
@@ -202,6 +207,10 @@ def _assert_actionlint_provisioning() -> None:
     assert actionlint_download.get("shell") == "bash"
     for expected_script_line in _ACTIONLINT_INSTALLER_LINES:
         assert expected_script_line in download_script
+    assert (
+        "printf '%s  %s\\n' \"${ACTIONLINT_SHA256}\" "
+        '"${ACTIONLINT_ARCHIVE_PATH}" | sha256sum --check --'
+    ) in download_script
     assert download_script.index("sha256sum --check --") < download_script.index(
         'bash "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_VERSION}"'
     )
@@ -243,10 +252,35 @@ def test_the_workflow_lint_target_runs_both_linters(tmp_path: pth.Path) -> None:
     ]
 
 
+def test_the_lint_target_runs_the_workflow_linters(tmp_path: pth.Path) -> None:
+    """The aggregate lint target reaches both GitHub Actions linters."""
+    environment, invocation_log = _make_environment(
+        tmp_path, tools=("uv", "yamllint", "actionlint")
+    )
+    overrides = tmp_path / "lint-target-overrides.mk"
+    overrides.write_text(
+        ".PHONY: python-lint rust-lint\npython-lint:\n\t@:\nrust-lint:\n\t@:\n",
+        encoding="utf-8",
+    )
+
+    completed = _run_make(
+        "lint",
+        environment=environment,
+        makefiles=(repo_root() / "Makefile", overrides),
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert invocation_log.read_text(encoding="utf-8").splitlines() == [
+        "uv\trun\twhich\truff",
+        f"yamllint\t--config-file\t.yamllint.yml\t{_WORKFLOW_DIRECTORY}",
+        "actionlint",
+    ]
+
+
 def test_the_workflow_lint_target_rejects_a_missing_linter(tmp_path: pth.Path) -> None:
     """A missing yamllint fails before Actionlint could make the target pass."""
     environment, invocation_log = _make_environment(tmp_path, tools=("actionlint",))
-    environment["PATH"] = f"{tmp_path / 'tools'}:/usr/bin:/bin"
+    environment["PATH"] = os.pathsep.join((str(tmp_path / "tools"), os.defpath))
 
     completed = _run_make("github-actions-lint", environment=environment)
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2669,10 +2669,12 @@ assertion, alias, suppression rationale, or dispatch structure instead.
 
 ### GitHub Actions workflow linting
 
-`make lint` finishes by running `yamllint .github/workflows` and `actionlint`.
+`make lint` finishes by running
+`yamllint --config-file .yamllint.yml .github/workflows` and `actionlint`.
 Together they validate YAML policy, GitHub Actions expressions, and shell used
-by workflow `run:` steps. `.yamllint.yml` permits GitHub's unquoted `on`
-trigger key while requiring quoted `'true'` and `'false'` values.
+by workflow `run:` steps. `.yamllint.yml` requires each workflow to start with
+`---`, permits GitHub's unquoted `on` trigger key, and requires quoted `'true'`
+and `'false'` values.
 
 Install yamllint locally with `uv tool install "yamllint==1.38.0"`, then
 install actionlint using its [upstream installation

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2666,7 +2666,6 @@ fix findings in execution order, then rerun `make lint` to reach the next
 stage. Do not disable df12 messages to absorb existing findings; repair the
 assertion, alias, suppression rationale, or dispatch structure instead.
 
-
 ### GitHub Actions workflow linting
 
 `make lint` finishes by running
@@ -2677,8 +2676,8 @@ by workflow `run:` steps. `.yamllint.yml` requires each workflow to start with
 and `'false'` values.
 
 Install yamllint locally with `uv tool install "yamllint==1.38.0"`, then
-install actionlint using its [upstream installation
-instructions](https://github.com/rhysd/actionlint/blob/main/README.md#installation).
+install actionlint using its
+[upstream installation instructions](https://github.com/rhysd/actionlint/blob/main/README.md#installation).
 Both commands must be available on `PATH` before running `make lint`.
 
 CI caches the `uv` cache, tool environment, and executable directory before

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2666,6 +2666,27 @@ fix findings in execution order, then rerun `make lint` to reach the next
 stage. Do not disable df12 messages to absorb existing findings; repair the
 assertion, alias, suppression rationale, or dispatch structure instead.
 
+
+### GitHub Actions workflow linting
+
+`make lint` finishes by running `yamllint .github/workflows` and `actionlint`.
+Together they validate YAML policy, GitHub Actions expressions, and shell used
+by workflow `run:` steps. `.yamllint.yml` permits GitHub's unquoted `on`
+trigger key while requiring quoted `'true'` and `'false'` values.
+
+Install yamllint locally with `uv tool install "yamllint==1.38.0"`, then
+install actionlint using its [upstream installation
+instructions](https://github.com/rhysd/actionlint/blob/main/README.md#installation).
+Both commands must be available on `PATH` before running `make lint`.
+
+CI caches the `uv` cache, tool environment, and executable directory before
+installing yamllint. It separately caches actionlint 1.7.12; on a cache miss,
+it downloads the archive through actionlint's installer pinned to commit
+`914e7df21a07ef503a81201c76d2b11c789d3fca` and verifies SHA-256
+`8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8` before
+extraction. The lint job invokes trusted `/usr/bin/make` and passes actionlint
+by absolute `ACTIONLINT` path, so checkout contents cannot shadow `make`.
+
 ### Spelling policy
 
 The lint and Markdown gates run pinned `typos` 1.48.0 with British English and


### PR DESCRIPTION
## Summary

This branch makes GitHub Actions validation part of Cuprum's standard lint gate, catching workflow YAML, Actions semantics, and run-step shell errors before CI. The follow-up hardening requires a YAML document start in every workflow, invokes yamllint with the repository policy explicitly, and locks those properties behind regression tests.

Closes #313.

## Review walkthrough

- The [Makefile lint integration](https://github.com/leynos/cuprum/blob/import-catnap-github-actions-validation/Makefile#L184) runs yamllint with `.yamllint.yml` before actionlint as part of `make lint`.
- The [Yamllint policy](https://github.com/leynos/cuprum/blob/import-catnap-github-actions-validation/.yamllint.yml#L1) retains GitHub's unquoted `on` trigger support while requiring `---` document starts. [Actionlint configuration](https://github.com/leynos/cuprum/blob/import-catnap-github-actions-validation/.github/actionlint.yaml#L1) recognises Cuprum's custom runner.
- The [CI lint job](https://github.com/leynos/cuprum/blob/import-catnap-github-actions-validation/.github/workflows/ci.yml#L36) caches and pins both linters; actionlint's archive is checksum-verified before its pinned installer runs.
- The [workflow-lint contracts](https://github.com/leynos/cuprum/blob/import-catnap-github-actions-validation/cuprum/unittests/test_workflow_lint.py#L219) cover explicit policy invocation, document starts, actionlint failure propagation, provisioning integrity, and install order.
- [Developer guidance](https://github.com/leynos/cuprum/blob/import-catnap-github-actions-validation/docs/developers-guide.md#L2278) documents the enforced policy and local command.

## Validation

- `make github-actions-lint`
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie`
- `git diff --check`

## Notes

- `checkmake Makefile` retains six pre-existing findings in untouched targets; the added target introduces none.

## References

- Issue: [#313](https://github.com/leynos/cuprum/issues/313)
- Lody session: [1e8eb685-b398-4dd3-b702-e5dacc011224](https://lody.ai/leynos/sessions/1e8eb685-b398-4dd3-b702-e5dacc011224)

## Summary by Sourcery

Make GitHub Actions workflow validation part of the repository's standard lint gate.

New Features:
- Add GitHub Actions workflow validation to the standard lint gate using yamllint and actionlint.

Bug Fixes:
- Harden workflow package verification so failures stop subsequent checks.
- Require all GitHub Actions workflows to include explicit YAML document starts.

Enhancements:
- Define repository-specific YAML and actionlint policies, including support for GitHub's unquoted `on` trigger key and custom runners.
- Pin, cache, and integrity-check workflow linter provisioning in CI.
- Add regression coverage for linter invocation, provisioning, workflow formatting, and wheel verification.

CI:
- Integrate cached yamllint and checksum-verified actionlint installation into the CI lint job.

Documentation:
- Document local GitHub Actions linting requirements and CI linter provisioning for developers.

Tests:
- Add contract tests covering workflow linting behavior, CI provisioning, document starts, and wheel verification failure handling.