### PR TITLE
Format Markdown documents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MBAKE_VERSION: '1.4.6'
-      MDTABLEFIX_VERSION: '0.5.0'
-      MDTABLEFIX_RUST_VERSION: '1.89.0'
+      MDTABLEFIX_VERSION: '0.5.1'
       WHITAKER_INSTALLER_VERSION: '0.2.7'
     steps:
       - name: Check out repository
@@ -152,7 +151,7 @@ jobs:
       # Cargo registry nor `target/${BUILD_PROFILE}`. This job owns the
       # registry; nothing owns `target`, because sccache owns compiler output.
       - name: Install Rust toolchain
-        uses: leynos/shared-actions/.github/actions/setup-rust@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/setup-rust@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         with:
           toolchain: '1.85.0'
           cache-provider: external
@@ -162,32 +161,16 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
-            ~/.cargo/bin/mdtablefix
-            ~/.cargo/bin/mdtablefix.exe
-          key: mdtablefix-${{ runner.os }}-${{ runner.arch }}-${{ env.UBUNTU_RELEASE }}-${{ env.CACHE_GENERATION }}-${{ env.MDTABLEFIX_VERSION }}-${{ env.MDTABLEFIX_RUST_VERSION }}
+            ~/.local/bin/mdtablefix
+            ~/.local/bin/mdtablefix.exe
+          key: mdtablefix-${{ runner.os }}-${{ runner.arch }}-${{ env.UBUNTU_RELEASE }}-${{ env.CACHE_GENERATION }}-${{ env.MDTABLEFIX_VERSION }}
 
       - name: Install mdtablefix
-        run: |
-          expected_mdtablefix_version="mdtablefix ${MDTABLEFIX_VERSION}"
-          installed_mdtablefix_version=""
-          if command -v mdtablefix >/dev/null 2>&1; then
-          installed_mdtablefix_version=$(mdtablefix --version 2>/dev/null | tr -d '\r')
-          fi
-          if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then
-            if cargo binstall -V >/dev/null 2>&1; then
-              cargo binstall --no-confirm --locked "mdtablefix@${MDTABLEFIX_VERSION}"
-            else
-              echo "cargo-binstall unavailable; building mdtablefix from crates.io"
-              rustup toolchain install --profile minimal "${MDTABLEFIX_RUST_VERSION}"
-              cargo +"${MDTABLEFIX_RUST_VERSION}" install --locked mdtablefix \
-                --version "${MDTABLEFIX_VERSION}"
-            fi
-          fi
-          installed_mdtablefix_version=$(mdtablefix --version | tr -d '\r')
-          if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then
-            echo "expected ${expected_mdtablefix_version}, got ${installed_mdtablefix_version}" >&2
-            exit 1
-          fi
+        # The shared action accepts only releases with correct multi-platform
+        # metadata and fails closed instead of compiling a formatter in CI.
+        uses: leynos/shared-actions/.github/actions/install-mdtablefix@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
+        with:
+          version: ${{ env.MDTABLEFIX_VERSION }}
 
       - name: Cache Whitaker installation
         id: cache-whitaker
@@ -426,7 +409,7 @@ jobs:
           enable-cache: false
 
       - name: Install Rust toolchain
-        uses: leynos/shared-actions/.github/actions/setup-rust@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/setup-rust@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         with:
           toolchain: '1.85.0'
           cache-provider: external
@@ -626,7 +609,7 @@ jobs:
       # pinned toolchain the other Rust-touching jobs use rather than whatever
       # the runner image happens to ship.
       - name: Install Rust toolchain
-        uses: leynos/shared-actions/.github/actions/setup-rust@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/setup-rust@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         with:
           toolchain: '1.85.0'
           cache-provider: external
@@ -836,7 +819,7 @@ jobs:
           enable-cache: false
 
       - name: Install Rust toolchain
-        uses: leynos/shared-actions/.github/actions/setup-rust@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/setup-rust@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         with:
           toolchain: '1.85.0'
           cache-provider: external
@@ -860,7 +843,7 @@ jobs:
       # treats changes within one percentage point as measurement noise.
       #
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/generate-coverage@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         env:
           # The same warnings posture and the same core budget the
           # uninstrumented run used.
@@ -892,7 +875,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         with:
           format: cobertura
           mode: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           installed_mdtablefix_version=$(mdtablefix --version 2>/dev/null | tr -d '\r')
           fi
           if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then
-            if cargo binstall --version >/dev/null 2>&1; then
+            if cargo binstall -V >/dev/null 2>&1; then
               cargo binstall --no-confirm --locked "mdtablefix@${MDTABLEFIX_VERSION}"
             else
               echo "cargo-binstall unavailable; building mdtablefix from crates.io"
@@ -203,7 +203,7 @@ jobs:
       - name: Install Whitaker
         run: |
           if [ "${{ steps.cache-whitaker.outputs.cache-hit }}" != "true" ]; then
-            if cargo binstall --version >/dev/null 2>&1; then
+            if cargo binstall -V >/dev/null 2>&1; then
               cargo binstall --no-confirm --locked \
                 --disable-strategies compile \
                 --git https://github.com/leynos/whitaker \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     env:
       MBAKE_VERSION: '1.4.6'
       MDTABLEFIX_VERSION: '0.5.0'
-      MDTABLEFIX_RUST_TOOLCHAIN: '1.89.0'
+      MDTABLEFIX_RUST_VERSION: '1.89.0'
       WHITAKER_INSTALLER_VERSION: '0.2.7'
     steps:
       - name: Check out repository
@@ -164,7 +164,7 @@ jobs:
           path: |
             ~/.cargo/bin/mdtablefix
             ~/.cargo/bin/mdtablefix.exe
-          key: mdtablefix-${{ runner.os }}-${{ runner.arch }}-${{ env.MDTABLEFIX_VERSION }}
+          key: mdtablefix-${{ runner.os }}-${{ runner.arch }}-${{ env.MDTABLEFIX_VERSION }}-${{ env.MDTABLEFIX_RUST_VERSION }}
 
       - name: Install mdtablefix
         run: |
@@ -174,9 +174,14 @@ jobs:
             installed_mdtablefix_version="$(mdtablefix --version 2>/dev/null | tr -d '\r')"
           fi
           if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then
-            rustup toolchain install "${MDTABLEFIX_RUST_TOOLCHAIN}" --profile minimal
-            cargo +"${MDTABLEFIX_RUST_TOOLCHAIN}" install --locked mdtablefix \
-              --version "${MDTABLEFIX_VERSION}"
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "mdtablefix@${MDTABLEFIX_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building mdtablefix from crates.io"
+              rustup toolchain install --profile minimal "${MDTABLEFIX_RUST_VERSION}"
+              cargo +"${MDTABLEFIX_RUST_VERSION}" install --locked mdtablefix \
+                --version "${MDTABLEFIX_VERSION}"
+            fi
           fi
           installed_mdtablefix_version="$(mdtablefix --version | tr -d '\r')"
           if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           path: |
             ~/.cargo/bin/mdtablefix
             ~/.cargo/bin/mdtablefix.exe
-          key: mdtablefix-${{ runner.os }}-${{ runner.arch }}-${{ env.MDTABLEFIX_VERSION }}-${{ env.MDTABLEFIX_RUST_VERSION }}
+          key: mdtablefix-${{ runner.os }}-${{ runner.arch }}-${{ env.UBUNTU_RELEASE }}-${{ env.CACHE_GENERATION }}-${{ env.MDTABLEFIX_VERSION }}-${{ env.MDTABLEFIX_RUST_VERSION }}
 
       - name: Install mdtablefix
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     env:
       MBAKE_VERSION: '1.4.6'
       MDTABLEFIX_VERSION: '0.5.0'
+      MDTABLEFIX_RUST_TOOLCHAIN: '1.89.0'
       WHITAKER_INSTALLER_VERSION: '0.2.7'
     steps:
       - name: Check out repository
@@ -163,7 +164,6 @@ jobs:
           path: |
             ~/.cargo/bin/mdtablefix
             ~/.cargo/bin/mdtablefix.exe
-            ~/.cache/cargo-binstall
           key: mdtablefix-${{ runner.os }}-${{ runner.arch }}-${{ env.MDTABLEFIX_VERSION }}
 
       - name: Install mdtablefix
@@ -174,12 +174,9 @@ jobs:
             installed_mdtablefix_version="$(mdtablefix --version 2>/dev/null | tr -d '\r')"
           fi
           if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then
-            if cargo binstall --version >/dev/null 2>&1; then
-              cargo binstall --no-confirm --locked "mdtablefix@${MDTABLEFIX_VERSION}"
-            else
-              echo "cargo-binstall unavailable; building mdtablefix from crates.io"
-              cargo install --locked mdtablefix --version "${MDTABLEFIX_VERSION}"
-            fi
+            rustup toolchain install "${MDTABLEFIX_RUST_TOOLCHAIN}" --profile minimal
+            cargo +"${MDTABLEFIX_RUST_TOOLCHAIN}" install --locked mdtablefix \
+              --version "${MDTABLEFIX_VERSION}"
           fi
           installed_mdtablefix_version="$(mdtablefix --version | tr -d '\r')"
           if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
           expected_mdtablefix_version="mdtablefix ${MDTABLEFIX_VERSION}"
           installed_mdtablefix_version=""
           if command -v mdtablefix >/dev/null 2>&1; then
-            installed_mdtablefix_version="$(mdtablefix --version 2>/dev/null | tr -d '\r')"
+          installed_mdtablefix_version=$(mdtablefix --version 2>/dev/null | tr -d '\r')
           fi
           if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then
             if cargo binstall --version >/dev/null 2>&1; then
@@ -183,7 +183,7 @@ jobs:
                 --version "${MDTABLEFIX_VERSION}"
             fi
           fi
-          installed_mdtablefix_version="$(mdtablefix --version | tr -d '\r')"
+          installed_mdtablefix_version=$(mdtablefix --version | tr -d '\r')
           if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then
             echo "expected ${expected_mdtablefix_version}, got ${installed_mdtablefix_version}" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MBAKE_VERSION: '1.4.6'
+      MDTABLEFIX_VERSION: '0.5.0'
       WHITAKER_INSTALLER_VERSION: '0.2.7'
     steps:
       - name: Check out repository
@@ -156,6 +157,36 @@ jobs:
           cache-provider: external
           use-sccache: 'false'
 
+      - name: Cache mdtablefix
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            ~/.cargo/bin/mdtablefix
+            ~/.cargo/bin/mdtablefix.exe
+            ~/.cache/cargo-binstall
+          key: mdtablefix-${{ runner.os }}-${{ runner.arch }}-${{ env.MDTABLEFIX_VERSION }}
+
+      - name: Install mdtablefix
+        run: |
+          expected_mdtablefix_version="mdtablefix ${MDTABLEFIX_VERSION}"
+          installed_mdtablefix_version=""
+          if command -v mdtablefix >/dev/null 2>&1; then
+            installed_mdtablefix_version="$(mdtablefix --version 2>/dev/null | tr -d '\r')"
+          fi
+          if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "mdtablefix@${MDTABLEFIX_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building mdtablefix from crates.io"
+              cargo install --locked mdtablefix --version "${MDTABLEFIX_VERSION}"
+            fi
+          fi
+          installed_mdtablefix_version="$(mdtablefix --version | tr -d '\r')"
+          if [[ "${installed_mdtablefix_version}" != "${expected_mdtablefix_version}" ]]; then
+            echo "expected ${expected_mdtablefix_version}, got ${installed_mdtablefix_version}" >&2
+            exit 1
+          fi
+
       - name: Cache Whitaker installation
         id: cache-whitaker
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -188,6 +219,9 @@ jobs:
 
       - name: Install code
         run: make build
+
+      - name: Markdown formatter checker tests
+        run: make test-markdown-format
 
       - name: Check formatting
         run: make check-fmt

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -146,7 +146,7 @@ jobs:
       # same pinned toolchain the pull-request coverage job uses rather than
       # whatever the runner image ships.
       - name: Install Rust toolchain
-        uses: leynos/shared-actions/.github/actions/setup-rust@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/setup-rust@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         with:
           toolchain: '1.85.0'
           cache-provider: external
@@ -164,7 +164,7 @@ jobs:
       # The pinned action writes a run-specific baseline cache entry and treats
       # changes within one percentage point as measurement noise.
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@f6d4d5f549655c118f86f371b8d55c200d3efa50
+        uses: leynos/shared-actions/.github/actions/generate-coverage@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         env:
           # The same warnings posture and the same core budget the
           # uninstrumented run used.
@@ -196,7 +196,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         with:
           format: cobertura
           path: coverage.xml

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@6b9dc1be1b8bfb585ddd0083d50b9d6597cd902e
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@6b9dc1be1b8bfb585ddd0083d50b9d6597cd902e
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
     with:
       # Flat layout: the mutable source is the cuprum/ package at the
       # repository root, so change detection watches it directly.

--- a/.rules/python-pyproject.md
+++ b/.rules/python-pyproject.md
@@ -81,11 +81,11 @@ exists on a contributor's machine.
 
 Table 1. Dependency field selection.
 
-| Field | Installed for | Use it for |
-| --- | --- | --- |
-| `project.dependencies` | Everyone who installs the package | Libraries the shipped code imports at runtime |
-| `project.optional-dependencies` | End users who opt into an *extra* | Optional runtime *features* (`package[extra]`) |
-| `dependency-groups` | Local development only | Test, lint, type-check, docs, and other tooling |
+| Field                           | Installed for                     | Use it for                                      |
+| ------------------------------- | --------------------------------- | ----------------------------------------------- |
+| `project.dependencies`          | Everyone who installs the package | Libraries the shipped code imports at runtime   |
+| `project.optional-dependencies` | End users who opt into an *extra* | Optional runtime *features* (`package[extra]`)  |
+| `dependency-groups`             | Local development only            | Test, lint, type-check, docs, and other tooling |
 
 ### Required runtime dependencies — `project.dependencies`
 
@@ -121,9 +121,9 @@ feature = [
 Tooling only contributors need: test frameworks, linters, type checkers,
 documentation builders, and property or mutation testers. These are
 **local-only** — PEP 735 dependency groups are *not* included in published
-package metadata (they are not part of the wheel), so they must live here rather
-than in `project.optional-dependencies`. Add them with `uv add --dev` (the
-`dev` group) or `uv add --group <name>`:
+package metadata (they are not part of the wheel), so they must live here
+rather than in `project.optional-dependencies`. Add them with `uv add --dev`
+(the `dev` group) or `uv add --group <name>`:
 
 ```toml
 [dependency-groups]
@@ -152,8 +152,7 @@ default-groups = ["dev", "docs"]  # or "all"
 Groups may nest via `{ include-group = "..." }`, and by default `uv` resolves
 every group together into a single `uv.lock`, so groups must be mutually
 compatible unless you declare incompatible sets explicitly under
-`[tool.uv].conflicts`.
-(Astral Docs[^6])
+`[tool.uv].conflicts`. (Astral Docs[^6])
 
 > **Rule of thumb:** if an end user needs it to *run* the code, it belongs
 > in `project.dependencies` (always) or `project.optional-dependencies`
@@ -201,8 +200,8 @@ build-backend = "setuptools.build_meta"
 ```
 
 - **`requires`:** A list of packages needed at build time. For editable installs
-  in `uv`, you need at least `setuptools>=61.0` and `wheel`. (Python
-  Packaging[^4], Astral Docs[^7])
+  in `uv`, you need at least `setuptools>=61.0` and `wheel`. (Python Packaging
+  [^4], Astral Docs[^7])
 - **`build-backend`:** The entry point for your build backend.
   `setuptools.build_meta` is the PEP 517-compliant backend for setuptools.
   (Python Packaging[^4], Astral Docs[^7])

--- a/.rules/python-return.md
+++ b/.rules/python-return.md
@@ -60,10 +60,11 @@ def func(x):
     return -1
 ```
 
-Don't rely on implicit `None` if the function may return a value elsewhere—always
-return something at the end.
+Don't rely on implicit `None` if the function may return a value
+elsewhere—always return something at the end.
 
-Functions whose only possible result is `None` do not need a final bare `return`:
+Functions whose only possible result is `None` do not need a final bare
+`return`:
 
 ```python
 # GOOD:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,11 @@
   is separate from `sh.observe`, so an existing observer is untouched.
 - **Native Rust-pump cleanup telemetry:** Add `cleanup_started` and
   `cleanup_completed` `PumpEvent` phases, with completion-only
-  `PumpEvent.duration_s`, the unlabelled
-  `cuprum_rust_pump_cleanup_total` counter and
-  `cuprum_rust_pump_cleanup_duration_seconds` histogram, and cleanup `DEBUG`
-  records. The native worker retains descriptor ownership until cleanup
-  completes, so these events and records describe the cancellation-cleanup
-  contract.
+  `PumpEvent.duration_s`, the unlabelled `cuprum_rust_pump_cleanup_total`
+  counter and `cuprum_rust_pump_cleanup_duration_seconds` histogram, and the
+  cleanup `DEBUG` records. The native worker retains descriptor ownership until
+  cleanup completes, so these events and records describe the
+  cancellation-cleanup contract.
 - **`PumpEvent`:** The frozen event a pump hook receives, carrying the routing
   `phase` and, for a decline, the `reason` for the decline.
 - **`PumpHook`:** The synchronous callable type a pump observer must satisfy.
@@ -69,9 +68,9 @@
 
 - **`ProgramCatalogue.visible_settings` is now a property:** Prefer
   `catalogue.visible_settings` over the former callable spelling. Existing
-  `catalogue.visible_settings()` callers remain supported during the
-  next-minor migration and receive the same cached, read-only mapping of
-  project names to `ProjectSettings`
+  `catalogue.visible_settings()` callers remain supported during the next-minor
+  migration and receive the same cached, read-only mapping of project names to
+  `ProjectSettings`
   ([`079d6698`](https://github.com/leynos/cuprum/commit/079d6698cfdc833928628b0c3278a5cb7d646d9b)).
 - **New `ExecPhase` value (breaking for fail-closed hooks):** `ExecPhase` gains
   `pipeline_fail_fast`. Observe hooks that match exhaustively on phase and

--- a/Makefile
+++ b/Makefile
@@ -192,10 +192,15 @@ fmt: ruff $(MDFORMAT_ALL) ## Format sources
 check-fmt: ruff ## Verify formatting
 	$(RUFF) format --check
 	cd $(RUST_DIR) && $(CARGO) fmt --all -- --check
-	@$(MD_FILES_FIND) | xargs -0 sh -c '\
+	@markdown_files="$$(mktemp)" || exit $$?; \
+	trap 'rm -f "$$markdown_files"' 0; \
+	if ! $(MD_FILES_FIND) > "$$markdown_files"; then \
+		exit 1; \
+	fi; \
+	xargs -0 sh -c '\
 		if [ "$$#" -gt 0 ]; then \
 			scripts/check-markdown-format.sh "$$@"; \
-		fi' sh
+		fi' sh < "$$markdown_files"
 
 test-markdown-format: ## Validate the Markdown formatter checker
 	@PYTHONPATH=scripts $(UV_RUN_ENV) uv run --no-project --python 3.13 \

--- a/Makefile
+++ b/Makefile
@@ -118,12 +118,21 @@ DF12_PYLINT = $(PYLINT_ENV) $(UV_RUN_ENV) uv run --isolated \
   --disable=all --load-plugins=df12_python_lints \
   --enable=$(DF12_PYLINT_MESSAGES)
 AMBRLEAKS = $(UV_RUN_ENV) uv run --python $(DF12_PYTHON) ambrleaks
+# Markdown files, excluding build output and tool caches.
+MD_FILES_FIND = find . -type f -name '*.md' \
+	-not -path '*/target/*' -not -path './.venv/*' \
+	-not -path './.vtcode/*' -not -path './memories/*' \
+	-not -path './.pytest_cache/*' \
+	-not -path './.uv-cache/*' \
+	-not -path './.uv-tools/*' \
+	-not -path './.node_modules/*' \
+	-not -path './node_modules/*' -print0
 
 .PHONY: help all clean build build-release lint python-lint rust-lint \
         lint-windows fmt check-fmt \
         markdownlint spelling spelling-config spelling-helper-test \
         _run_spelling_gate nixie test test-python test-rust typecheck \
-        test-extension develop \
+        test-extension test-markdown-format develop \
         benchmark-micro benchmark-e2e \
         $(TOOLS) $(VENV_TOOLS)
 .NOTPARALLEL: lint
@@ -190,7 +199,16 @@ fmt: ruff $(MDFORMAT_ALL) ## Format sources
 check-fmt: ruff ## Verify formatting
 	$(RUFF) format --check
 	cd $(RUST_DIR) && $(CARGO) fmt --all -- --check
-	# mdformat-all doesn't currently do checking
+	@$(MD_FILES_FIND) | xargs -0 sh -c '\
+		if [ "$$#" -gt 0 ]; then \
+			scripts/check-markdown-format.sh "$$@"; \
+		fi' sh
+
+test-markdown-format: ## Validate the Markdown formatter checker
+	@PYTHONPATH=scripts $(UV_RUN_ENV) uv run --no-project --python 3.13 \
+		--with pytest==9.0.2 --with hypothesis==6.151.9 \
+		python -m pytest scripts/tests/test_check_markdown_format.py -c /dev/null \
+		--rootdir=. -p no:cacheprovider
 
 lint: python-lint rust-lint ## Run Python and Rust linters
 

--- a/Makefile
+++ b/Makefile
@@ -118,15 +118,8 @@ DF12_PYLINT = $(PYLINT_ENV) $(UV_RUN_ENV) uv run --isolated \
   --disable=all --load-plugins=df12_python_lints \
   --enable=$(DF12_PYLINT_MESSAGES)
 AMBRLEAKS = $(UV_RUN_ENV) uv run --python $(DF12_PYTHON) ambrleaks
-# Markdown files, excluding build output and tool caches.
-MD_FILES_FIND = find . -type f -name '*.md' \
-	-not -path '*/target/*' -not -path './.venv/*' \
-	-not -path './.vtcode/*' -not -path './memories/*' \
-	-not -path './.pytest_cache/*' \
-	-not -path './.uv-cache/*' \
-	-not -path './.uv-tools/*' \
-	-not -path './.node_modules/*' \
-	-not -path './node_modules/*' -print0
+# Tracked Markdown files, NUL-delimited for safe transport to the formatter.
+MD_FILES_FIND = git ls-files -z -- '*.md'
 
 .PHONY: help all clean build build-release lint python-lint rust-lint \
         lint-windows fmt check-fmt \

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,10 @@ DF12_PYLINT = $(PYLINT_ENV) $(UV_RUN_ENV) uv run --isolated \
   --disable=all --load-plugins=df12_python_lints \
   --enable=$(DF12_PYLINT_MESSAGES)
 AMBRLEAKS = $(UV_RUN_ENV) uv run --python $(DF12_PYTHON) ambrleaks
-# Tracked Markdown files, NUL-delimited for safe transport to the formatter.
-MD_FILES_FIND = git ls-files -z -- '*.md'
+# Existing tracked Markdown files, NUL-delimited for safe transport to the
+# formatter. `pipefail` preserves the check-fmt gate's fail-closed behaviour
+# when Git cannot enumerate its index.
+MD_FILES_FIND = bash -o pipefail -c 'git ls-files -z -- "$$1" | while IFS= read -r -d "" markdown_file; do if [ -e "$$markdown_file" ]; then printf "%s\0" "$$markdown_file"; fi; done' -- '*.md'
 
 .PHONY: help all clean build build-release lint python-lint rust-lint \
         lint-windows fmt check-fmt \

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -143,6 +143,7 @@
       'cuprum/unittests/test_maturin_build.py',
       'cuprum/unittests/test_maturin_pins.py',
       'cuprum/unittests/test_maturin_toolchain.py',
+      'cuprum/unittests/test_mdtablefix_ci_installer.py',
       'cuprum/unittests/test_metrics_adapter.py',
       'cuprum/unittests/test_metrics_adapter_stateful.py',
       'cuprum/unittests/test_native_pump_cleanup_stateful.py',

--- a/cuprum/unittests/test_mdtablefix_ci_installer.py
+++ b/cuprum/unittests/test_mdtablefix_ci_installer.py
@@ -1,0 +1,160 @@
+"""Process-boundary contracts for CI's mdtablefix installer branches."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - executes the checked-in CI script.
+import typing as typ
+
+import pytest
+
+from tests.helpers.workflow import Workflow, step_named
+
+if typ.TYPE_CHECKING:
+    import pathlib as pth
+
+
+def _installer_script(workflow_data: Workflow) -> str:
+    """Return the checked-in mdtablefix installer script."""
+    step = step_named(workflow_data, "lint-test", "Install mdtablefix")
+    script = step.get("run")
+    assert isinstance(script, str), "the Install mdtablefix CI step must run a script"
+    return script
+
+
+def _write_command_stub(directory: pth.Path, name: str, body: str) -> pth.Path:
+    """Create an executable command stub with the given shell body."""
+    command = directory / name
+    command.write_text(f"#!/bin/sh\n{body}", encoding="utf-8")
+    command.chmod(0o755)
+    return command
+
+
+def _install_command_stubs(directory: pth.Path) -> None:
+    """Install the controlled cargo, rustup, and mdtablefix command stubs."""
+    _write_command_stub(
+        directory,
+        "cargo",
+        """\
+printf 'cargo' >> "$INSTALLER_LOG"
+printf ' %s' "$@" >> "$INSTALLER_LOG"
+printf '\\n' >> "$INSTALLER_LOG"
+if [ "$1" = binstall ] && [ "$2" = -V ]; then
+  exit "$CARGO_BINSTALL_STATUS"
+fi
+if [ "$1" = binstall ] || { [ "$1" = +1.89.0 ] && [ "$2" = install ]; }; then
+  printf '0.5.0' > "$MDTABLEFIX_STATE"
+fi
+""",
+    )
+    _write_command_stub(
+        directory,
+        "rustup",
+        """\
+printf 'rustup' >> "$INSTALLER_LOG"
+printf ' %s' "$@" >> "$INSTALLER_LOG"
+printf '\\n' >> "$INSTALLER_LOG"
+""",
+    )
+    _write_command_stub(
+        directory,
+        "mdtablefix",
+        """\
+printf 'mdtablefix' >> "$INSTALLER_LOG"
+printf ' %s' "$@" >> "$INSTALLER_LOG"
+printf '\\n' >> "$INSTALLER_LOG"
+if [ -f "$MDTABLEFIX_STATE" ]; then
+  version=$(cat "$MDTABLEFIX_STATE")
+else
+  version=0.4.0
+fi
+printf 'mdtablefix %s\\n' "$version"
+""",
+    )
+
+
+def _run_installer(
+    temporary_directory: pth.Path,
+    script: str,
+    *,
+    cargo_binstall_status: int,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    """Run one installer branch with controlled command availability."""
+    commands_directory = temporary_directory / "commands"
+    commands_directory.mkdir()
+    _install_command_stubs(commands_directory)
+    installer = temporary_directory / "install-mdtablefix.sh"
+    installer.write_text(script, encoding="utf-8")
+    log = temporary_directory / "installer.log"
+    state = temporary_directory / "mdtablefix-version"
+    bash = shutil.which("bash")
+    assert bash is not None, "the installer contract test requires Bash"
+    result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - executes the checked-in CI script.
+        [bash, str(installer)],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+        env=os.environ
+        | {
+            "CARGO_BINSTALL_STATUS": str(cargo_binstall_status),
+            "INSTALLER_LOG": str(log),
+            "MDTABLEFIX_STATE": str(state),
+            "MDTABLEFIX_VERSION": "0.5.0",
+            "MDTABLEFIX_RUST_VERSION": "1.89.0",
+            "PATH": f"{commands_directory}{os.pathsep}{os.environ['PATH']}",
+        },
+    )
+    return result, log.read_text(encoding="utf-8").splitlines()
+
+
+@pytest.mark.parametrize(
+    ("cargo_binstall_status", "expected_install", "unexpected_install"),
+    [
+        pytest.param(
+            0,
+            "cargo binstall --no-confirm --locked mdtablefix@0.5.0",
+            "rustup toolchain install --profile minimal 1.89.0",
+            id="prebuilt-binstall",
+        ),
+        pytest.param(
+            1,
+            "rustup toolchain install --profile minimal 1.89.0",
+            "cargo binstall --no-confirm --locked mdtablefix@0.5.0",
+            id="rust-source-fallback",
+        ),
+    ],
+)
+def test_mdtablefix_installer_uses_the_available_install_path(
+    workflow_data: Workflow,
+    tmp_path: pth.Path,
+    *,
+    cargo_binstall_status: int,
+    expected_install: str,
+    unexpected_install: str,
+) -> None:
+    """The CI installer selects binstall or the dedicated Rust fallback."""
+    result, calls = _run_installer(
+        tmp_path,
+        _installer_script(workflow_data),
+        cargo_binstall_status=cargo_binstall_status,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "cargo binstall -V" in calls, (
+        "the installer must probe cargo binstall with its supported -V command"
+    )
+    assert expected_install in calls, (
+        f"the installer must execute {expected_install!r}; found {calls!r}"
+    )
+    assert unexpected_install not in calls, (
+        f"the installer must not execute {unexpected_install!r}; found {calls!r}"
+    )
+    if cargo_binstall_status != 0:
+        assert "cargo +1.89.0 install --locked mdtablefix --version 0.5.0" in calls, (
+            "the fallback must build mdtablefix with the dedicated Rust 1.89.0 "
+            "toolchain"
+        )
+    assert calls[-1] == "mdtablefix --version", (
+        "the installer must verify the installed mdtablefix version after installation"
+    )

--- a/cuprum/unittests/test_mdtablefix_ci_installer.py
+++ b/cuprum/unittests/test_mdtablefix_ci_installer.py
@@ -15,6 +15,14 @@ if typ.TYPE_CHECKING:
     import pathlib as pth
 
 
+class _InstallerCase(typ.NamedTuple):
+    """Describe one mdtablefix installer branch."""
+
+    cargo_binstall_status: int
+    expected_install: str
+    unexpected_install: str
+
+
 def _installer_script(workflow_data: Workflow) -> str:
     """Return the checked-in mdtablefix installer script."""
     step = step_named(workflow_data, "lint-test", "Install mdtablefix")
@@ -109,18 +117,26 @@ def _run_installer(
 
 
 @pytest.mark.parametrize(
-    ("cargo_binstall_status", "expected_install", "unexpected_install"),
+    "case",
     [
         pytest.param(
-            0,
-            "cargo binstall --no-confirm --locked mdtablefix@0.5.0",
-            "rustup toolchain install --profile minimal 1.89.0",
+            _InstallerCase(
+                cargo_binstall_status=0,
+                expected_install=(
+                    "cargo binstall --no-confirm --locked mdtablefix@0.5.0"
+                ),
+                unexpected_install="rustup toolchain install --profile minimal 1.89.0",
+            ),
             id="prebuilt-binstall",
         ),
         pytest.param(
-            1,
-            "rustup toolchain install --profile minimal 1.89.0",
-            "cargo binstall --no-confirm --locked mdtablefix@0.5.0",
+            _InstallerCase(
+                cargo_binstall_status=1,
+                expected_install="rustup toolchain install --profile minimal 1.89.0",
+                unexpected_install=(
+                    "cargo binstall --no-confirm --locked mdtablefix@0.5.0"
+                ),
+            ),
             id="rust-source-fallback",
         ),
     ],
@@ -129,28 +145,26 @@ def test_mdtablefix_installer_uses_the_available_install_path(
     workflow_data: Workflow,
     tmp_path: pth.Path,
     *,
-    cargo_binstall_status: int,
-    expected_install: str,
-    unexpected_install: str,
+    case: _InstallerCase,
 ) -> None:
     """The CI installer selects binstall or the dedicated Rust fallback."""
     result, calls = _run_installer(
         tmp_path,
         _installer_script(workflow_data),
-        cargo_binstall_status=cargo_binstall_status,
+        cargo_binstall_status=case.cargo_binstall_status,
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "cargo binstall -V" in calls, (
         "the installer must probe cargo binstall with its supported -V command"
     )
-    assert expected_install in calls, (
-        f"the installer must execute {expected_install!r}; found {calls!r}"
+    assert case.expected_install in calls, (
+        f"the installer must execute {case.expected_install!r}; found {calls!r}"
     )
-    assert unexpected_install not in calls, (
-        f"the installer must not execute {unexpected_install!r}; found {calls!r}"
+    assert case.unexpected_install not in calls, (
+        f"the installer must not execute {case.unexpected_install!r}; found {calls!r}"
     )
-    if cargo_binstall_status != 0:
+    if case.cargo_binstall_status != 0:
         assert "cargo +1.89.0 install --locked mdtablefix --version 0.5.0" in calls, (
             "the fallback must build mdtablefix with the dedicated Rust 1.89.0 "
             "toolchain"

--- a/cuprum/unittests/test_mdtablefix_ci_installer.py
+++ b/cuprum/unittests/test_mdtablefix_ci_installer.py
@@ -1,174 +1,34 @@
-"""Process-boundary contracts for CI's mdtablefix installer branches."""
+"""Declarative contract for CI's shared mdtablefix installer."""
 
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess  # ruff: ignore[suspicious-subprocess-import] - executes the checked-in CI script.
-import typing as typ
-
-import pytest
-
 from tests.helpers.workflow import Workflow, step_named
 
-if typ.TYPE_CHECKING:
-    import pathlib as pth
-
-
-class _InstallerCase(typ.NamedTuple):
-    """Describe one mdtablefix installer branch."""
-
-    cargo_binstall_status: int
-    expected_install: str
-    unexpected_install: str
-
-
-def _installer_script(workflow_data: Workflow) -> str:
-    """Return the checked-in mdtablefix installer script."""
-    step = step_named(workflow_data, "lint-test", "Install mdtablefix")
-    script = step.get("run")
-    assert isinstance(script, str), "the Install mdtablefix CI step must run a script"
-    return script
-
-
-def _write_command_stub(directory: pth.Path, name: str, body: str) -> pth.Path:
-    """Create an executable command stub with the given shell body."""
-    command = directory / name
-    command.write_text(f"#!/bin/sh\n{body}", encoding="utf-8")
-    command.chmod(0o755)
-    return command
-
-
-def _install_command_stubs(directory: pth.Path) -> None:
-    """Install the controlled cargo, rustup, and mdtablefix command stubs."""
-    _write_command_stub(
-        directory,
-        "cargo",
-        """\
-printf 'cargo' >> "$INSTALLER_LOG"
-printf ' %s' "$@" >> "$INSTALLER_LOG"
-printf '\\n' >> "$INSTALLER_LOG"
-if [ "$1" = binstall ] && [ "$2" = -V ]; then
-  exit "$CARGO_BINSTALL_STATUS"
-fi
-if [ "$1" = binstall ] || { [ "$1" = +1.89.0 ] && [ "$2" = install ]; }; then
-  printf '0.5.0' > "$MDTABLEFIX_STATE"
-fi
-""",
-    )
-    _write_command_stub(
-        directory,
-        "rustup",
-        """\
-printf 'rustup' >> "$INSTALLER_LOG"
-printf ' %s' "$@" >> "$INSTALLER_LOG"
-printf '\\n' >> "$INSTALLER_LOG"
-""",
-    )
-    _write_command_stub(
-        directory,
-        "mdtablefix",
-        """\
-printf 'mdtablefix' >> "$INSTALLER_LOG"
-printf ' %s' "$@" >> "$INSTALLER_LOG"
-printf '\\n' >> "$INSTALLER_LOG"
-if [ -f "$MDTABLEFIX_STATE" ]; then
-  version=$(cat "$MDTABLEFIX_STATE")
-else
-  version=0.4.0
-fi
-printf 'mdtablefix %s\\n' "$version"
-""",
-    )
-
-
-def _run_installer(
-    temporary_directory: pth.Path,
-    script: str,
-    *,
-    cargo_binstall_status: int,
-) -> tuple[subprocess.CompletedProcess[str], list[str]]:
-    """Run one installer branch with controlled command availability."""
-    commands_directory = temporary_directory / "commands"
-    commands_directory.mkdir()
-    _install_command_stubs(commands_directory)
-    installer = temporary_directory / "install-mdtablefix.sh"
-    installer.write_text(script, encoding="utf-8")
-    log = temporary_directory / "installer.log"
-    state = temporary_directory / "mdtablefix-version"
-    bash = shutil.which("bash")
-    assert bash is not None, "the installer contract test requires Bash"
-    result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - executes the checked-in CI script.
-        [bash, str(installer)],
-        check=False,
-        capture_output=True,
-        encoding="utf-8",
-        env=os.environ
-        | {
-            "CARGO_BINSTALL_STATUS": str(cargo_binstall_status),
-            "INSTALLER_LOG": str(log),
-            "MDTABLEFIX_STATE": str(state),
-            "MDTABLEFIX_VERSION": "0.5.0",
-            "MDTABLEFIX_RUST_VERSION": "1.89.0",
-            "PATH": f"{commands_directory}{os.pathsep}{os.environ['PATH']}",
-        },
-    )
-    return result, log.read_text(encoding="utf-8").splitlines()
-
-
-@pytest.mark.parametrize(
-    "case",
-    [
-        pytest.param(
-            _InstallerCase(
-                cargo_binstall_status=0,
-                expected_install=(
-                    "cargo binstall --no-confirm --locked mdtablefix@0.5.0"
-                ),
-                unexpected_install="rustup toolchain install --profile minimal 1.89.0",
-            ),
-            id="prebuilt-binstall",
-        ),
-        pytest.param(
-            _InstallerCase(
-                cargo_binstall_status=1,
-                expected_install="rustup toolchain install --profile minimal 1.89.0",
-                unexpected_install=(
-                    "cargo binstall --no-confirm --locked mdtablefix@0.5.0"
-                ),
-            ),
-            id="rust-source-fallback",
-        ),
-    ],
+_SHARED_ACTION_REVISION = "c5a54701c8603a0fa756a6b34c49bc2af75a6c11"
+_INSTALL_MDTABLEFIX = (
+    "leynos/shared-actions/.github/actions/install-mdtablefix@"
+    f"{_SHARED_ACTION_REVISION}"
 )
-def test_mdtablefix_installer_uses_the_available_install_path(
-    workflow_data: Workflow,
-    tmp_path: pth.Path,
-    *,
-    case: _InstallerCase,
-) -> None:
-    """The CI installer selects binstall or the dedicated Rust fallback."""
-    result, calls = _run_installer(
-        tmp_path,
-        _installer_script(workflow_data),
-        cargo_binstall_status=case.cargo_binstall_status,
-    )
 
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert "cargo binstall -V" in calls, (
-        "the installer must probe cargo binstall with its supported -V command"
+
+def test_mdtablefix_installer_uses_the_shared_prebuilt_action(
+    workflow_data: Workflow,
+) -> None:
+    """CI delegates pinned prebuilt formatter installation to shared-actions."""
+    step = step_named(workflow_data, "lint-test", "Install mdtablefix")
+
+    assert step.get("uses") == _INSTALL_MDTABLEFIX, (
+        "the Install mdtablefix CI step must use the pinned shared prebuilt "
+        "installer action"
     )
-    assert case.expected_install in calls, (
-        f"the installer must execute {case.expected_install!r}; found {calls!r}"
+    inputs = step.get("with")
+    assert isinstance(inputs, dict), (
+        "the Install mdtablefix CI step must pass inputs to the shared action"
     )
-    assert case.unexpected_install not in calls, (
-        f"the installer must not execute {case.unexpected_install!r}; found {calls!r}"
+    assert inputs.get("version") == "${{ env.MDTABLEFIX_VERSION }}", (
+        "the Install mdtablefix CI step must pass the workflow's pinned "
+        "formatter version"
     )
-    if case.cargo_binstall_status != 0:
-        assert "cargo +1.89.0 install --locked mdtablefix --version 0.5.0" in calls, (
-            "the fallback must build mdtablefix with the dedicated Rust 1.89.0 "
-            "toolchain"
-        )
-    assert calls[-1] == "mdtablefix --version", (
-        "the installer must verify the installed mdtablefix version after installation"
+    assert "run" not in step, (
+        "the Install mdtablefix CI step must not retain a local source-build fallback"
     )

--- a/cuprum/unittests/test_toolchain_pins.py
+++ b/cuprum/unittests/test_toolchain_pins.py
@@ -250,6 +250,9 @@ def test_mdtablefix_installs_with_its_pinned_rust_toolchain() -> None:
         'cargo binstall --no-confirm --locked "mdtablefix@${MDTABLEFIX_VERSION}"'
         in script
     ), "the Install mdtablefix CI step must retain the cargo binstall fast path"
+    assert "cargo binstall -V >/dev/null 2>&1" in script, (
+        "the Install mdtablefix CI step must probe cargo binstall with -V"
+    )
     assert (
         'rustup toolchain install --profile minimal "${MDTABLEFIX_RUST_VERSION}"'
         in script
@@ -270,6 +273,11 @@ def test_mdtablefix_installs_with_its_pinned_rust_toolchain() -> None:
     assert "${{ env.MDTABLEFIX_RUST_VERSION }}" in cache_key, (
         "the Cache mdtablefix CI mapping must include MDTABLEFIX_RUST_VERSION "
         "in with.key"
+    )
+
+    whitaker_script = _lint_test_step_script(job, "Install Whitaker")
+    assert "cargo binstall -V >/dev/null 2>&1" in whitaker_script, (
+        "the Install Whitaker CI step must probe cargo binstall with -V"
     )
 
 

--- a/cuprum/unittests/test_toolchain_pins.py
+++ b/cuprum/unittests/test_toolchain_pins.py
@@ -76,7 +76,29 @@ def _read_workflow_env(root: pth.Path, name: str) -> str:
     assert isinstance(value, str), f"ci.yml env must pin {name} as a string"
     return value
 
+def _lint_test_job(root: pth.Path) -> dict[str, object]:
+    """Read the lint-test job from the CI workflow."""
+    workflow = yaml.safe_load(
+        (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    )
+    assert isinstance(workflow, dict), "ci.yml must parse to a mapping"
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "ci.yml must declare a jobs mapping"
+    job = jobs.get("lint-test")
+    assert isinstance(job, dict), "ci.yml must declare the lint-test job"
+    return job
 
+def _lint_test_step_script(job: dict[str, object], name: str) -> str:
+    """Read the named run script from the lint-test job."""
+    steps = job.get("steps")
+    assert isinstance(steps, list), "the lint-test job must declare steps"
+    for step in steps:
+        if not isinstance(step, dict) or step.get("name") != name:
+            continue
+        script = step.get("run")
+        assert isinstance(script, str), f"the {name!r} step must run a script"
+        return script
+    pytest.fail(f"the lint-test job must declare an {name!r} step")
 def _dev_dependencies(root: pth.Path) -> list[str]:
     """Read the pyproject dev dependency group."""
     pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
@@ -159,7 +181,17 @@ def test_ruff_and_ty_pins_are_release_versions() -> None:
                 "dotted release version"
             )
 
+def test_mdtablefix_installs_with_its_pinned_rust_toolchain() -> None:
+    """The formatter build uses a toolchain that supports its pinned release."""
+    job = _lint_test_job(repo_root())
+    environment = job.get("env")
+    assert isinstance(environment, dict), "the lint-test job must declare env"
+    toolchain = environment.get("MDTABLEFIX_RUST_TOOLCHAIN")
+    assert toolchain == "1.89.0", "mdtablefix 0.5.0 requires Rust 1.89"
+    script = _lint_test_step_script(job, "Install mdtablefix")
 
+    assert 'rustup toolchain install "${MDTABLEFIX_RUST_TOOLCHAIN}"' in script
+    assert 'cargo +"${MDTABLEFIX_RUST_TOOLCHAIN}" install --locked mdtablefix' in script
 def test_make_lint_and_typecheck_use_the_pinned_tool_commands() -> None:
     """The dry-run recipes invoke Ruff and ty through their synchronized pins."""
     root = repo_root()

--- a/cuprum/unittests/test_toolchain_pins.py
+++ b/cuprum/unittests/test_toolchain_pins.py
@@ -270,10 +270,15 @@ def test_mdtablefix_installs_with_its_pinned_rust_toolchain() -> None:
     assert isinstance(cache_key, str), (
         "the Cache mdtablefix CI mapping must declare with.key as a string"
     )
-    assert "${{ env.MDTABLEFIX_RUST_VERSION }}" in cache_key, (
-        "the Cache mdtablefix CI mapping must include MDTABLEFIX_RUST_VERSION "
-        "in with.key"
-    )
+    for name in (
+        "MDTABLEFIX_VERSION",
+        "MDTABLEFIX_RUST_VERSION",
+        "UBUNTU_RELEASE",
+        "CACHE_GENERATION",
+    ):
+        assert f"${{{{ env.{name} }}}}" in cache_key, (
+            f"the Cache mdtablefix CI mapping must include {name} in with.key"
+        )
 
     whitaker_script = _lint_test_step_script(job, "Install Whitaker")
     assert "cargo binstall -V >/dev/null 2>&1" in whitaker_script, (

--- a/cuprum/unittests/test_toolchain_pins.py
+++ b/cuprum/unittests/test_toolchain_pins.py
@@ -53,6 +53,47 @@ _DF12_PYPROJECT_REF_RE = re.compile(
 )
 
 
+class StepInputs(typ.TypedDict, total=False):
+    """Inputs read from a CI workflow step."""
+
+    key: str
+    toolchain: str
+
+
+# `with` is a Python keyword, so declare that TypedDict key functionally.
+_StepWith = typ.TypedDict("_StepWith", {"with": StepInputs}, total=False)
+
+
+class Step(_StepWith, total=False):
+    """Fields read from a CI workflow step."""
+
+    name: str
+    run: str
+
+
+class Job(typ.TypedDict, total=False):
+    """Fields read from the lint-test CI job."""
+
+    env: dict[str, str]
+    steps: list[Step]
+
+
+class Workflow(typ.TypedDict, total=False):
+    """Fields read from the CI workflow document."""
+
+    env: dict[str, str]
+    jobs: dict[str, Job]
+
+
+def _ci_workflow(root: pth.Path) -> Workflow:
+    """Read the CI workflow after verifying its outer mapping shape."""
+    workflow = yaml.safe_load(
+        (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    )
+    assert isinstance(workflow, dict), "ci.yml must parse to a mapping"
+    return typ.cast("Workflow", workflow)
+
+
 def _read_makefile_pin(root: pth.Path, name: str) -> str:
     """Read a `NAME ?= value` default from the repository Makefile."""
     makefile = (root / "Makefile").read_text(encoding="utf-8")
@@ -67,41 +108,42 @@ def _read_makefile_pin(root: pth.Path, name: str) -> str:
 
 def _read_workflow_env(root: pth.Path, name: str) -> str:
     """Read a workflow-level env value from ci.yml."""
-    workflow = yaml.safe_load(
-        (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    )
+    workflow = _ci_workflow(root)
     env = workflow.get("env")
     assert isinstance(env, dict), "ci.yml must declare a workflow-level env block"
     value = env.get(name)
     assert isinstance(value, str), f"ci.yml env must pin {name} as a string"
     return value
 
-def _lint_test_job(root: pth.Path) -> dict[str, object]:
+
+def _lint_test_job(root: pth.Path) -> Job:
     """Read the lint-test job from the CI workflow."""
-    workflow = yaml.safe_load(
-        (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    )
-    assert isinstance(workflow, dict), "ci.yml must parse to a mapping"
+    workflow = _ci_workflow(root)
     jobs = workflow.get("jobs")
     assert isinstance(jobs, dict), "ci.yml must declare a jobs mapping"
     job = jobs.get("lint-test")
     assert isinstance(job, dict), "ci.yml must declare the lint-test job"
     return job
 
-def _lint_test_step(job: dict[str, object], name: str) -> dict[str, object]:
+
+def _lint_test_step(job: Job, name: str) -> Step:
     """Read a named step from the lint-test job."""
     steps = job.get("steps")
     assert isinstance(steps, list), "the lint-test job must declare steps"
-    for step in steps:
+    for step in typ.cast("list[object]", steps):
         if not isinstance(step, dict) or step.get("name") != name:
             continue
-        return step
+        return typ.cast("Step", step)
     pytest.fail(f"the lint-test job must declare an {name!r} step")
-def _lint_test_step_script(job: dict[str, object], name: str) -> str:
+
+
+def _lint_test_step_script(job: Job, name: str) -> str:
     """Read the named run script from the lint-test job."""
     script = _lint_test_step(job, name).get("run")
     assert isinstance(script, str), f"the {name!r} step must run a script"
     return script
+
+
 def _dev_dependencies(root: pth.Path) -> list[str]:
     """Read the pyproject dev dependency group."""
     pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
@@ -184,35 +226,53 @@ def test_ruff_and_ty_pins_are_release_versions() -> None:
                 "dotted release version"
             )
 
+
 def test_mdtablefix_installs_with_its_pinned_rust_toolchain() -> None:
     """The formatter source fallback uses its required Rust toolchain only."""
     job = _lint_test_job(repo_root())
     toolchain_setup = _lint_test_step(job, "Install Rust toolchain")
     toolchain_configuration = toolchain_setup.get("with")
-    assert isinstance(toolchain_configuration, dict)
-    assert toolchain_configuration.get("toolchain") == "1.85.0"
+    assert isinstance(toolchain_configuration, dict), (
+        "the Install Rust toolchain CI mapping must declare a with field"
+    )
+    assert toolchain_configuration.get("toolchain") == "1.85.0", (
+        "the Install Rust toolchain CI mapping must keep with.toolchain at 1.85.0"
+    )
 
     environment = job.get("env")
     assert isinstance(environment, dict), "the lint-test job must declare env"
-    assert environment.get("MDTABLEFIX_RUST_VERSION") == "1.89.0"
+    assert environment.get("MDTABLEFIX_RUST_VERSION") == "1.89.0", (
+        "the lint-test CI mapping must set env.MDTABLEFIX_RUST_VERSION to 1.89.0"
+    )
 
     script = _lint_test_step_script(job, "Install mdtablefix")
     assert (
         'cargo binstall --no-confirm --locked "mdtablefix@${MDTABLEFIX_VERSION}"'
         in script
-    )
+    ), "the Install mdtablefix CI step must retain the cargo binstall fast path"
     assert (
         'rustup toolchain install --profile minimal "${MDTABLEFIX_RUST_VERSION}"'
         in script
-    )
-    assert 'cargo +"${MDTABLEFIX_RUST_VERSION}" install --locked mdtablefix' in script
+    ), "the Install mdtablefix CI step must install the dedicated formatter toolchain"
+    assert (
+        'cargo +"${MDTABLEFIX_RUST_VERSION}" install --locked mdtablefix' in script
+    ), "the Install mdtablefix CI step must build with the formatter toolchain"
 
     cache = _lint_test_step(job, "Cache mdtablefix")
     cache_configuration = cache.get("with")
-    assert isinstance(cache_configuration, dict)
+    assert isinstance(cache_configuration, dict), (
+        "the Cache mdtablefix CI mapping must declare a with field"
+    )
     cache_key = cache_configuration.get("key")
-    assert isinstance(cache_key, str)
-    assert "${{ env.MDTABLEFIX_RUST_VERSION }}" in cache_key
+    assert isinstance(cache_key, str), (
+        "the Cache mdtablefix CI mapping must declare with.key as a string"
+    )
+    assert "${{ env.MDTABLEFIX_RUST_VERSION }}" in cache_key, (
+        "the Cache mdtablefix CI mapping must include MDTABLEFIX_RUST_VERSION "
+        "in with.key"
+    )
+
+
 def test_make_lint_and_typecheck_use_the_pinned_tool_commands() -> None:
     """The dry-run recipes invoke Ruff and ty through their synchronized pins."""
     root = repo_root()

--- a/cuprum/unittests/test_toolchain_pins.py
+++ b/cuprum/unittests/test_toolchain_pins.py
@@ -88,17 +88,20 @@ def _lint_test_job(root: pth.Path) -> dict[str, object]:
     assert isinstance(job, dict), "ci.yml must declare the lint-test job"
     return job
 
-def _lint_test_step_script(job: dict[str, object], name: str) -> str:
-    """Read the named run script from the lint-test job."""
+def _lint_test_step(job: dict[str, object], name: str) -> dict[str, object]:
+    """Read a named step from the lint-test job."""
     steps = job.get("steps")
     assert isinstance(steps, list), "the lint-test job must declare steps"
     for step in steps:
         if not isinstance(step, dict) or step.get("name") != name:
             continue
-        script = step.get("run")
-        assert isinstance(script, str), f"the {name!r} step must run a script"
-        return script
+        return step
     pytest.fail(f"the lint-test job must declare an {name!r} step")
+def _lint_test_step_script(job: dict[str, object], name: str) -> str:
+    """Read the named run script from the lint-test job."""
+    script = _lint_test_step(job, name).get("run")
+    assert isinstance(script, str), f"the {name!r} step must run a script"
+    return script
 def _dev_dependencies(root: pth.Path) -> list[str]:
     """Read the pyproject dev dependency group."""
     pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
@@ -182,16 +185,34 @@ def test_ruff_and_ty_pins_are_release_versions() -> None:
             )
 
 def test_mdtablefix_installs_with_its_pinned_rust_toolchain() -> None:
-    """The formatter build uses a toolchain that supports its pinned release."""
+    """The formatter source fallback uses its required Rust toolchain only."""
     job = _lint_test_job(repo_root())
+    toolchain_setup = _lint_test_step(job, "Install Rust toolchain")
+    toolchain_configuration = toolchain_setup.get("with")
+    assert isinstance(toolchain_configuration, dict)
+    assert toolchain_configuration.get("toolchain") == "1.85.0"
+
     environment = job.get("env")
     assert isinstance(environment, dict), "the lint-test job must declare env"
-    toolchain = environment.get("MDTABLEFIX_RUST_TOOLCHAIN")
-    assert toolchain == "1.89.0", "mdtablefix 0.5.0 requires Rust 1.89"
-    script = _lint_test_step_script(job, "Install mdtablefix")
+    assert environment.get("MDTABLEFIX_RUST_VERSION") == "1.89.0"
 
-    assert 'rustup toolchain install "${MDTABLEFIX_RUST_TOOLCHAIN}"' in script
-    assert 'cargo +"${MDTABLEFIX_RUST_TOOLCHAIN}" install --locked mdtablefix' in script
+    script = _lint_test_step_script(job, "Install mdtablefix")
+    assert (
+        'cargo binstall --no-confirm --locked "mdtablefix@${MDTABLEFIX_VERSION}"'
+        in script
+    )
+    assert (
+        'rustup toolchain install --profile minimal "${MDTABLEFIX_RUST_VERSION}"'
+        in script
+    )
+    assert 'cargo +"${MDTABLEFIX_RUST_VERSION}" install --locked mdtablefix' in script
+
+    cache = _lint_test_step(job, "Cache mdtablefix")
+    cache_configuration = cache.get("with")
+    assert isinstance(cache_configuration, dict)
+    cache_key = cache_configuration.get("key")
+    assert isinstance(cache_key, str)
+    assert "${{ env.MDTABLEFIX_RUST_VERSION }}" in cache_key
 def test_make_lint_and_typecheck_use_the_pinned_tool_commands() -> None:
     """The dry-run recipes invoke Ruff and ty through their synchronized pins."""
     root = repo_root()

--- a/cuprum/unittests/test_toolchain_pins.py
+++ b/cuprum/unittests/test_toolchain_pins.py
@@ -58,6 +58,7 @@ class StepInputs(typ.TypedDict, total=False):
 
     key: str
     toolchain: str
+    version: str
 
 
 # `with` is a Python keyword, so declare that TypedDict key functionally.
@@ -69,6 +70,7 @@ class Step(_StepWith, total=False):
 
     name: str
     run: str
+    uses: str
 
 
 class Job(typ.TypedDict, total=False):
@@ -227,8 +229,8 @@ def test_ruff_and_ty_pins_are_release_versions() -> None:
             )
 
 
-def test_mdtablefix_installs_with_its_pinned_rust_toolchain() -> None:
-    """The formatter source fallback uses its required Rust toolchain only."""
+def test_mdtablefix_uses_its_pinned_prebuilt_installer() -> None:
+    """The formatter uses a pinned prebuilt installer, not a Rust fallback."""
     job = _lint_test_job(repo_root())
     toolchain_setup = _lint_test_step(job, "Install Rust toolchain")
     toolchain_configuration = toolchain_setup.get("with")
@@ -241,25 +243,13 @@ def test_mdtablefix_installs_with_its_pinned_rust_toolchain() -> None:
 
     environment = job.get("env")
     assert isinstance(environment, dict), "the lint-test job must declare env"
-    assert environment.get("MDTABLEFIX_RUST_VERSION") == "1.89.0", (
-        "the lint-test CI mapping must set env.MDTABLEFIX_RUST_VERSION to 1.89.0"
+    assert environment.get("MDTABLEFIX_VERSION") == "0.5.1", (
+        "the lint-test CI mapping must set env.MDTABLEFIX_VERSION to 0.5.1"
     )
-
-    script = _lint_test_step_script(job, "Install mdtablefix")
-    assert (
-        'cargo binstall --no-confirm --locked "mdtablefix@${MDTABLEFIX_VERSION}"'
-        in script
-    ), "the Install mdtablefix CI step must retain the cargo binstall fast path"
-    assert "cargo binstall -V >/dev/null 2>&1" in script, (
-        "the Install mdtablefix CI step must probe cargo binstall with -V"
+    assert "MDTABLEFIX_RUST_VERSION" not in environment, (
+        "the lint-test CI mapping must not retain the removed formatter source "
+        "toolchain pin"
     )
-    assert (
-        'rustup toolchain install --profile minimal "${MDTABLEFIX_RUST_VERSION}"'
-        in script
-    ), "the Install mdtablefix CI step must install the dedicated formatter toolchain"
-    assert (
-        'cargo +"${MDTABLEFIX_RUST_VERSION}" install --locked mdtablefix' in script
-    ), "the Install mdtablefix CI step must build with the formatter toolchain"
 
     cache = _lint_test_step(job, "Cache mdtablefix")
     cache_configuration = cache.get("with")
@@ -272,7 +262,6 @@ def test_mdtablefix_installs_with_its_pinned_rust_toolchain() -> None:
     )
     for name in (
         "MDTABLEFIX_VERSION",
-        "MDTABLEFIX_RUST_VERSION",
         "UBUNTU_RELEASE",
         "CACHE_GENERATION",
     ):

--- a/docs/adr-002-additional-rust-components.md
+++ b/docs/adr-002-additional-rust-components.md
@@ -317,11 +317,10 @@ sink and no line callbacks.
 production code does not route stream consumption through it yet. The symbol is
 annotated as "implemented but not yet integrated" in `cuprum/_streams_rs.py`
 and the users' guide so it is not mistaken for a wired bridge. A guard test
-(`cuprum/unittests/test_rust_consume_integration_guard.py`) fails if
-production code starts
-referencing the symbol without revisiting this decision. Phase 2 integration
-should remove that marker only alongside the dispatcher, fallback path, and the
-Python/Rust parity property tests tracked by issue #90.
+(`cuprum/unittests/test_rust_consume_integration_guard.py`) fails if production
+code starts referencing the symbol without revisiting this decision. Phase 2
+integration should remove that marker only alongside the dispatcher, fallback
+path, and the Python/Rust parity property tests tracked by issue #90.
 
 The same profiling baseline records adjacent work that should not be folded
 into the initial `rust_consume_stream()` dispatcher:
@@ -410,8 +409,8 @@ remains the behavioural reference, and users keep the same public API.
 The Python pipeline now makes the native pump's descriptor boundary explicit.
 `_run_rust_pump` retains the descriptor owned by the asyncio writer transport
 and passes `rust_pump_stream` a duplicate, because the native pump consumes and
-closes the descriptor it receives. Ownership of that duplicate remains with
-the executor worker until its future settles, including native-load failure and
+closes the descriptor it receives. Ownership of that duplicate remains with the
+executor worker until its future settles, including native-load failure and
 awaiting-task cancellation. Descriptor-mode restoration and reader transport
 resumption therefore occur at worker settlement, and the duplicate is closed
 after that boundary. This preserves the original Python transport ownership

--- a/docs/adr-003-two-tier-python-linting.md
+++ b/docs/adr-003-two-tier-python-linting.md
@@ -140,8 +140,7 @@ The canonical policy lives in `pyproject.toml`:
 
 The lint estate was upgraded while preserving the two-tier decision above. Ruff
 is pinned to 0.16.4 and ty is pinned to 0.0.74. The `df12-python-lints`
-dependency and standalone lint pass use v0.3.0 at commit
-`4cf41736cce2f7ba2778882a5c629c044568a0e5`.
+dependency and standalone lint pass use the controlled v0.3.0 release tag.
 
 - `RUFF_VERSION` and `TY_VERSION` are synchronized across the Makefile
   defaults, the workflow-level environment in `.github/workflows/ci.yml`, and
@@ -153,6 +152,25 @@ dependency and standalone lint pass use v0.3.0 at commit
   `$(TY) check --python .venv` so ty analyses the project virtual environment
   explicitly.
 - `DF12_PYTHON_LINTS_REF` and the development dependency use the same
-  immutable df12 commit. The enabled message list includes `R9112`
+  controlled df12 release tag. The enabled message list includes `R9112`
   (`prefer-type-statement`) so the Python 3.12-compatible codebase uses the
   modern type-alias statement syntax.
+
+## Addendum (2026-09-04): Enforce the df12-python-lints release tag
+
+The lint configuration now enforces the `df12-python-lints` v0.3.0 release tag
+at every configured site. This keeps the standalone `make lint` command and the
+development dependency on the same named release, making the effective tool
+version explicit and reviewable.
+
+- `DF12_PYTHON_LINTS_REF` in `Makefile` and the Git dependency in
+  `pyproject.toml` both select `v0.3.0`.
+- `cuprum/unittests/test_toolchain_pins.py` checks both references for parity
+  and rejects any value other than the controlled release tag.
+- The selected df12 message set, including `R9112`, is unchanged; this
+  addendum records the version-selection contract rather than a lint-policy
+  change.
+
+The explicit tag keeps the two installation paths aligned, but a future release
+update must change both references and the contract test together. The project
+lock file should also be regenerated when the development dependency changes.

--- a/docs/adr-003-two-tier-python-linting.md
+++ b/docs/adr-003-two-tier-python-linting.md
@@ -138,10 +138,10 @@ The canonical policy lives in `pyproject.toml`:
 
 ## Addendum (2026-08-31): Ruff, ty, and df12 toolchain pins
 
-The lint estate was upgraded while preserving the two-tier decision above.
-Ruff is pinned to 0.16.4 and ty is pinned to 0.0.74. The
-`df12-python-lints` dependency and standalone lint pass use the controlled
-v0.3.0 release tag.
+The lint estate was upgraded while preserving the two-tier decision above. Ruff
+is pinned to 0.16.4 and ty is pinned to 0.0.74. The `df12-python-lints`
+dependency and standalone lint pass use v0.3.0 at commit
+`4cf41736cce2f7ba2778882a5c629c044568a0e5`.
 
 - `RUFF_VERSION` and `TY_VERSION` are synchronized across the Makefile
   defaults, the workflow-level environment in `.github/workflows/ci.yml`, and
@@ -149,9 +149,10 @@ v0.3.0 release tag.
   `cuprum/unittests/test_toolchain_pins.py` enforces this parity.
 - `$(RUFF)` invokes `uv tool run --from 'ruff==$(RUFF_VERSION)' ruff`, and
   `$(TY)` invokes `uv tool run --from 'ty==$(TY_VERSION)' ty`, with the shared
-  local tool environment. The `typecheck` target runs `$(TY) check --python
-  .venv` so ty analyses the project virtual environment explicitly.
+  local tool environment. The `typecheck` target runs
+  `$(TY) check --python .venv` so ty analyses the project virtual environment
+  explicitly.
 - `DF12_PYTHON_LINTS_REF` and the development dependency use the same
-  controlled df12 release tag. The enabled message list includes `R9112`
+  immutable df12 commit. The enabled message list includes `R9112`
   (`prefer-type-statement`) so the Python 3.12-compatible codebase uses the
   modern type-alias statement syntax.

--- a/docs/adr-007-subprocess-execution-module-boundaries.md
+++ b/docs/adr-007-subprocess-execution-module-boundaries.md
@@ -52,10 +52,10 @@ Keep runner orchestration, process spawning, and stream-consumer creation in
 accounting to `_subprocess_timeout.py`; and move process waiting, termination,
 and stream-consumer draining to `_subprocess_wait.py`.
 
-The original proposal exposed the drain helpers through
-`_subprocess_drain.py` as a narrow compatibility boundary for focused tests
-and private imports rather than a second live implementation. The
-2026-08-30 addendum records that this former boundary was removed.
+The original proposal exposed the drain helpers through `_subprocess_drain.py`
+as a narrow compatibility boundary for focused tests and private imports rather
+than a second live implementation. The 2026-08-30 addendum records that this
+former boundary was removed.
 
 This makes ownership explicit while retaining the runner as the composition
 root.
@@ -86,8 +86,8 @@ spawning and stream-consumer creation/wiring. `_subprocess_stdin` owns
 timeout translation, and the exit-event helpers shared by timeout and normal
 completion paths. `_subprocess_wait` owns the deadline wait, process
 termination, and remains the single owner of stream-consumer draining. The
-formerly proposed `_subprocess_drain` compatibility boundary was removed by
-the 2026-08-30 addendum.
+formerly proposed `_subprocess_drain` compatibility boundary was removed by the
+2026-08-30 addendum.
 
 The drain is capture-aware. A capturing drain waits for up to
 `_CAPTURE_EOF_GRACE_S` for terminated-process readers to observe EOF, then

--- a/docs/adr-008-rust-pump-observation-channel.md
+++ b/docs/adr-008-rust-pump-observation-channel.md
@@ -210,11 +210,10 @@ events reuse the source pipeline-stage `ExecId` solely to look up the existing
 active span. The token is not a trace attribute, and PID correlation is not
 used.
 
-The extension records `cuprum.cleanup_started` and
-`cuprum.cleanup_completed`. Both events have the stable
-`operation="native_pump_cleanup"` attribute and an `outcome` of `"started"`
-or `"completed"`; completion additionally has `duration_s`, the monotonic
-cleanup wait in seconds. It adds no descriptor data, command arguments,
-exception text, or unbounded trace attributes. Events without a matching open
-span are dropped safely. Cleanup tracing does not set span status or end the
-span.
+The extension records `cuprum.cleanup_started` and `cuprum.cleanup_completed`.
+Both events have the stable `operation="native_pump_cleanup"` attribute and an
+`outcome` of `"started"` or `"completed"`; completion additionally has
+`duration_s`, the monotonic cleanup wait in seconds. It adds no descriptor
+data, command arguments, exception text, or unbounded trace attributes. Events
+without a matching open span are dropped safely. Cleanup tracing does not set
+span status or end the span.

--- a/docs/ci-cache-ownership.md
+++ b/docs/ci-cache-ownership.md
@@ -22,11 +22,10 @@ ownership back out of the workflows.
 
 _Table 1: The cache families, what each holds, and what scopes its key._
 
-Every key also carries a generation, the operating system, and the
-architecture.
-`target` trees appear in no family at all: sccache holds the objects a `target`
-archive would preserve, and a `target` archive is invalidated by every source
-change while the objects inside it are not.
+Every key also carries a generation, the operating system, and the architecture.
+`target` trees appear in no family at all: sccache holds the objects a
+`target` archive would preserve, and a `target` archive is invalidated by every
+source change while the objects inside it are not.
 
 ## Why the lane is in every key
 
@@ -53,8 +52,8 @@ The build shape. An unoptimized `maturin develop` build, the same build with
 
 This was measured rather than assumed. Until 2026-09-04 the compiler key named
 neither dimension, so every Ubicloud job read one archive that the instrumented
-Python 3.13 coverage job had written. In two dispatches over an unchanged
-tree[^1][^2], the one reader on the same interpreter took 14 of its 17 cacheable
+Python 3.13 coverage job had written. In two dispatches over an unchanged tree
+[^1][^2], the one reader on the same interpreter took 14 of its 17 cacheable
 compiles and the 3.12, 3.14, and 3.15a readers took none. Read and write errors
 were zero throughout: the archive restored perfectly and simply held nothing
 those jobs could use.
@@ -118,18 +117,17 @@ re-derive it rather than inherit it.
 The worked example is this repository's own split, measured on 2026-09-04
 between the cold writer[^4] and a warm dispatch[^5] over an unchanged tree.
 
-| Job | Compiling step | Cold | Warm | Saved |
-| --- | --- | --- | --- | --- |
-| `typecheck-test` 3.12 | Run tests | 112 s | 101 s | 11 s |
-| `typecheck-test` 3.14 | Run tests | 99 s | 90 s | 9 s |
-| `typecheck-test` 3.15a | Run tests | 98 s | 88 s | 10 s |
-| `extension-tests` | Build the native extension | 13 s | 7 s | 6 s |
-| `benchmark-ratchet` | benchmarks and ratchet | 59 s | 54 s | 5 s |
+| Job                    | Compiling step             | Cold  | Warm  | Saved |
+| ---------------------- | -------------------------- | ----- | ----- | ----- |
+| `typecheck-test` 3.12  | Run tests                  | 112 s | 101 s | 11 s  |
+| `typecheck-test` 3.14  | Run tests                  | 99 s  | 90 s  | 9 s   |
+| `typecheck-test` 3.15a | Run tests                  | 98 s  | 88 s  | 10 s  |
+| `extension-tests`      | Build the native extension | 13 s  | 7 s   | 6 s   |
+| `benchmark-ratchet`    | benchmarks and ratchet     | 59 s  | 54 s  | 5 s   |
 
-_Table 3: What each family saves its reader on a warm run. The
-`typecheck-test` step also runs the Python suite, so its wall time is dominated
-by pytest rather than by compilation; `extension-tests` is the compile-only
-signal._
+_Table 3: What each family saves its reader on a warm run. The `typecheck-test`
+step also runs the Python suite, so its wall time is dominated by pytest rather
+than by compilation; `extension-tests` is the compile-only signal._
 
 The estimate that justified the split was wrong by a factor of seven, which is
 the reason this section exists. Six families were expected to cost about 1 GB

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -853,8 +853,8 @@ descriptor ownership. The latter carries `PumpEvent.duration_s`, the monotonic
 cleanup wait duration; other phases leave it unset. Cleanup is required because
 the executor worker retains descriptor ownership until it settles.
 
-`PumpMetricsHook` emits `cuprum_rust_pump_cleanup_total` once for each completed
-native cleanup and one observation of
+`PumpMetricsHook` emits `cuprum_rust_pump_cleanup_total` once for each
+completed native cleanup and one observation of
 `cuprum_rust_pump_cleanup_duration_seconds` for each such cleanup. Both cleanup
 metrics are unlabelled and emitted only on completion. `RustPumpDeclineReason`
 bounds the `reason` label on the decline metric, and `PumpMetricsHook` emits
@@ -866,15 +866,14 @@ observation channel, not an extension of `ExecEvent`. A caller registers the
 same `TracingHook` on both `sh.observe(hook)` and
 `observe_pump(hook.record_pump_event)`. For an inter-stage hop, each cleanup
 event carries the source stage's existing `ExecId` solely for lookup of its
-open pipeline-stage span; it is not a trace attribute, and the correlation
-does not use a PID. The hook records `cuprum.cleanup_started` when cleanup
-begins and `cuprum.cleanup_completed` when descriptor ownership is released.
-Both events have `operation="native_pump_cleanup"` and a bounded `outcome`
-(`"started"` or `"completed"`); only completion has `duration_s`, the
-monotonic cleanup wait in seconds. Descriptor numbers, command arguments,
-exception text, and other unbounded values are excluded. Events without a
-matching active span are dropped, and cleanup events neither set span status
-nor end the span.
+open pipeline-stage span; it is not a trace attribute, and the correlation does
+not use a PID. The hook records `cuprum.cleanup_started` when cleanup begins and
+`cuprum.cleanup_completed` when descriptor ownership is released. Both events
+have `operation="native_pump_cleanup"` and a bounded `outcome` (`"started"` or
+`"completed"`); only completion has `duration_s`, the monotonic cleanup wait in
+seconds. Descriptor numbers, command arguments, exception text, and other
+unbounded values are excluded. Events without a matching active span are
+dropped, and cleanup events neither set span status nor end the span.
 
 ### 7.2 Logging via `logging`
 

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1268,14 +1268,14 @@ preserving the `SafeCmd.run()` execution contract:
   escalation), and draining the stream consumers exactly once. Its explicit
   drain interface uses `_RunTaskOwnership` to bundle the optional stdin-writer
   task with the stdout and stderr consumer tasks, `_DrainContext` to carry
-  capture and observability settings, and `_reconcile_run_tasks(tasks,
-  context)` to cancel stdin before settling both consumers as one shielded
-  cleanup unit. A capturing drain gives readers a bounded
-  `_CAPTURE_EOF_GRACE_S` window to observe EOF before cancellation, maps an
-  absent reader result to an empty string, and therefore keeps captured timeout
-  output deterministic; non-capturing drains skip the window and retain `None`
-  for absent text. Split out of `_subprocess_execution` so that module stays
-  about orchestration — spawning, wiring streams, assembling the result.
+  capture and observability settings, and
+  `_reconcile_run_tasks(tasks, context)` to cancel stdin before settling both
+  consumers as one shielded cleanup unit. A capturing drain gives readers a
+  bounded `_CAPTURE_EOF_GRACE_S` window to observe EOF before cancellation,
+  maps an absent reader result to an empty string, and therefore keeps captured
+  timeout output deterministic; non-capturing drains skip the window and retain
+  `None` for absent text. Split out of `_subprocess_execution` so that module
+  stays about orchestration — spawning, wiring streams, assembling the result.
 - When that window expires with readers still pending, `_subprocess_wait` uses
   `_timeout_reporting` to emit one correlated `capture_eof_grace_expired`
   `ExecEvent`. The event carries the execution's `exec_id` and `pid`,
@@ -1726,8 +1726,9 @@ design decisions guide these adapters:
   (8.1.3).
 - Events without an `exec_id` (legacy or manually constructed) are ambiguous
   and are ignored: no span is created for such a `start`, and their `stdout`/
-  `stderr`/`stdin_error`/`timeout`/`teardown_error`/ `capture_eof_grace_expired`
-  /`pipeline_fail_fast`/`exit` events are dropped rather than guessed from PID.
+  `stderr`/`stdin_error`/`timeout`/`teardown_error`/
+  `capture_eof_grace_expired` /`pipeline_fail_fast`/`exit` events are dropped
+  rather than guessed from PID.
 - Output lines can optionally be recorded as span events (controlled by
   `record_output` parameter). `stdin_error`, `timeout`, and `teardown_error`
   are also recorded as span events, unconditionally, without ending the span.

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -2839,9 +2839,8 @@ closed for every event, including pushes to `main`, so an unknown path verdict
 cannot spend paid-runner time. The gate summary records both the detector
 status and the resulting benchmark decision. The gate and its rationale are
 described under "Gating the paid benchmark job" in the developers' guide. The
-job executes smoke-mode throughput benchmarks for the
-current checkout (with a release build of the Rust extension) and compares
-each scenario's within-run
+job executes smoke-mode throughput benchmarks for the current checkout (with a
+release build of the Rust extension) and compares each scenario's within-run
 Rust-to-Python mean ratio against the latest successful `main` baseline
 artefact. The CI profile measures ten runs per command and orders matched
 Python/Rust commands adjacently so time-dependent runner load is less likely to

--- a/docs/cuprum-design.md
+++ b/docs/cuprum-design.md
@@ -1050,14 +1050,13 @@ implemented with the following decisions:
 
 - **Event phases:** Cuprum emits `plan`, `start`, `stdout`, `stderr`, `stdin`,
   `stdin_error`, `exit`, `timeout`, `teardown_error`,
-  `capture_eof_grace_expired`, and `pipeline_fail_fast`
-  phases for both single commands and pipeline stages — the declared
-  `ExecPhase` values. `timeout`, `teardown_error`, and
-  `capture_eof_grace_expired` are ancillary diagnostics rather than lifecycle
-  phases. `capture_eof_grace_expired` is emitted only when a capturing drain
-  exhausts its fixed `_CAPTURE_EOF_GRACE_S` budget with one or more readers
-  still pending.
-  Pipeline stage events are tagged with a stage index and stage count.
+  `capture_eof_grace_expired`, and `pipeline_fail_fast` phases for both single
+  commands and pipeline stages — the declared `ExecPhase` values. `timeout`,
+  `teardown_error`, and `capture_eof_grace_expired` are ancillary diagnostics
+  rather than lifecycle phases. `capture_eof_grace_expired` is emitted only
+  when a capturing drain exhausts its fixed `_CAPTURE_EOF_GRACE_S` budget with
+  one or more readers still pending. Pipeline stage events are tagged with a
+  stage index and stage count.
 - **Fail-fast decision:** a pipeline emits one `pipeline_fail_fast` event when
   a non-final stage is the first to fail and at least one other stage remains
   running. It is published before every other still-running stage — upstream
@@ -1162,12 +1161,11 @@ The `SafeCmd` executes the process, then invokes the `on_exit` hook with the
 command and the resulting `CommandResult`, and only then returns that result to
 the user — `_execute_with_hooks` dispatches the after-hooks before its own
 return, so a hook cannot observe a command the caller has already been told
-about. The exit hook
-asks again whether the exit level is enabled: if it is disabled it returns
-immediately, leaving nothing to clean up because nothing was stored; if it is
-enabled it takes the lock, pops the recorded start time — removing the entry,
-so the store cannot grow without bound — releases the lock, computes
-`duration_s`, and logs the `cuprum.exit` record.
+about. The exit hook asks again whether the exit level is enabled: if it is
+disabled it returns immediately, leaving nothing to clean up because nothing
+was stored; if it is enabled it takes the lock, pops the recorded start time —
+removing the entry, so the store cannot grow without bound — releases the lock,
+computes `duration_s`, and logs the `cuprum.exit` record.
 
 Figure 3: Sequence of start/exit logging hook execution
 
@@ -1279,12 +1277,11 @@ preserving the `SafeCmd.run()` execution contract:
   for absent text. Split out of `_subprocess_execution` so that module stays
   about orchestration — spawning, wiring streams, assembling the result.
 - When that window expires with readers still pending, `_subprocess_wait` uses
-  `_timeout_reporting` to emit one correlated
-  `capture_eof_grace_expired` `ExecEvent`. The event carries the execution's
-  `exec_id` and `pid`, `operation="drain"`, `eof_grace_s`, and
-  `pending_readers`. `MetricsHook` projects it to
-  `cuprum_capture_eof_grace_expired_total` with only `program` and `project`
-  labels, while `TracingHook` adds a
+  `_timeout_reporting` to emit one correlated `capture_eof_grace_expired`
+  `ExecEvent`. The event carries the execution's `exec_id` and `pid`,
+  `operation="drain"`, `eof_grace_s`, and `pending_readers`. `MetricsHook`
+  projects it to `cuprum_capture_eof_grace_expired_total` with only `program`
+  and `project` labels, while `TracingHook` adds a
   `cuprum.capture_eof_grace_expired` event to the matching span. No captured
   stream payload is emitted in that event. Unexpected reader failures remain
   separately reported as `teardown_error`.
@@ -1709,11 +1706,10 @@ design decisions guide these adapters:
 - Counter metrics (`cuprum_executions_total`, `cuprum_failures_total`,
   `cuprum_stdout_lines_total`, `cuprum_stderr_lines_total`,
   `cuprum_stdin_bytes_total`, `cuprum_stdin_errors_total`,
-  `cuprum_pipeline_fail_fast_total`,
-  `cuprum_capture_eof_grace_expired_total`) are incremented on the
-  corresponding event phases. The EOF-grace counter has only the low-cardinality
-  `program` and `project` labels; duration and pending-reader count remain event
-  fields, not labels.
+  `cuprum_pipeline_fail_fast_total`, `cuprum_capture_eof_grace_expired_total`)
+  are incremented on the corresponding event phases. The EOF-grace counter has
+  only the low-cardinality `program` and `project` labels; duration and
+  pending-reader count remain event fields, not labels.
 - Histogram metrics (`cuprum_duration_seconds`) are observed on `exit` events.
 - All metrics include `program` and `project` labels for multi‑dimensional
   analysis. The `project` label uses `_project_tag` and falls back to
@@ -1730,9 +1726,8 @@ design decisions guide these adapters:
   (8.1.3).
 - Events without an `exec_id` (legacy or manually constructed) are ambiguous
   and are ignored: no span is created for such a `start`, and their `stdout`/
-  `stderr`/`stdin_error`/`timeout`/`teardown_error`/
-  `capture_eof_grace_expired`/`pipeline_fail_fast`/`exit` events are dropped
-  rather than guessed from PID.
+  `stderr`/`stdin_error`/`timeout`/`teardown_error`/ `capture_eof_grace_expired`
+  /`pipeline_fail_fast`/`exit` events are dropped rather than guessed from PID.
 - Output lines can optionally be recorded as span events (controlled by
   `record_output` parameter). `stdin_error`, `timeout`, and `teardown_error`
   are also recorded as span events, unconditionally, without ending the span.
@@ -1768,14 +1763,14 @@ design decisions guide these adapters:
 - Labels are resolved only when the reducer yields at least one operation, so a
   `plan` event — which records nothing — never projects labels off the event.
 - The reducer is total over `ExecPhase` — every declared phase has an arm,
-  including `capture_eof_grace_expired` — and fail-closed beyond it: any other phase
-  raises `_UnhandledMetricsPhaseError` rather than being silently ignored. That
-  is deliberate, and its cost is worth stating plainly. A hook exception is not
-  swallowed, so adding a value to `ExecPhase` without adding an arm here would
-  raise for every caller that has already registered `MetricsHook`. A new phase
-  therefore cannot reach metrics without a decision in this reducer. The
-  structured logging adapter is fail-open by contrast, formatting an
-  unrecognized phase generically.
+  including `capture_eof_grace_expired` — and fail-closed beyond it: any other
+  phase raises `_UnhandledMetricsPhaseError` rather than being silently
+  ignored. That is deliberate, and its cost is worth stating plainly. A hook
+  exception is not swallowed, so adding a value to `ExecPhase` without adding
+  an arm here would raise for every caller that has already registered
+  `MetricsHook`. A new phase therefore cannot reach metrics without a decision
+  in this reducer. The structured logging adapter is fail-open by contrast,
+  formatting an unrecognized phase generically.
 
 For screen readers: The following sequence diagram shows how one execution
 event becomes collector calls. The observe-hook dispatcher invokes

--- a/docs/debugging/debugging-plan-20260903T000305Z.md
+++ b/docs/debugging/debugging-plan-20260903T000305Z.md
@@ -1,12 +1,9 @@
 # Debugging Plan: benchmark runner cannot fetch df12-python-lints
 
-**Generated**: 2026-09-03T00:03:05Z
-**Issue ID**: PR #289, CI run 33678861823
-**Severity**: High
-**Falsification sub-agent**: alchemist
-**Planning agent boundary**: This document was prepared by the planning agent.
-Falsification must be executed by the named sub-agent, not by the planning
-agent.
+**Generated**: 2026-09-03T00:03:05Z **Issue ID**: PR #289, CI run 33678861823
+**Severity**: High **Falsification sub-agent**: alchemist **Planning agent
+boundary**: This document was prepared by the planning agent. Falsification
+must be executed by the named sub-agent, not by the planning agent.
 
 ## Problem Statement
 
@@ -60,8 +57,9 @@ resolved commit `4cf41736cce2f7ba2778882a5c629c044568a0e5`.
 - **H3 falsified.** The public `refs/tags/v0.3.0` advertises the exact commit in
   `uv.lock`, and the same failure occurred before the configuration switched
   from that commit SHA to the tag.
-- **H4 inconclusive.** GitHub rejected `gh run rerun --failed` with `Resource
-  not accessible by integration`, so no unchanged hosted retry was available.
+- **H4 inconclusive.** GitHub rejected `gh run rerun --failed` with
+  `Resource not accessible by integration`, so no unchanged hosted retry was
+  available.
 - **H5 not falsified.** A fresh dev-group sync with
   `--no-install-package df12-python-lints` installed the other 53 packages,
   including Maturin 1.13.3, without fetching or installing the lint plugin.
@@ -178,9 +176,8 @@ ______________________________________________________________________
 development group. Excluding that package leaves the extension toolchain
 available while removing the failing Git fetch.
 
-**Prediction**: A fresh dev sync with
-`--no-install-package df12-python-lints` neither fetches nor installs the plugin
-and still installs Maturin.
+**Prediction**: A fresh dev sync with `--no-install-package df12-python-lints`
+neither fetches nor installs the plugin and still installs Maturin.
 
 **Falsification test**: Sync the dev group into fresh cache, tool, and virtual
 environment directories with that exclusion, then query Maturin directly.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2615,21 +2615,21 @@ files; it never modifies the worktree. It accepts exact LF or CRLF output, but
 rejects mixed line endings. Run `make test-markdown-format` after changing the
 checker.
 
-The gate requires the `mdtablefix` version pinned by `MDTABLEFIX_VERSION` in
-`.github/workflows/ci.yml`. Install that version locally so formatter output
-matches CI:
+The gate installs the `mdtablefix` version pinned by `MDTABLEFIX_VERSION` in
+`.github/workflows/ci.yml` through the
+`leynos/shared-actions/.github/actions/install-mdtablefix` action. The action
+requires `mdtablefix` 0.5.1 or later, installs only a matching prebuilt
+release, and fails closed when the runner has no supported archive; it never
+builds the formatter from source. Cuprum's project toolchain remains Rust
+1.85.0.
 
-`mdtablefix` 0.5.0 requires Rust 1.89.0 when built from source. Cuprum's
-project toolchain remains Rust 1.85.0; CI uses `MDTABLEFIX_RUST_VERSION` to
-select Rust 1.89.0 only for this formatter fallback.
+Install the pinned prebuilt version locally with `cargo-binstall` so formatter
+output matches CI:
 
 ```bash
-MDTABLEFIX_VERSION="$(sed -n "s/.*MDTABLEFIX_VERSION: '\(.*\)'.*/\1/p" \
-  .github/workflows/ci.yml)"
-MDTABLEFIX_RUST_VERSION="$(sed -n "s/.*MDTABLEFIX_RUST_VERSION: '\(.*\)'.*/\1/p" \
-  .github/workflows/ci.yml)"
-cargo +"$MDTABLEFIX_RUST_VERSION" install --locked mdtablefix \
-  --version "$MDTABLEFIX_VERSION"
+MDTABLEFIX_VERSION=0.5.1
+cargo binstall --no-confirm --locked --disable-strategies compile \
+  --install-path "$HOME/.local/bin" "mdtablefix@${MDTABLEFIX_VERSION}"
 ```
 
 ### Docstring structure

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2597,6 +2597,31 @@ The short version is:
 - `$(AMBRLEAKS)` scans `cuprum/unittests` and `tests`; exact deterministic
   fixture values that resemble secrets belong in `ambrleaks.toml`.
 
+
+### Markdown formatting
+
+`make fmt` runs `mdformat-all`, which applies `mdtablefix` with
+`--wrap --renumber --breaks --ellipsis --fences --in-place` before applying
+`markdownlint-cli2 --fix`. `mdtablefix` therefore owns table padding and
+paragraph wrapping, while `make markdownlint` verifies the result.
+
+`make check-fmt` passes repository Markdown files to
+`scripts/check-markdown-format.sh`. Because `mdtablefix` has no check-only
+mode, the checker formats temporary copies and compares them with the source
+files; it never modifies the worktree. It accepts exact LF or CRLF output, but
+rejects mixed line endings. Run `make test-markdown-format` after changing the
+checker.
+
+The gate requires the `mdtablefix` version pinned by `MDTABLEFIX_VERSION` in
+`.github/workflows/ci.yml`. Install that version locally so formatter output
+matches CI:
+
+```bash
+MDTABLEFIX_VERSION="$(sed -n "s/.*MDTABLEFIX_VERSION: '\(.*\)'.*/\1/p" \
+  .github/workflows/ci.yml)"
+cargo install --locked mdtablefix --version "$MDTABLEFIX_VERSION"
+```
+
 ### Docstring structure
 
 Public functions, classes, and methods require comprehensive NumPy-style

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -727,6 +727,8 @@ interpreters therefore confirm the contracts rather than skipping them.
 
 Pipeline byte movement is split so each module has one reason to change:
 
+Table 1: pipeline stream modules and their responsibilities
+
 | Module                        | Owns                                               |
 | ----------------------------- | -------------------------------------------------- |
 | `_pipeline_streams.py`        | Backend choice and the Python/Rust pump dispatch   |
@@ -829,6 +831,8 @@ break already-registered `MetricsHook` instances that match that closed set.
 `observe_pump` registers synchronous hooks in a `ContextVar`, and
 `PumpMetricsHook` maps the events to bounded counters and a cleanup-duration
 histogram:
+
+Table 1: metrics emitted by `PumpMetricsHook`
 
 | Metric                                       | Labels   |
 | -------------------------------------------- | -------- |

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2597,7 +2597,6 @@ The short version is:
 - `$(AMBRLEAKS)` scans `cuprum/unittests` and `tests`; exact deterministic
   fixture values that resemble secrets belong in `ambrleaks.toml`.
 
-
 ### Markdown formatting
 
 `make fmt` runs `mdformat-all`, which applies `mdtablefix` with

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -936,7 +936,7 @@ descriptive:
   `_PipelineSpawnResult.stages.observations`, the immutable `_StageWaitContext`
   snapshot passed to `_PipelineWaitState.from_processes` alongside
   `started_at`. It defaults to an empty tuple, and `_PipelineWaitState.exec_id`
-  then reports `None`, because the pure transition never reads it and the
+  then reports `None` because the pure transition never reads it and the
   symbolic model must not carry it.
 - `cuprum_terminated_stage_count` is what
   `_terminate_pipeline_remaining_stages` returns. Reporting it from the helper

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1078,7 +1078,9 @@ that turns the `ExecEvent` stream into OpenTelemetry-style spans. It depends
 only on the `Tracer` and `Span` protocols from
 `cuprum.adapters.tracing_protocols`, so any backend that implements them can be
 plugged in. `tracing_adapter` re-exports `Span` and `Tracer` as its public
-integration boundary. `cuprum/adapters/tracing_memory.py` supplies
+integration boundary. The legacy `cuprum.adapters._tracing_protocols` module is
+a compatibility re-export only and does not define a second protocol contract.
+`cuprum/adapters/tracing_memory.py` supplies
 `InMemoryTracer` and `InMemorySpan`, the reference doubles used by tests and
 examples: `InMemoryTracer` collects spans in memory and protects its span store
 through the shared `_LockedStore` lock (its mutators, and `reset()`, run under
@@ -1328,7 +1330,8 @@ Runtime (`cuprum/`):
   stages.
 - `cuprum/_streams_pump.py` — the stream pump loop with backpressure.
 - `cuprum/adapters/tracing_protocols.py` — the canonical PEP 544 `Span`/
-  `Tracer` protocols. `tracing_adapter` re-exports both.
+  `Tracer` protocols. `tracing_adapter` re-exports both;
+  `_tracing_protocols.py` remains a compatibility re-export only.
 
 Benchmarks (`benchmarks/`):
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2619,10 +2619,17 @@ The gate requires the `mdtablefix` version pinned by `MDTABLEFIX_VERSION` in
 `.github/workflows/ci.yml`. Install that version locally so formatter output
 matches CI:
 
+`mdtablefix` 0.5.0 requires Rust 1.89.0 when built from source. Cuprum's
+project toolchain remains Rust 1.85.0; CI uses `MDTABLEFIX_RUST_VERSION` to
+select Rust 1.89.0 only for this formatter fallback.
+
 ```bash
 MDTABLEFIX_VERSION="$(sed -n "s/.*MDTABLEFIX_VERSION: '\(.*\)'.*/\1/p" \
   .github/workflows/ci.yml)"
-cargo install --locked mdtablefix --version "$MDTABLEFIX_VERSION"
+MDTABLEFIX_RUST_VERSION="$(sed -n "s/.*MDTABLEFIX_RUST_VERSION: '\(.*\)'.*/\1/p" \
+  .github/workflows/ci.yml)"
+cargo +"$MDTABLEFIX_RUST_VERSION" install --locked mdtablefix \
+  --version "$MDTABLEFIX_VERSION"
 ```
 
 ### Docstring structure

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1084,11 +1084,11 @@ only on the `Tracer` and `Span` protocols from
 plugged in. `tracing_adapter` re-exports `Span` and `Tracer` as its public
 integration boundary. The legacy `cuprum.adapters._tracing_protocols` module is
 a compatibility re-export only and does not define a second protocol contract.
-`cuprum/adapters/tracing_memory.py` supplies
-`InMemoryTracer` and `InMemorySpan`, the reference doubles used by tests and
-examples: `InMemoryTracer` collects spans in memory and protects its span store
-through the shared `_LockedStore` lock (its mutators, and `reset()`, run under
-that lock), while `InMemorySpan` is a plain mutable record that provides no
+`cuprum/adapters/tracing_memory.py` supplies `InMemoryTracer` and
+`InMemorySpan`, the reference doubles used by tests and examples:
+`InMemoryTracer` collects spans in memory and protects its span store through
+the shared `_LockedStore` lock (its mutators, and `reset()`, run under that
+lock), while `InMemorySpan` is a plain mutable record that provides no
 synchronization of its own.
 
 **Phase dispatch.** `TracingHook.__call__` matches every `ExecEvent.phase` in a

--- a/docs/execplans/4-5-2-add-performance-guidance-to-users-guide.md
+++ b/docs/execplans/4-5-2-add-performance-guidance-to-users-guide.md
@@ -412,24 +412,24 @@ Do not mark the roadmap item done until every required gate passes.
 
 4. Run targeted tests and capture the red phase.
 
-```bash
-set -o pipefail
-uv run pytest -q cuprum/unittests/test_backend.py \
-  cuprum/unittests/test_pipeline_stream_backend_selection.py \
-  2>&1 | tee /tmp/4-5-2-targeted-unit-pre.log
-```
+   ```bash
+   set -o pipefail
+   uv run pytest -q cuprum/unittests/test_backend.py \
+     cuprum/unittests/test_pipeline_stream_backend_selection.py \
+     2>&1 | tee /tmp/4-5-2-targeted-unit-pre.log
+   ```
 
-```bash
-set -o pipefail
-uv run pytest -q tests/behaviour/test_backend_dispatcher_behaviour.py \
-  tests/behaviour/test_stream_backend_pipeline.py \
-  2>&1 | tee /tmp/4-5-2-targeted-bdd-pre.log
-```
+   ```bash
+   set -o pipefail
+   uv run pytest -q tests/behaviour/test_backend_dispatcher_behaviour.py \
+     tests/behaviour/test_stream_backend_pipeline.py \
+     2>&1 | tee /tmp/4-5-2-targeted-bdd-pre.log
+   ```
 
    Expected before documentation updates: a new or adjusted assertion should
    fail if the documented contract is not already covered correctly.
 
-1. Update `docs/users-guide.md`.
+5. Update `docs/users-guide.md`.
 
    The final guide should likely include:
 
@@ -445,7 +445,7 @@ uv run pytest -q tests/behaviour/test_backend_dispatcher_behaviour.py \
      transfers can see substantial improvements and should be measured with
      `make benchmark-e2e`.
 
-2. Update `docs/cuprum-design.md`.
+6. Update `docs/cuprum-design.md`.
 
    Reconcile section 13.5 and nearby text so the design document no longer
    implies that Rust consume-path acceleration is active if it is not.
@@ -454,45 +454,45 @@ uv run pytest -q tests/behaviour/test_backend_dispatcher_behaviour.py \
    in the design document as a design clarification rather than leaving it only
    in the guide.
 
-3. Mark roadmap item `4.5.2` done.
+7. Mark roadmap item `4.5.2` done.
 
    Update `docs/roadmap.md` only after the guide, design document, and tests
    all reflect the same final behaviour.
 
-4. Run full validation.
+8. Run full validation.
 
-```bash
-set -o pipefail
-make check-fmt 2>&1 | tee /tmp/4-5-2-check-fmt.log
-```
+   ```bash
+   set -o pipefail
+   make check-fmt 2>&1 | tee /tmp/4-5-2-check-fmt.log
+   ```
 
-```bash
-set -o pipefail
-make typecheck 2>&1 | tee /tmp/4-5-2-typecheck.log
-```
+   ```bash
+   set -o pipefail
+   make typecheck 2>&1 | tee /tmp/4-5-2-typecheck.log
+   ```
 
-```bash
-set -o pipefail
-make lint 2>&1 | tee /tmp/4-5-2-lint.log
-```
+   ```bash
+   set -o pipefail
+   make lint 2>&1 | tee /tmp/4-5-2-lint.log
+   ```
 
-```bash
-set -o pipefail
-make test 2>&1 | tee /tmp/4-5-2-test.log
-```
+   ```bash
+   set -o pipefail
+   make test 2>&1 | tee /tmp/4-5-2-test.log
+   ```
 
-```bash
-set -o pipefail
-MDLINT=/root/.bun/bin/markdownlint-cli2 make markdownlint \
-  2>&1 | tee /tmp/4-5-2-markdownlint.log
-```
+   ```bash
+   set -o pipefail
+   MDLINT=/root/.bun/bin/markdownlint-cli2 make markdownlint \
+     2>&1 | tee /tmp/4-5-2-markdownlint.log
+   ```
 
-```bash
-set -o pipefail
-make nixie 2>&1 | tee /tmp/4-5-2-nixie.log
-```
+   ```bash
+   set -o pipefail
+   make nixie 2>&1 | tee /tmp/4-5-2-nixie.log
+   ```
 
-1. Record the outcome in this ExecPlan.
+9. Record the outcome in this ExecPlan.
 
    Update:
 

--- a/docs/execplans/enforce-ize-identifiers.md
+++ b/docs/execplans/enforce-ize-identifiers.md
@@ -190,7 +190,7 @@ The final widened `spelling` target must report no unapproved source spelling.
   pattern ignores; accepting their words globally would weaken the gate.
 - Common Changelog repeats `Changed` headings across releases, while the
   repository's Markdown configuration rejects duplicate headings globally. The
-  existing released `Changed` heading now carries a one-line MD024 exception so
+  existing released `Changed` heading now carries a one-line MD024 exception, so
   the new Unreleased section can use the required conventional heading.
 
 ## Decision Log

--- a/docs/execplans/enforce-ize-identifiers.md
+++ b/docs/execplans/enforce-ize-identifiers.md
@@ -190,8 +190,8 @@ The final widened `spelling` target must report no unapproved source spelling.
   pattern ignores; accepting their words globally would weaken the gate.
 - Common Changelog repeats `Changed` headings across releases, while the
   repository's Markdown configuration rejects duplicate headings globally. The
-  existing released `Changed` heading now carries a one-line MD024 exception, so
-  the new Unreleased section can use the required conventional heading.
+  existing released `Changed` heading now carries a one-line MD024 exception,
+  so the new Unreleased section can use the required conventional heading.
 
 ## Decision Log
 

--- a/docs/execplans/enforce-ize-identifiers.md
+++ b/docs/execplans/enforce-ize-identifiers.md
@@ -189,10 +189,9 @@ The final widened `spelling` target must report no unapproved source spelling.
   exercise the spelling renderer and stream splitting. They require exact
   pattern ignores; accepting their words globally would weaken the gate.
 - Common Changelog repeats `Changed` headings across releases, while the
-  repository's Markdown configuration rejects duplicate headings globally.
-  The existing released `Changed` heading now carries a one-line MD024
-  exception so the new Unreleased section can use the required conventional
-  heading.
+  repository's Markdown configuration rejects duplicate headings globally. The
+  existing released `Changed` heading now carries a one-line MD024 exception so
+  the new Unreleased section can use the required conventional heading.
 
 ## Decision Log
 
@@ -217,8 +216,9 @@ milestone, and three foreground `coderabbit review --agent` runs reported zero
 findings.
 
 The exact requested branch is published and tracks its matching origin branch.
-Draft PR [#259](https://github.com/leynos/cuprum/pull/259) closes issue #249 and
-contains the literal Lody session reference. The main lesson is that whole-file
-spelling enforcement necessarily covers more than identifiers: external wire
-contracts and deliberate fixtures need precise local patterns, while all
-repository-owned source prose must start green before the pathspec widens.
+Draft PR [#259](https://github.com/leynos/cuprum/pull/259) closes issue #249
+and contains the literal Lody session reference. The main lesson is that
+whole-file spelling enforcement necessarily covers more than identifiers:
+external wire contracts and deliberate fixtures need precise local patterns,
+while all repository-owned source prose must start green before the pathspec
+widens.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -986,7 +986,7 @@ The hook attaches selected `cuprum_*` prefixed extra fields to log records:
 - `cuprum_stage_index` / `cuprum_stage_count`: Failing stage position and
   pipeline width (for `pipeline_fail_fast` events)
 - `cuprum_eof_grace_s` / `cuprum_pending_readers`: Fixed EOF-grace duration
-  and pending-reader count (for `capture_eof_grace_expired` events) Event tags
+  and pending-reader count (for `capture_eof_grace_expired` events). Event tags
   are not emitted by this structured logging adapter.
 
 When registered, `structured_logging_hook()` emits `pipeline_fail_fast` at

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -42,10 +42,10 @@ allowlist. It returns a cached, read-only mapping from project name to
 `ProjectSettings`.
 
 Callers upgrading from a release that exposed `visible_settings()` should
-remove the parentheses and adopt `catalogue.visible_settings` in the next
-minor release. The callable form remains a compatibility path during the
-transition; both forms return the same read-only mapping, and attempts to
-mutate it fail as before.
+remove the parentheses and adopt `catalogue.visible_settings` in the next minor
+release. The callable form remains a compatibility path during the transition;
+both forms return the same read-only mapping, and attempts to mutate it fail as
+before.
 
 ### Handling duplicate catalogue entries
 
@@ -1699,8 +1699,8 @@ The channel counts declines, post-cancellation failures, and native-pump
 cleanup. A successful hand-off emits no event, deliberately: there is no
 per-hop counter and no total-hop counter to divide by. So the decline counter
 gives the *number* of hops that left the fast path, not the *fraction* that
-stayed on it. To report that fraction, pair the decline counter with a hop total
-measured independently — for example, a separately maintained counter
+stayed on it. To report that fraction, pair the decline counter with a hop
+total measured independently — for example, a separately maintained counter
 incremented once per submitted inter-stage hop.
 
 Cancellation emits `PumpEvent.phase="cleanup_started"` when it starts waiting
@@ -1715,13 +1715,13 @@ the same `TracingHook` with both `sh.observe(hook)` and
 `observe_pump(hook.record_pump_event)`. For each inter-stage hop, the cleanup
 events reuse the source stage's `ExecId` only to find its existing open span;
 the token is not a trace attribute, and no PID is used for correlation. The
-hook emits `cuprum.cleanup_started` and `cuprum.cleanup_completed`. Both
-events carry the bounded
-attributes `operation="native_pump_cleanup"` and `outcome` (`"started"` or
-`"completed"`); only the completion event carries `duration_s`, in monotonic
-seconds. No descriptor numbers, command arguments, exception text, or other
-unbounded values are emitted. An event without a matching active span is
-dropped safely; cleanup tracing neither changes span status nor ends the span.
+hook emits `cuprum.cleanup_started` and `cuprum.cleanup_completed`. Both events
+carry the bounded attributes `operation="native_pump_cleanup"` and `outcome`
+(`"started"` or `"completed"`); only the completion event carries `duration_s`,
+in monotonic seconds. No descriptor numbers, command arguments, exception text,
+or other unbounded values are emitted. An event without a matching active span
+is dropped safely; cleanup tracing neither changes span status nor ends the
+span.
 
 #### Cleanup DEBUG records
 
@@ -1730,10 +1730,10 @@ Cancellation cleanup also emits `DEBUG` records on the
 `cuprum_action="rust_pump_cleanup"` and
 `cuprum_operation="native_pump_cleanup"`; start records have
 `cuprum_outcome="started"`, while completion records have
-`cuprum_outcome="completed"` and the completion-only
-`cuprum_duration_s` field. A completion record is emitted only after the
-native worker has released descriptor ownership. These logs and pump events
-are emitted during cancellation cleanup.
+`cuprum_outcome="completed"` and the completion-only `cuprum_duration_s` field.
+A completion record is emitted only after the native worker has released
+descriptor ownership. These logs and pump events are emitted during
+cancellation cleanup.
 
 ```python
 from cuprum.adapters.metrics_adapter import InMemoryMetrics
@@ -1762,7 +1762,7 @@ with sh.observe(MetricsHook(metrics)), observe_pump(PumpMetricsHook(metrics)):
 Table 2: counters emitted by `PumpMetricsHook`
 
 | Counter                                      | Labels   | Incremented when                                                 |
-| -------------------------------------------- | -------- | ---------------------------------------------------------------  |
+| -------------------------------------------- | -------- | ---------------------------------------------------------------- |
 | `cuprum_rust_pump_declined_total`            | `reason` | a hop fell back from the Rust pump to the Python pump            |
 | `cuprum_rust_pump_failed_after_cancel_total` | none     | a cancelled hop's Rust worker failure was consumed and recorded  |
 | `cuprum_rust_pump_cleanup_total`             | none     | native cleanup completed after cancellation                      |

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -810,8 +810,8 @@ once per execution and excludes expected `CancelledError` failures.
 The `capture_eof_grace_expired` event carries the execution's `exec_id` and
 `pid`, `operation` (`"drain"`), `eof_grace_s`, and `pending_readers` (one or
 two). It is emitted only when a capturing drain reaches the fixed grace limit;
-the corresponding `cuprum_capture_eof_grace_expired_total` metric uses only
-the `program` and `project` labels, and tracing adds a
+the corresponding `cuprum_capture_eof_grace_expired_total` metric uses only the
+`program` and `project` labels, and tracing adds a
 `cuprum.capture_eof_grace_expired` event to the matching span. The grace-expiry
 event itself carries no captured stdout or stderr payload.
 
@@ -986,8 +986,8 @@ The hook attaches selected `cuprum_*` prefixed extra fields to log records:
 - `cuprum_stage_index` / `cuprum_stage_count`: Failing stage position and
   pipeline width (for `pipeline_fail_fast` events)
 - `cuprum_eof_grace_s` / `cuprum_pending_readers`: Fixed EOF-grace duration
-  and pending-reader count (for `capture_eof_grace_expired` events)
-Event tags are not emitted by this structured logging adapter.
+  and pending-reader count (for `capture_eof_grace_expired` events) Event tags
+  are not emitted by this structured logging adapter.
 
 When registered, `structured_logging_hook()` emits `pipeline_fail_fast` at
 `LogLevels.fail_fast_level`, which defaults to `logging.WARNING`. This default
@@ -1146,14 +1146,14 @@ Output lines (stdout/stderr) are recorded as span events when
 `record_output=True` (the default).
 
 **Ancillary span events.** `stdin_error`, `timeout`, `teardown_error`, and
-`capture_eof_grace_expired` are
-recorded as `cuprum.<phase>` events on the execution's open span. They leave it
-neither ended nor marked; a later `exit` closes it normally. `timeout` is
-always followed by `exit`, while `teardown_error` may be the final event.
-Ancillary events carry their set `line`, `operation`, `error_type`, `note`,
-`timeout_s`, `timeout_mode`, `eof_grace_s`, and `pending_readers` fields, and
-correlate by `exec_id`; an event without a matching open span is dropped.
-The grace-expiry event carries no captured stdout or stderr payload.
+`capture_eof_grace_expired` are recorded as `cuprum.<phase>` events on the
+execution's open span. They leave it neither ended nor marked; a later `exit`
+closes it normally. `timeout` is always followed by `exit`, while
+`teardown_error` may be the final event. Ancillary events carry their set
+`line`, `operation`, `error_type`, `note`, `timeout_s`, `timeout_mode`,
+`eof_grace_s`, and `pending_readers` fields, and correlate by `exec_id`; an
+event without a matching open span is dropped. The grace-expiry event carries
+no captured stdout or stderr payload.
 
 **Correlation note:** the hook correlates an execution's `start`, `stdout`,
 `stderr`, and `exit` events by `ExecEvent.exec_id`, a stable token minted once
@@ -1164,8 +1164,7 @@ always carry an `exec_id`, so ordinary usage is unaffected. Only hand-built or
 legacy events that omit `exec_id` are affected: the hook cannot correlate them,
 so it ignores them — a `start` without an `exec_id` creates no span, and
 `stdout`/`stderr`/`stdin_error`/`timeout`/`teardown_error`/
-`capture_eof_grace_expired`/`pipeline_fail_fast`/`exit` without one are
-dropped.
+`capture_eof_grace_expired`/`pipeline_fail_fast`/`exit` without one are dropped.
 
 A pipeline's `pipeline_fail_fast` event is recorded as a
 `cuprum.pipeline_fail_fast` span event on the failing stage's already-open

--- a/scripts/check-markdown-format.sh
+++ b/scripts/check-markdown-format.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verifies that Markdown sources are already in the canonical form `make fmt`
+# produces, without modifying any tracked file.
+#
+# `mdtablefix` owns table padding and paragraph wrapping. It has no check-only
+# mode, so this script formats staged copies in one batch, then compares each
+# result against the corresponding source without modifying tracked files.
+# `mdtablefix` emits LF, whereas Git can check text out with CRLF on Windows;
+# the comparison accepts only either exact line-ending form. Keep the flags in
+# step with the `mdtablefix` invocation in
+# `mdformat-all`, which `make fmt` runs.
+#
+# `make fmt` also applies `markdownlint-cli2 --fix` after `mdtablefix`, but that
+# pass is deliberately not replayed here. `make markdownlint` already rejects
+# any lint violation, so on a passing tree `--fix` has nothing to change.
+# Comparing against `mdtablefix` alone additionally surfaces documents the two
+# tools would fight over -- a heading nested inside an ordered list, for
+# instance, ends the list for `mdtablefix` while `MD029` keeps renumbering it --
+# which indicates malformed Markdown that should be restructured.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $(basename "$0") <file>..." >&2
+  exit 64 # EX_USAGE
+fi
+
+MDTABLEFIX="${MDTABLEFIX:-mdtablefix}"
+
+if ! command -v "$MDTABLEFIX" >/dev/null 2>&1; then
+  echo "$(basename "$0"): '$MDTABLEFIX' is not installed or not on PATH." >&2
+  exit 127
+fi
+
+staged_directory="$(mktemp -d)"
+trap 'rm -rf "$staged_directory"' EXIT
+
+original_files=()
+staged_files=()
+for file in "$@"; do
+  staged_file="$staged_directory/${#original_files[@]}.md"
+  cp -- "$file" "$staged_file"
+  original_files+=("$file")
+  staged_files+=("$staged_file")
+done
+
+"$MDTABLEFIX" --in-place --wrap --renumber --breaks --ellipsis --fences \
+  "${staged_files[@]}"
+
+unformatted=()
+for index in "${!original_files[@]}"; do
+  original_file="${original_files[$index]}"
+  staged_file="${staged_files[$index]}"
+  if ! cmp -s "$staged_file" "$original_file" \
+    && ! sed $'s/$/\r/' "$staged_file" | cmp -s - "$original_file"; then
+    unformatted+=("$original_file")
+  fi
+done
+
+if [[ ${#unformatted[@]} -gt 0 ]]; then
+  echo "The following Markdown files are not formatted; run 'make fmt':" >&2
+  printf '  %s\n' "${unformatted[@]}" >&2
+  exit 1
+fi

--- a/scripts/check-markdown-format.sh
+++ b/scripts/check-markdown-format.sh
@@ -50,9 +50,12 @@ unformatted=()
 for index in "${!original_files[@]}"; do
   original_file="${original_files[$index]}"
   staged_file="${staged_files[$index]}"
-  if ! cmp -s "$staged_file" "$original_file" \
-    && ! sed $'s/$/\r/' "$staged_file" | cmp -s - "$original_file"; then
-    unformatted+=("$original_file")
+  if ! cmp -s "$staged_file" "$original_file"; then
+    crlf_staged_file="${staged_file}.crlf"
+    sed $'s/$/\r/' "$staged_file" > "$crlf_staged_file"
+    if ! cmp -s "$crlf_staged_file" "$original_file"; then
+      unformatted+=("$original_file")
+    fi
   fi
 done
 

--- a/scripts/markdown_format_test_support.py
+++ b/scripts/markdown_format_test_support.py
@@ -1,0 +1,134 @@
+"""Support the process-boundary Markdown formatting gate tests."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - the process boundary is under test.
+import typing as typ
+from pathlib import Path
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CHECKER = REPOSITORY_ROOT / "scripts" / "check-markdown-format.sh"
+
+_DEFAULT_TRACKED_FILES = (
+    Path("guide.md"),
+    Path("nested") / "tracked with spaces.md",
+    Path("nested") / "tracked\nwith newline.md",
+)
+
+
+class _UnavailableTestDependencyError(RuntimeError):
+    """Report a missing external dependency for the integration test setup."""
+
+    def __init__(self, dependency: str) -> None:
+        self._dependency = dependency
+
+    def __str__(self) -> str:
+        return f"the gate integration test requires {self._dependency}"
+
+
+def run_process(
+    command: list[str],
+    environment: cabc.Mapping[str, str],
+    current_directory: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a controlled process with captured output."""
+    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - executes the controlled fixture.
+        command,
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+        cwd=current_directory,
+    )
+
+
+def create_format_gate_repository(
+    temporary_directory: Path,
+    tracked_files: tuple[Path, ...] = _DEFAULT_TRACKED_FILES,
+) -> tuple[Path, tuple[Path, ...], Path]:
+    """Create tracked, ignored, and untracked Markdown sources for the gate."""
+    repository = temporary_directory / "repository"
+    repository.mkdir()
+    for path in tracked_files:
+        source = repository / path
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("formatted\n", encoding="utf-8")
+    (repository / ".gitignore").write_text("ignored.md\n", encoding="utf-8")
+    (repository / "ignored.md").write_text("formatted\n", encoding="utf-8")
+    (repository / "untracked.md").write_text("formatted\n", encoding="utf-8")
+    (repository / "ruff").touch()
+    write_markdown_checker_stub(repository)
+    return repository, tracked_files, repository / "checker-paths.bin"
+
+
+def stage_markdown_sources(repository: Path, tracked_files: tuple[Path, ...]) -> None:
+    """Initialize a Git index containing the formatter's Markdown inputs."""
+    git = shutil.which("git")
+    if git is None:
+        raise _UnavailableTestDependencyError("Git")
+    initialized = run_process([git, "init", "-q"], os.environ, repository)
+    if initialized.returncode != 0:
+        raise AssertionError(initialized.stdout + initialized.stderr)
+    added = run_process(
+        [git, "add", ".gitignore", *(str(path) for path in tracked_files)],
+        os.environ,
+        repository,
+    )
+    if added.returncode != 0:
+        raise AssertionError(added.stdout + added.stderr)
+
+
+def run_check_format_gate(
+    repository: Path,
+    checker_log: Path,
+    markdown_discovery: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real formatting recipe against the controlled repository."""
+    make = shutil.which("make")
+    if make is None:
+        raise _UnavailableTestDependencyError("make")
+    command_stub = write_successful_command(repository)
+    discovery_override = (
+        [] if markdown_discovery is None else [f"MD_FILES_FIND={markdown_discovery}"]
+    )
+    return run_process(
+        [
+            make,
+            "-f",
+            str(REPOSITORY_ROOT / "Makefile"),
+            "check-fmt",
+            "VENV_TOOLS=",
+            f"RUFF={command_stub}",
+            f"CARGO={command_stub}",
+            "RUST_DIR=.",
+            *discovery_override,
+        ],
+        os.environ | {"MARKDOWN_CHECKER_CALL_LOG": str(checker_log)},
+        repository,
+    )
+
+
+def write_successful_command(directory: Path) -> Path:
+    """Create a command stub that accepts every argument."""
+    executable = directory / "successful-command"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    return executable
+
+
+def write_markdown_checker_stub(directory: Path) -> Path:
+    """Create a checker stub that records its NUL-delimited path arguments."""
+    scripts_directory = directory / "scripts"
+    scripts_directory.mkdir()
+    checker = scripts_directory / "check-markdown-format.sh"
+    checker.write_text(
+        '#!/bin/sh\nprintf \'%s\\0\' "$@" > "$MARKDOWN_CHECKER_CALL_LOG"\n',
+        encoding="utf-8",
+    )
+    checker.chmod(0o755)
+    return checker

--- a/scripts/tests/test_check_markdown_format.py
+++ b/scripts/tests/test_check_markdown_format.py
@@ -26,7 +26,7 @@ LINE_ALPHABET = tuple("abcdefghijklmnopqrstuvwxyz0123456789 -_[]*")
 
 
 def _write_fake_formatter(directory: Path) -> tuple[Path, Path]:
-    """Create a formatter fixture that records calls and canonicalises bytes."""
+    """Create a formatter fixture that records calls and canonicalizes bytes."""
     executable = directory / "mdtablefix"
     call_log = directory / "formatter-calls.jsonl"
     executable.write_text(

--- a/scripts/tests/test_check_markdown_format.py
+++ b/scripts/tests/test_check_markdown_format.py
@@ -1,4 +1,9 @@
-"""Exercise the Markdown formatter checker at its process boundary."""
+"""Exercise the Markdown formatter checker at its process boundary.
+
+The tests invoke ``scripts/check-markdown-format.sh`` through the Makefile's
+``check-fmt`` gate seam. They cover batching, LF and CRLF line endings, source
+preservation, formatter errors, and argument validation.
+"""
 
 from __future__ import annotations
 
@@ -182,11 +187,15 @@ def _stage_markdown_sources(repository: Path, tracked_files: tuple[Path, ...]) -
 def _run_check_format_gate(
     repository: Path,
     checker_log: Path,
+    markdown_discovery: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run the real formatting recipe against the controlled repository."""
     make = shutil.which("make")
     assert make is not None, "the gate integration test requires make"
     command_stub = _write_successful_command(repository)
+    discovery_override = (
+        [] if markdown_discovery is None else [f"MD_FILES_FIND={markdown_discovery}"]
+    )
     return _run_process(
         [
             make,
@@ -197,6 +206,7 @@ def _run_check_format_gate(
             f"RUFF={command_stub}",
             f"CARGO={command_stub}",
             "RUST_DIR=.",
+            *discovery_override,
         ],
         os.environ | {"MARKDOWN_CHECKER_CALL_LOG": str(checker_log)},
         repository,
@@ -331,6 +341,19 @@ def test_check_format_passes_only_tracked_markdown_sources(tmp_path: Path) -> No
     expected_paths = sorted(path.as_posix().encode() for path in tracked_files)
     assert recorded_paths == expected_paths, (
         "the formatting gate must pass exactly every tracked Markdown source"
+    )
+
+
+def test_check_format_rejects_markdown_discovery_failure(tmp_path: Path) -> None:
+    """Fail closed when Git cannot enumerate tracked Markdown sources."""
+    repository, tracked_files, checker_log = _create_format_gate_repository(tmp_path)
+    _stage_markdown_sources(repository, tracked_files)
+
+    result = _run_check_format_gate(repository, checker_log, markdown_discovery="false")
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert not checker_log.exists(), (
+        "the formatting checker must not run after Markdown discovery fails"
     )
 
 

--- a/scripts/tests/test_check_markdown_format.py
+++ b/scripts/tests/test_check_markdown_format.py
@@ -304,6 +304,22 @@ def test_reports_each_noncanonical_source_without_modifying_it(
     )
 
 
+def test_rejects_large_noncanonical_source_without_a_sed_broken_pipe(
+    formatter: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    """Report format drift without leaking a SIGPIPE diagnostic from `sed`."""
+    executable, call_log = formatter
+    source = tmp_path / "large-unformatted.md"
+    source.write_bytes(b"unformatted\n" + b"formatted\n" * 100_000)
+
+    result = _run_checker(executable, call_log, source)
+
+    assert result.returncode == 1, result.stderr
+    assert "Broken pipe" not in result.stderr, result.stderr
+    assert str(source) in result.stderr, result.stderr
+
+
 def test_check_format_passes_only_tracked_markdown_sources(tmp_path: Path) -> None:
     """Exercise the Makefile gate's tracked, NUL-delimited Markdown discovery."""
     repository, tracked_files, checker_log = _create_format_gate_repository(tmp_path)

--- a/scripts/tests/test_check_markdown_format.py
+++ b/scripts/tests/test_check_markdown_format.py
@@ -1,0 +1,229 @@
+"""Exercise the Markdown formatter checker at its process boundary."""
+
+import json
+import os
+import subprocess  # noqa: S404 - the process boundary is under test.
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPOSITORY_ROOT / "scripts" / "check-markdown-format.sh"
+FORMATTER_FLAGS = [
+    "--in-place",
+    "--wrap",
+    "--renumber",
+    "--breaks",
+    "--ellipsis",
+    "--fences",
+]
+LINE_ALPHABET = tuple("abcdefghijklmnopqrstuvwxyz0123456789 -_[]*")
+
+
+def _write_fake_formatter(directory: Path) -> tuple[Path, Path]:
+    """Create a formatter fixture that records calls and canonicalises bytes."""
+    executable = directory / "mdtablefix"
+    call_log = directory / "formatter-calls.jsonl"
+    executable.write_text(
+        textwrap.dedent(
+            """\
+            #!__PYTHON__
+            import json
+            import os
+            import pathlib
+            import sys
+
+            arguments = sys.argv[1:]
+            if arguments == ["--version"]:
+                print("mdtablefix 0.5.0")
+                raise SystemExit(0)
+
+            expected_flags = [
+                "--in-place",
+                "--wrap",
+                "--renumber",
+                "--breaks",
+                "--ellipsis",
+                "--fences",
+            ]
+            if arguments[:len(expected_flags)] != expected_flags:
+                print("unexpected formatter flags", file=sys.stderr)
+                raise SystemExit(64)
+
+            paths = arguments[len(expected_flags):]
+            if not paths:
+                print("expected at least one Markdown path", file=sys.stderr)
+                raise SystemExit(64)
+
+            with pathlib.Path(os.environ["MDTABLEFIX_CALL_LOG"]).open("a") as log:
+                print(json.dumps(arguments), file=log)
+
+            for path in paths:
+                source = pathlib.Path(path)
+                canonical = source.read_bytes().replace(b"\\r\\n", b"\\n")
+                canonical = canonical.replace(b"\\r", b"\\n")
+                source.write_bytes(canonical.replace(b"unformatted", b"formatted"))
+            """
+        ).replace("__PYTHON__", sys.executable),
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return executable, call_log
+
+
+@pytest.fixture
+def formatter(tmp_path: Path) -> tuple[Path, Path]:
+    """Provide a controlled formatter executable and its call log."""
+    return _write_fake_formatter(tmp_path)
+
+
+def _run_checker(
+    formatter: Path,
+    call_log: Path,
+    *files: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Run the checker against files with the controlled formatter fixture."""
+    environment = os.environ | {
+        "MDTABLEFIX": str(formatter),
+        "MDTABLEFIX_CALL_LOG": str(call_log),
+    }
+    return subprocess.run(  # noqa: S603 - executes the controlled fixture.
+        [str(CHECKER), *(str(file) for file in files)],
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+    )
+
+
+def test_requires_at_least_one_markdown_file(formatter: tuple[Path, Path]) -> None:
+    """Reject an empty file list before trying to invoke the formatter."""
+    executable, call_log = formatter
+
+    result = _run_checker(executable, call_log)
+
+    assert result.returncode == 64, result.stderr
+    assert "Usage:" in result.stderr, result.stderr
+    assert not call_log.exists(), "the formatter must not run for an empty file list"
+
+
+def test_reports_a_missing_formatter(tmp_path: Path) -> None:
+    """Explain how to supply the formatter when its executable is unavailable."""
+    source = tmp_path / "source.md"
+    source.write_text("formatted\n", encoding="utf-8")
+
+    result = _run_checker(tmp_path / "missing-mdtablefix", tmp_path / "calls", source)
+
+    assert result.returncode == 127, result.stderr
+    assert "is not installed or not on PATH" in result.stderr, result.stderr
+
+
+def test_accepts_lf_and_crlf_without_modifying_sources(
+    formatter: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    """Accept exact canonical output in either Git checkout line-ending form."""
+    executable, call_log = formatter
+    lf_source = tmp_path / "lf.md"
+    crlf_source = tmp_path / "crlf.md"
+    lf_source.write_bytes(b"formatted\n")
+    crlf_source.write_bytes(b"formatted\r\n")
+
+    result = _run_checker(executable, call_log, lf_source, crlf_source)
+
+    assert result.returncode == 0, result.stderr
+    assert lf_source.read_bytes() == b"formatted\n", (
+        "the checker modified the LF source"
+    )
+    assert crlf_source.read_bytes() == b"formatted\r\n", (
+        "the checker modified the CRLF source"
+    )
+    calls = [
+        json.loads(line) for line in call_log.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(calls) == 1, "the checker must invoke the formatter once per batch"
+    assert calls[0][: len(FORMATTER_FLAGS)] == FORMATTER_FLAGS, (
+        "the checker must pass the canonical formatter flags"
+    )
+    staged_paths = [Path(path) for path in calls[0][len(FORMATTER_FLAGS) :]]
+    assert [path.name for path in staged_paths] == ["0.md", "1.md"], (
+        "the formatter must receive staged source copies"
+    )
+    assert all(path.parent != tmp_path for path in staged_paths), (
+        "the formatter must not receive tracked source paths"
+    )
+
+
+def test_reports_each_noncanonical_source_without_modifying_it(
+    formatter: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    """Reject altered and mixed-ending files while leaving every source intact."""
+    executable, call_log = formatter
+    unformatted_source = tmp_path / "unformatted.md"
+    mixed_source = tmp_path / "mixed.md"
+    canonical_source = tmp_path / "canonical.md"
+    unformatted_source.write_bytes(b"unformatted\n")
+    mixed_source.write_bytes(b"formatted\r\nsecond line\n")
+    canonical_source.write_bytes(b"formatted\n")
+
+    result = _run_checker(
+        executable,
+        call_log,
+        unformatted_source,
+        mixed_source,
+        canonical_source,
+    )
+
+    assert result.returncode == 1, result.stderr
+    assert str(unformatted_source) in result.stderr, result.stderr
+    assert str(mixed_source) in result.stderr, result.stderr
+    assert str(canonical_source) not in result.stderr, result.stderr
+    assert unformatted_source.read_bytes() == b"unformatted\n", (
+        "the checker modified the unformatted source"
+    )
+    assert mixed_source.read_bytes() == b"formatted\r\nsecond line\n", (
+        "the checker modified the mixed-ending source"
+    )
+    assert canonical_source.read_bytes() == b"formatted\n", (
+        "the checker modified the canonical source"
+    )
+    calls = [
+        json.loads(line) for line in call_log.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(calls) == 1, "the checker must invoke the formatter once per batch"
+    assert len(calls[0]) == len(FORMATTER_FLAGS) + 3, (
+        "the formatter must receive every source in the batch"
+    )
+
+
+@given(
+    lines=st.lists(st.text(alphabet=LINE_ALPHABET, max_size=40), min_size=2, max_size=5)
+)
+@settings(deadline=None)
+def test_accepts_only_uniform_canonical_line_endings(lines: list[str]) -> None:
+    """Accept LF and CRLF canonical forms while rejecting a mixed equivalent."""
+    canonical = "\n".join(lines) + "\n"
+    with tempfile.TemporaryDirectory() as directory_name:
+        directory = Path(directory_name)
+        executable, call_log = _write_fake_formatter(directory)
+        lf_source = directory / "lf.md"
+        crlf_source = directory / "crlf.md"
+        mixed_source = directory / "mixed.md"
+        lf_source.write_text(canonical, encoding="utf-8")
+        crlf_source.write_bytes(canonical.replace("\n", "\r\n").encode())
+        mixed_source.write_bytes(
+            (lines[0] + "\r\n" + "\n".join(lines[1:]) + "\n").encode()
+        )
+
+        passing = _run_checker(executable, call_log, lf_source, crlf_source)
+        failing = _run_checker(executable, call_log, mixed_source)
+
+    assert passing.returncode == 0, passing.stderr
+    assert failing.returncode == 1, failing.stderr
+    assert str(mixed_source) in failing.stderr, failing.stderr

--- a/scripts/tests/test_check_markdown_format.py
+++ b/scripts/tests/test_check_markdown_format.py
@@ -1,27 +1,34 @@
 """Exercise the Markdown formatter checker at its process boundary."""
 
+from __future__ import annotations
+
 import json
 import os
+import shutil
 import subprocess  # ruff: ignore[suspicious-subprocess-import] - the process boundary is under test.
 import sys
 import tempfile
 import textwrap
+import typing as typ
 from pathlib import Path
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 CHECKER = REPOSITORY_ROOT / "scripts" / "check-markdown-format.sh"
-FORMATTER_FLAGS = [
+FORMATTER_FLAGS = (
     "--in-place",
     "--wrap",
     "--renumber",
     "--breaks",
     "--ellipsis",
     "--fences",
-]
+)
 LINE_ALPHABET = tuple("abcdefghijklmnopqrstuvwxyz0123456789 -_[]*")
 
 
@@ -82,22 +89,117 @@ def formatter(tmp_path: Path) -> tuple[Path, Path]:
     return _write_fake_formatter(tmp_path)
 
 
+def _run_process(
+    command: list[str],
+    environment: cabc.Mapping[str, str],
+    current_directory: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a controlled process with captured output."""
+    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - executes the controlled fixture.
+        command,
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+        cwd=current_directory,
+    )
+
+
 def _run_checker(
     formatter: Path,
     call_log: Path,
     *files: Path,
 ) -> subprocess.CompletedProcess[str]:
     """Run the checker against files with the controlled formatter fixture."""
-    environment = os.environ | {
-        "MDTABLEFIX": str(formatter),
-        "MDTABLEFIX_CALL_LOG": str(call_log),
-    }
-    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - executes the controlled fixture.
+    return _run_process(
         [str(CHECKER), *(str(file) for file in files)],
-        capture_output=True,
-        check=False,
-        env=environment,
-        text=True,
+        os.environ
+        | {
+            "MDTABLEFIX": str(formatter),
+            "MDTABLEFIX_CALL_LOG": str(call_log),
+        },
+    )
+
+
+def _write_successful_command(directory: Path) -> Path:
+    """Create a command stub that accepts every argument."""
+    executable = directory / "successful-command"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    return executable
+
+
+def _write_markdown_checker_stub(directory: Path) -> Path:
+    """Create a checker stub that records its NUL-delimited path arguments."""
+    scripts_directory = directory / "scripts"
+    scripts_directory.mkdir()
+    checker = scripts_directory / "check-markdown-format.sh"
+    checker.write_text(
+        '#!/bin/sh\nprintf \'%s\\0\' "$@" > "$MARKDOWN_CHECKER_CALL_LOG"\n',
+        encoding="utf-8",
+    )
+    checker.chmod(0o755)
+    return checker
+
+
+def _create_format_gate_repository(
+    temporary_directory: Path,
+) -> tuple[Path, tuple[Path, ...], Path]:
+    """Create tracked, ignored, and untracked Markdown sources for the gate."""
+    repository = temporary_directory / "repository"
+    repository.mkdir()
+    tracked_files = (
+        Path("guide.md"),
+        Path("nested") / "tracked with spaces.md",
+        Path("nested") / "tracked\nwith newline.md",
+    )
+    for path in tracked_files:
+        source = repository / path
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("formatted\n", encoding="utf-8")
+    (repository / ".gitignore").write_text("ignored.md\n", encoding="utf-8")
+    (repository / "ignored.md").write_text("formatted\n", encoding="utf-8")
+    (repository / "untracked.md").write_text("formatted\n", encoding="utf-8")
+    (repository / "ruff").touch()
+    _write_markdown_checker_stub(repository)
+    return repository, tracked_files, repository / "checker-paths.bin"
+
+
+def _stage_markdown_sources(repository: Path, tracked_files: tuple[Path, ...]) -> None:
+    """Initialize a Git index containing the formatter's Markdown inputs."""
+    git = shutil.which("git")
+    assert git is not None, "the gate integration test requires Git"
+    initialized = _run_process([git, "init", "-q"], os.environ, repository)
+    assert initialized.returncode == 0, initialized.stdout + initialized.stderr
+    added = _run_process(
+        [git, "add", ".gitignore", *(str(path) for path in tracked_files)],
+        os.environ,
+        repository,
+    )
+    assert added.returncode == 0, added.stdout + added.stderr
+
+
+def _run_check_format_gate(
+    repository: Path,
+    checker_log: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real formatting recipe against the controlled repository."""
+    make = shutil.which("make")
+    assert make is not None, "the gate integration test requires make"
+    command_stub = _write_successful_command(repository)
+    return _run_process(
+        [
+            make,
+            "-f",
+            str(REPOSITORY_ROOT / "Makefile"),
+            "check-fmt",
+            "VENV_TOOLS=",
+            f"RUFF={command_stub}",
+            f"CARGO={command_stub}",
+            "RUST_DIR=.",
+        ],
+        os.environ | {"MARKDOWN_CHECKER_CALL_LOG": str(checker_log)},
+        repository,
     )
 
 
@@ -147,7 +249,7 @@ def test_accepts_lf_and_crlf_without_modifying_sources(
         json.loads(line) for line in call_log.read_text(encoding="utf-8").splitlines()
     ]
     assert len(calls) == 1, "the checker must invoke the formatter once per batch"
-    assert calls[0][: len(FORMATTER_FLAGS)] == FORMATTER_FLAGS, (
+    assert tuple(calls[0][: len(FORMATTER_FLAGS)]) == FORMATTER_FLAGS, (
         "the checker must pass the canonical formatter flags"
     )
     staged_paths = [Path(path) for path in calls[0][len(FORMATTER_FLAGS) :]]
@@ -199,6 +301,20 @@ def test_reports_each_noncanonical_source_without_modifying_it(
     assert len(calls) == 1, "the checker must invoke the formatter once per batch"
     assert len(calls[0]) == len(FORMATTER_FLAGS) + 3, (
         "the formatter must receive every source in the batch"
+    )
+
+
+def test_check_format_passes_only_tracked_markdown_sources(tmp_path: Path) -> None:
+    """Exercise the Makefile gate's tracked, NUL-delimited Markdown discovery."""
+    repository, tracked_files, checker_log = _create_format_gate_repository(tmp_path)
+    _stage_markdown_sources(repository, tracked_files)
+    result = _run_check_format_gate(repository, checker_log)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    recorded_paths = checker_log.read_bytes().removesuffix(b"\0").split(b"\0")
+    expected_paths = sorted(path.as_posix().encode() for path in tracked_files)
+    assert recorded_paths == expected_paths, (
+        "the formatting gate must pass exactly every tracked Markdown source"
     )
 
 

--- a/scripts/tests/test_check_markdown_format.py
+++ b/scripts/tests/test_check_markdown_format.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-import subprocess  # noqa: S404 - the process boundary is under test.
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - the process boundary is under test.
 import sys
 import tempfile
 import textwrap
@@ -92,7 +92,7 @@ def _run_checker(
         "MDTABLEFIX": str(formatter),
         "MDTABLEFIX_CALL_LOG": str(call_log),
     }
-    return subprocess.run(  # noqa: S603 - executes the controlled fixture.
+    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - executes the controlled fixture.
         [str(CHECKER), *(str(file) for file in files)],
         capture_output=True,
         check=False,

--- a/scripts/tests/test_check_markdown_format.py
+++ b/scripts/tests/test_check_markdown_format.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
-import subprocess  # ruff: ignore[suspicious-subprocess-import] - the process boundary is under test.
 import sys
 import tempfile
 import textwrap
@@ -21,11 +19,16 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-if typ.TYPE_CHECKING:
-    import collections.abc as cabc
+from scripts.markdown_format_test_support import (
+    CHECKER,
+    create_format_gate_repository,
+    run_check_format_gate,
+    run_process,
+    stage_markdown_sources,
+)
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-CHECKER = REPOSITORY_ROOT / "scripts" / "check-markdown-format.sh"
+if typ.TYPE_CHECKING:
+    import subprocess
 FORMATTER_FLAGS = (
     "--in-place",
     "--wrap",
@@ -94,122 +97,19 @@ def formatter(tmp_path: Path) -> tuple[Path, Path]:
     return _write_fake_formatter(tmp_path)
 
 
-def _run_process(
-    command: list[str],
-    environment: cabc.Mapping[str, str],
-    current_directory: Path | None = None,
-) -> subprocess.CompletedProcess[str]:
-    """Run a controlled process with captured output."""
-    return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true] - executes the controlled fixture.
-        command,
-        capture_output=True,
-        check=False,
-        env=environment,
-        text=True,
-        cwd=current_directory,
-    )
-
-
 def _run_checker(
     formatter: Path,
     call_log: Path,
     *files: Path,
 ) -> subprocess.CompletedProcess[str]:
     """Run the checker against files with the controlled formatter fixture."""
-    return _run_process(
+    return run_process(
         [str(CHECKER), *(str(file) for file in files)],
         os.environ
         | {
             "MDTABLEFIX": str(formatter),
             "MDTABLEFIX_CALL_LOG": str(call_log),
         },
-    )
-
-
-def _write_successful_command(directory: Path) -> Path:
-    """Create a command stub that accepts every argument."""
-    executable = directory / "successful-command"
-    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    executable.chmod(0o755)
-    return executable
-
-
-def _write_markdown_checker_stub(directory: Path) -> Path:
-    """Create a checker stub that records its NUL-delimited path arguments."""
-    scripts_directory = directory / "scripts"
-    scripts_directory.mkdir()
-    checker = scripts_directory / "check-markdown-format.sh"
-    checker.write_text(
-        '#!/bin/sh\nprintf \'%s\\0\' "$@" > "$MARKDOWN_CHECKER_CALL_LOG"\n',
-        encoding="utf-8",
-    )
-    checker.chmod(0o755)
-    return checker
-
-
-def _create_format_gate_repository(
-    temporary_directory: Path,
-) -> tuple[Path, tuple[Path, ...], Path]:
-    """Create tracked, ignored, and untracked Markdown sources for the gate."""
-    repository = temporary_directory / "repository"
-    repository.mkdir()
-    tracked_files = (
-        Path("guide.md"),
-        Path("nested") / "tracked with spaces.md",
-        Path("nested") / "tracked\nwith newline.md",
-    )
-    for path in tracked_files:
-        source = repository / path
-        source.parent.mkdir(parents=True, exist_ok=True)
-        source.write_text("formatted\n", encoding="utf-8")
-    (repository / ".gitignore").write_text("ignored.md\n", encoding="utf-8")
-    (repository / "ignored.md").write_text("formatted\n", encoding="utf-8")
-    (repository / "untracked.md").write_text("formatted\n", encoding="utf-8")
-    (repository / "ruff").touch()
-    _write_markdown_checker_stub(repository)
-    return repository, tracked_files, repository / "checker-paths.bin"
-
-
-def _stage_markdown_sources(repository: Path, tracked_files: tuple[Path, ...]) -> None:
-    """Initialize a Git index containing the formatter's Markdown inputs."""
-    git = shutil.which("git")
-    assert git is not None, "the gate integration test requires Git"
-    initialized = _run_process([git, "init", "-q"], os.environ, repository)
-    assert initialized.returncode == 0, initialized.stdout + initialized.stderr
-    added = _run_process(
-        [git, "add", ".gitignore", *(str(path) for path in tracked_files)],
-        os.environ,
-        repository,
-    )
-    assert added.returncode == 0, added.stdout + added.stderr
-
-
-def _run_check_format_gate(
-    repository: Path,
-    checker_log: Path,
-    markdown_discovery: str | None = None,
-) -> subprocess.CompletedProcess[str]:
-    """Run the real formatting recipe against the controlled repository."""
-    make = shutil.which("make")
-    assert make is not None, "the gate integration test requires make"
-    command_stub = _write_successful_command(repository)
-    discovery_override = (
-        [] if markdown_discovery is None else [f"MD_FILES_FIND={markdown_discovery}"]
-    )
-    return _run_process(
-        [
-            make,
-            "-f",
-            str(REPOSITORY_ROOT / "Makefile"),
-            "check-fmt",
-            "VENV_TOOLS=",
-            f"RUFF={command_stub}",
-            f"CARGO={command_stub}",
-            "RUST_DIR=.",
-            *discovery_override,
-        ],
-        os.environ | {"MARKDOWN_CHECKER_CALL_LOG": str(checker_log)},
-        repository,
     )
 
 
@@ -332,9 +232,9 @@ def test_rejects_large_noncanonical_source_without_a_sed_broken_pipe(
 
 def test_check_format_passes_only_tracked_markdown_sources(tmp_path: Path) -> None:
     """Exercise the Makefile gate's tracked, NUL-delimited Markdown discovery."""
-    repository, tracked_files, checker_log = _create_format_gate_repository(tmp_path)
-    _stage_markdown_sources(repository, tracked_files)
-    result = _run_check_format_gate(repository, checker_log)
+    repository, tracked_files, checker_log = create_format_gate_repository(tmp_path)
+    stage_markdown_sources(repository, tracked_files)
+    result = run_check_format_gate(repository, checker_log)
 
     assert result.returncode == 0, result.stdout + result.stderr
     recorded_paths = checker_log.read_bytes().removesuffix(b"\0").split(b"\0")
@@ -344,12 +244,49 @@ def test_check_format_passes_only_tracked_markdown_sources(tmp_path: Path) -> No
     )
 
 
+def test_check_format_skips_deleted_tracked_markdown_sources(tmp_path: Path) -> None:
+    """Ignore tracked Markdown paths removed from the worktree."""
+    repository, tracked_files, checker_log = create_format_gate_repository(tmp_path)
+    stage_markdown_sources(repository, tracked_files)
+    deleted_file, *existing_files = tracked_files
+    (repository / deleted_file).unlink()
+
+    result = run_check_format_gate(repository, checker_log)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    recorded_paths = checker_log.read_bytes().removesuffix(b"\0").split(b"\0")
+    assert recorded_paths == sorted(
+        path.as_posix().encode() for path in existing_files
+    ), (
+        "the formatting gate must exclude tracked Markdown paths missing from "
+        "the worktree"
+    )
+
+
+def test_check_format_skips_the_checker_without_tracked_markdown(
+    tmp_path: Path,
+) -> None:
+    """Succeed without invoking the checker when Git tracks no Markdown."""
+    repository, tracked_files, checker_log = create_format_gate_repository(
+        tmp_path,
+        (),
+    )
+    stage_markdown_sources(repository, tracked_files)
+
+    result = run_check_format_gate(repository, checker_log)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not checker_log.exists(), (
+        "the formatting checker must not run without tracked Markdown sources"
+    )
+
+
 def test_check_format_rejects_markdown_discovery_failure(tmp_path: Path) -> None:
     """Fail closed when Git cannot enumerate tracked Markdown sources."""
-    repository, tracked_files, checker_log = _create_format_gate_repository(tmp_path)
-    _stage_markdown_sources(repository, tracked_files)
+    repository, tracked_files, checker_log = create_format_gate_repository(tmp_path)
+    stage_markdown_sources(repository, tracked_files)
 
-    result = _run_check_format_gate(repository, checker_log, markdown_discovery="false")
+    result = run_check_format_gate(repository, checker_log, markdown_discovery="false")
 
     assert result.returncode != 0, result.stdout + result.stderr
     assert not checker_log.exists(), (

--- a/tests/helpers/ci_runners.py
+++ b/tests/helpers/ci_runners.py
@@ -63,7 +63,7 @@ CACHE_KEYS_ACTION_FILE = ROOT / ".github" / "actions" / "cache-keys" / "action.y
 SCCACHE_ACTION = "./.github/actions/setup-sccache"
 SETUP_RUST = (
     "leynos/shared-actions/.github/actions/setup-rust@"
-    "f6d4d5f549655c118f86f371b8d55c200d3efa50"
+    "c5a54701c8603a0fa756a6b34c49bc2af75a6c11"
 )
 #: Both shared actions are pinned to the same revision. It drops `target` from
 #: their own caches, so the no-target-archive rule holds even if a caller ever
@@ -77,7 +77,7 @@ SETUP_RUST = (
 #: previous pin. Holding one SHA across the estate is the point.
 GENERATE_COVERAGE = (
     "leynos/shared-actions/.github/actions/generate-coverage@"
-    "f6d4d5f549655c118f86f371b8d55c200d3efa50"
+    "c5a54701c8603a0fa756a6b34c49bc2af75a6c11"
 )
 OBSERVATION_STEP = "Record cache observations"
 


### PR DESCRIPTION
## Summary

- Import the Markdown format checker from `leynos/netsuke` and run it from `make check-fmt`.
- Pin `mdtablefix` 0.5.0 in CI and exercise the checker at its process boundary.
- Apply the repository Markdown formatter to the existing documentation baseline.
- Keep this mechanical normalisation separate from the Windows runtime-test change above it.

## Validation

- `make check-fmt`
- `make test-markdown-format`
- `mbake validate Makefile`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie`
- `coderabbit review --agent` (zero findings)

## References

- [Lody session](https://lody.ai/leynos/sessions/a096b1a6-c425-47d2-8fc8-18e70758293e)

## Summary by Sourcery

Enforce canonical Markdown formatting across the repository and validate it consistently in local checks and CI.

New Features:
- Add Markdown format validation to the Makefile and CI using a pinned prebuilt formatter.
- Add process-boundary tests covering Markdown discovery, formatting behavior, line endings, failures, and source preservation.

Enhancements:
- Normalize the repository’s Markdown documentation and rules to the canonical formatter output.
- Make Markdown checking fail closed while handling tracked, deleted, ignored, and untracked files safely.

CI:
- Pin and cache mdtablefix in CI, run its checker tests, and update shared action revisions.

Documentation:
- Document the Markdown formatting and validation workflow for contributors.

Tests:
- Add declarative CI contract coverage for the mdtablefix installer and version pin.