### PR TITLE
Run extension tests on Windows (#277)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,6 +770,55 @@ jobs:
           mode: report
           vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
 
+  extension-tests-windows:
+    name: Extension-gated tests (Windows Python/Rust boundary)
+    runs-on: windows-2022
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          # This job compiles and runs repository code, so the checkout token
+          # must not stay in .git/config where that code could reach it.
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        with:
+          enable-cache: true
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install 1.85.0 --profile minimal
+          rustup default 1.85.0
+
+      - name: Install GNU Make
+        shell: bash
+        run: |
+          if ! command -v make >/dev/null 2>&1; then
+            choco install make --no-progress --yes
+          fi
+          make --version
+
+      - name: Prepare Cargo dependencies
+        shell: bash
+        run: cargo fetch --locked --manifest-path rust/cuprum-rust/Cargo.toml
+
+      # Use the Makefile targets so this job shares the local build flags and
+      # extension-gated module list instead of copying either into CI.
+      - name: Build the native extension
+        shell: bash
+        run: make develop
+
+      - name: Run extension-gated tests
+        shell: bash
+        run: make test-extension
+
   coverage:
     # Pull requests only. Pushes to main are handled by coverage-main.yml,
     # which also uploads the report to CodeScene; guarding here stops

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1561,7 +1561,10 @@ jobs:
       # would correct it are the ones rejected. `!cancelled()` rather than
       # `always()` so an interrupted, half-measured run records nothing.
       - name: Record this run's benchmark sample
-        if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.candidate-artefacts.outputs.available == 'true' }}
+        if: >-
+          ${{ !cancelled() && github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          steps.candidate-artefacts.outputs.available == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1576,7 +1579,10 @@ jobs:
             --output "${artifact_dir}/main-baseline-history.json"
 
       - name: Upload main benchmark baseline artifact
-        if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.candidate-artefacts.outputs.available == 'true' }}
+        if: >-
+          ${{ !cancelled() && github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          steps.candidate-artefacts.outputs.available == 'true' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: benchmark-ratchet-main-baseline

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,12 @@ shell_quote = '$(subst ','"'"',$(1))'
 TYPOS_VERSION ?= 1.48.0
 TYPOS := uv tool run typos@$(TYPOS_VERSION)
 UV_ENV = UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
+ifeq ($(OS),Windows_NT)
+LOCAL_TOOL_ENV =
+else
 LOCAL_TOOL_PATH = $(HOME)/.local/bin:$(HOME)/.bun/bin:$(PATH)
 LOCAL_TOOL_ENV = PATH="$(LOCAL_TOOL_PATH)"
+endif
 UV_RUN_ENV = $(LOCAL_TOOL_ENV) $(UV_ENV)
 RUFF_ENV = RAYON_NUM_THREADS=1
 # Pin Ruff so `make` invokes the same version as the `ruff==` dev dependency

--- a/cuprum/_streams_rs.py
+++ b/cuprum/_streams_rs.py
@@ -167,11 +167,33 @@ def _prepare_rust_pump_call(
     )
 
 
+def _kernel32_handle_api() -> ModuleType:
+    """Load Kernel32 with the handle signatures required by this module."""
+    import ctypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # ty: ignore[unresolved-attribute]  # Windows-only ctypes API.
+    kernel32.GetCurrentProcess.argtypes = ()
+    kernel32.GetCurrentProcess.restype = ctypes.c_void_p
+    kernel32.DuplicateHandle.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.c_uint32,
+        ctypes.c_int,
+        ctypes.c_uint32,
+    )
+    kernel32.DuplicateHandle.restype = ctypes.c_int
+    kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+    kernel32.CloseHandle.restype = ctypes.c_int
+    return kernel32
+
+
 def _duplicate_windows_handle(handle: int) -> int:
     """Duplicate a Win32 handle so Rust can own it independently of the CRT."""
     import ctypes
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # ty: ignore[unresolved-attribute]  # Windows-only ctypes API.
+    kernel32 = _kernel32_handle_api()
     current_process = kernel32.GetCurrentProcess()
     duplicated_handle = ctypes.c_void_p()
     should_inherit_handle = False
@@ -196,7 +218,7 @@ def _close_windows_handle(handle: int) -> None:
     """Close a duplicated Win32 handle that was not handed to Rust."""
     import ctypes
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # ty: ignore[unresolved-attribute]  # Windows-only ctypes API.
+    kernel32 = _kernel32_handle_api()
     if not kernel32.CloseHandle(ctypes.c_void_p(handle)):
         raise _windows_error(ctypes)
 

--- a/cuprum/unittests/test_extension_build_contract.py
+++ b/cuprum/unittests/test_extension_build_contract.py
@@ -305,7 +305,33 @@ def test_a_caller_variable_cannot_reach_the_nested_make(
         "the Makefile"
     )
 
+def test_local_tool_environment_preserves_the_windows_action_path() -> None:
+    """Windows must retain the PATH that setup-uv has already configured."""
+    makefile = (repo_root() / "Makefile").read_text(encoding="utf-8")
+    match = re.search(
+        r"^ifeq \(\$\(OS\),Windows_NT\)\n"
+        r"(?P<windows>.*?)^else\n(?P<posix>.*?)^endif$",
+        makefile,
+        flags=re.MULTILINE | re.DOTALL,
+    )
 
+    assert match is not None, (
+        "LOCAL_TOOL_ENV must branch explicitly for Windows_NT, so Git Bash "
+        "keeps the setup-uv PATH instead of rebuilding it with POSIX separators"
+    )
+
+    windows = match["windows"]
+    posix = match["posix"]
+    assert re.fullmatch(r"LOCAL_TOOL_ENV\s*=\s*\n", windows) is not None, (
+        "the Windows_NT branch must leave LOCAL_TOOL_ENV empty rather than "
+        "prefixing or replacing PATH"
+    )
+    assert "PATH" not in windows, (
+        "the Windows_NT branch must not rewrite PATH; setup-uv already adds "
+        "the Windows uv directory"
+    )
+    assert "LOCAL_TOOL_PATH = $(HOME)/.local/bin:$(HOME)/.bun/bin:$(PATH)" in posix
+    assert 'LOCAL_TOOL_ENV = PATH="$(LOCAL_TOOL_PATH)"' in posix
 def test_the_develop_target_installs_pip_before_building() -> None:
     """`develop` must run `ensurepip` before `maturin develop`.
 

--- a/cuprum/unittests/test_extension_build_contract.py
+++ b/cuprum/unittests/test_extension_build_contract.py
@@ -305,6 +305,7 @@ def test_a_caller_variable_cannot_reach_the_nested_make(
         "the Makefile"
     )
 
+
 def test_local_tool_environment_preserves_the_windows_action_path() -> None:
     """Windows must retain the PATH that setup-uv has already configured."""
     makefile = (repo_root() / "Makefile").read_text(encoding="utf-8")
@@ -332,6 +333,8 @@ def test_local_tool_environment_preserves_the_windows_action_path() -> None:
     )
     assert "LOCAL_TOOL_PATH = $(HOME)/.local/bin:$(HOME)/.bun/bin:$(PATH)" in posix
     assert 'LOCAL_TOOL_ENV = PATH="$(LOCAL_TOOL_PATH)"' in posix
+
+
 def test_the_develop_target_installs_pip_before_building() -> None:
     """`develop` must run `ensurepip` before `maturin develop`.
 

--- a/cuprum/unittests/test_extension_ci_contract.py
+++ b/cuprum/unittests/test_extension_ci_contract.py
@@ -42,9 +42,7 @@ def _assert_extension_job_builds_before_gated_tests(
     job_name : str
         CI job identifier whose build and test step ordering is asserted.
     """
-    build, _ = first_step_running(
-        workflow_data, "make develop", job_name=job_name
-    )
+    build, _ = first_step_running(workflow_data, "make develop", job_name=job_name)
     tests, _ = first_step_running(
         workflow_data, "make test-extension", job_name=job_name
     )
@@ -60,9 +58,7 @@ def test_the_ci_job_builds_the_extension_before_running_the_gated_tests(
     workflow_data: Workflow,
 ) -> None:
     """The Linux extension-test job builds before it runs gated tests."""
-    _assert_extension_job_builds_before_gated_tests(
-        workflow_data, "extension-tests"
-    )
+    _assert_extension_job_builds_before_gated_tests(workflow_data, "extension-tests")
 
 
 def test_windows_ci_job_builds_the_extension_before_running_gated_tests(

--- a/cuprum/unittests/test_extension_ci_contract.py
+++ b/cuprum/unittests/test_extension_ci_contract.py
@@ -26,10 +26,11 @@ from tests.helpers.workflow import (
 )
 
 
-def test_the_ci_job_builds_the_extension_before_running_the_gated_tests(
+def _assert_extension_job_builds_before_gated_tests(
     workflow_data: Workflow,
+    job_name: str,
 ) -> None:
-    """`extension-tests` must run `make develop` first.
+    """Assert that an extension-test job runs `make develop` first.
 
     `make build` only syncs dependencies, so this ordering is the whole reason
     the job can pass at all, and nothing else asserts it.
@@ -37,19 +38,39 @@ def test_the_ci_job_builds_the_extension_before_running_the_gated_tests(
     Parameters
     ----------
     workflow_data : Workflow
-        Parsed ``ci.yml`` model used to inspect the extension-tests job.
+        Parsed ``ci.yml`` model used to inspect the job.
+    job_name : str
+        CI job identifier whose build and test step ordering is asserted.
     """
     build, _ = first_step_running(
-        workflow_data, "make develop", job_name="extension-tests"
+        workflow_data, "make develop", job_name=job_name
     )
     tests, _ = first_step_running(
-        workflow_data, "make test-extension", job_name="extension-tests"
+        workflow_data, "make test-extension", job_name=job_name
     )
 
     assert build < tests, (
-        "the extension-tests job must build the extension with `make "
-        "develop` before `make test-extension` runs; found the build at step "
+        f"the {job_name} job must build the extension with `make develop` "
+        "before `make test-extension` runs; found the build at step "
         f"{build} and the tests at step {tests}"
+    )
+
+
+def test_the_ci_job_builds_the_extension_before_running_the_gated_tests(
+    workflow_data: Workflow,
+) -> None:
+    """The Linux extension-test job builds before it runs gated tests."""
+    _assert_extension_job_builds_before_gated_tests(
+        workflow_data, "extension-tests"
+    )
+
+
+def test_windows_ci_job_builds_the_extension_before_running_gated_tests(
+    workflow_data: Workflow,
+) -> None:
+    """The Windows extension-test job builds before it runs gated tests."""
+    _assert_extension_job_builds_before_gated_tests(
+        workflow_data, "extension-tests-windows"
     )
 
 
@@ -123,7 +144,11 @@ def test_only_boundary_jobs_build_the_extension(workflow_data: Workflow) -> None
         if script_runs_command(script, "make develop")
     }
 
-    assert builders == {"benchmark-ratchet", "extension-tests"}, (
+    assert builders == {
+        "benchmark-ratchet",
+        "extension-tests",
+        "extension-tests-windows",
+    }, (
         "only the isolated extension and benchmark jobs may run `make develop`; "
         f"found {builders}"
     )

--- a/cuprum/unittests/test_rust_errno.py
+++ b/cuprum/unittests/test_rust_errno.py
@@ -38,10 +38,10 @@ if typ.TYPE_CHECKING:
 
 # The assertions are scoped to the platform they describe rather than the module
 # being skipped wholesale, because the two arms carry different taxonomies: the
-# POSIX cases below name an `errno` and the subclass CPython derives from it. No
-# job executes them today (see `docs/developers-guide.md`, "Preserving the
-# operating-system error code"); POSIX execution arrives with the
-# `extension-tests` job in #269. Until then they encode the contract.
+# POSIX cases below name an `errno` and the subclass CPython derives from it.
+# The `extension-tests` job executes them on Linux, while
+# `extension-tests-windows` executes the separate Win32 taxonomy in
+# `test_rust_errno_windows.py`.
 _posix_only = pytest.mark.skipif(
     sys.platform == "win32",
     reason="asserts POSIX errno values and the subclasses derived from them",

--- a/cuprum/unittests/test_rust_errno_windows.py
+++ b/cuprum/unittests/test_rust_errno_windows.py
@@ -11,9 +11,10 @@ Every expectation comes from outside the exception under test. The same failing
 extension is held to; deriving the expectation from the raised exception would
 let a hard-coded or simply wrong native code satisfy the assertion.
 
-No job executes this arm today — native Windows runtime coverage is tracked by
-leynos/cuprum#277 (see `docs/developers-guide.md`, "Preserving the operating-
-system error code") — so until then these cases encode the contract.
+CI's `extension-tests-windows` job executes this arm on `windows-2022` after
+building the extension through `make develop`; it then runs the shared
+`make test-extension` target, which keeps the platform-specific contract in
+the same module list as the Linux boundary coverage.
 
 Example
 -------

--- a/cuprum/unittests/test_rust_streams_boundary_property.py
+++ b/cuprum/unittests/test_rust_streams_boundary_property.py
@@ -51,6 +51,14 @@ _unix_only = pytest.mark.skipif(
     reason="asserts the Unix i32 file-descriptor conversion contract",
 )
 
+# Windows resolves a CRT descriptor to a file handle in the Python wrapper
+# before Rust receives ``buffer_size``. The throwaway descriptor this property
+# uses consequently fails there before the buffer-validation boundary can run.
+_buffer_validation_before_descriptor = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows resolves the descriptor before Rust validates buffer_size",
+)
+
 _SUPPRESS_FIXTURE = settings(
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     max_examples=50,
@@ -100,6 +108,7 @@ _OUT_OF_RANGE_BUFFER_SIZES = st.one_of(
         pytest.param(_pump_with_buffer_size, id="pump"),
     ],
 )
+@_buffer_validation_before_descriptor
 @_SUPPRESS_FIXTURE
 @given(bad_size=_OUT_OF_RANGE_BUFFER_SIZES)
 def test_rejects_out_of_range_buffer(
@@ -109,8 +118,8 @@ def test_rejects_out_of_range_buffer(
 ) -> None:
     """Both entry points reject any ``buffer_size`` outside ``1..=1 GiB``.
 
-    Validation precedes descriptor conversion, so a throwaway descriptor is
-    enough and no I/O is performed.
+    On the POSIX path, validation precedes descriptor conversion, so a
+    throwaway descriptor is enough and no I/O is performed.
     """
     with pytest.raises(ValueError, match="buffer_size"):
         entry_point(rust_streams, buffer_size=bad_size)

--- a/cuprum/unittests/test_streams_rs_writer_transfer.py
+++ b/cuprum/unittests/test_streams_rs_writer_transfer.py
@@ -83,6 +83,33 @@ def _patch_windows_pump(
     monkeypatch.setattr(_streams_rs.os, "close", closed_fds.append)
 
 
+def test_kernel32_handle_api_declares_pointer_sized_handle_abi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Kernel32 handle calls must retain pointer-sized values on Windows."""
+    kernel32 = mock.Mock()
+    windll = mock.Mock(return_value=kernel32)
+    monkeypatch.setattr(ctypes, "WinDLL", windll, raising=False)
+
+    assert _streams_rs._kernel32_handle_api() is kernel32
+
+    windll.assert_called_once_with("kernel32", use_last_error=True)
+    assert kernel32.GetCurrentProcess.argtypes == ()
+    assert kernel32.GetCurrentProcess.restype is ctypes.c_void_p
+    assert kernel32.DuplicateHandle.argtypes == (
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.c_uint32,
+        ctypes.c_int,
+        ctypes.c_uint32,
+    )
+    assert kernel32.DuplicateHandle.restype is ctypes.c_int
+    assert kernel32.CloseHandle.argtypes == (ctypes.c_void_p,)
+    assert kernel32.CloseHandle.restype is ctypes.c_int
+
+
 def test_windows_writer_transfer_releases_the_crt_duplicate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -21,21 +21,22 @@ Everything else runs on GitHub-hosted runners. Ubicloud offers Linux only, and
 a job that sleeps, calls an API, or publishes an artefact somebody else built
 gains nothing from a metered build slot.
 
-| Job                    | Workflow                 | Runner                |
-| ---------------------- | ------------------------ | --------------------- |
-| `typecheck-test`       | `ci.yml`                 | `ubicloud-standard-2` |
-| `extension-tests`      | `ci.yml`                 | `ubicloud-standard-2` |
-| `coverage`             | `ci.yml`                 | `ubicloud-standard-2` |
-| `benchmark-ratchet`    | `ci.yml`                 | `ubicloud-standard-2` |
-| `build-pure-wheel`     | `build-wheels.yml`       | `ubicloud-standard-2` |
-| `verify-wheel-install` | `build-wheels.yml`       | `ubicloud-standard-2` |
-| `coverage-upload`      | `coverage-main.yml`      | `ubicloud-standard-2` |
-| `lint-test`            | `ci.yml`                 | `ubuntu-latest`       |
-| `changes`              | `ci.yml`                 | `ubuntu-latest`       |
-| `refresh-sha`          | `get-codescene-sha.yml`  | `ubuntu-latest`       |
-| `publish`              | `release.yml`            | `ubuntu-latest`       |
-| `delay_and_comment`    | `delayed-pr-comment.yml` | `ubuntu-latest`       |
-| `build-native-wheels`  | `build-wheels.yml`       | `${{ matrix.os }}`    |
+| Job                       | Workflow                 | Runner                |
+| ------------------------- | ------------------------ | --------------------- |
+| `typecheck-test`          | `ci.yml`                 | `ubicloud-standard-2` |
+| `extension-tests`         | `ci.yml`                 | `ubicloud-standard-2` |
+| `coverage`                | `ci.yml`                 | `ubicloud-standard-2` |
+| `benchmark-ratchet`       | `ci.yml`                 | `ubicloud-standard-2` |
+| `build-pure-wheel`        | `build-wheels.yml`       | `ubicloud-standard-2` |
+| `verify-wheel-install`    | `build-wheels.yml`       | `ubicloud-standard-2` |
+| `coverage-upload`         | `coverage-main.yml`      | `ubicloud-standard-2` |
+| `lint-test`               | `ci.yml`                 | `ubuntu-latest`       |
+| `changes`                 | `ci.yml`                 | `ubuntu-latest`       |
+| `extension-tests-windows` | `ci.yml`                 | `windows-2022`        |
+| `refresh-sha`             | `get-codescene-sha.yml`  | `ubuntu-latest`       |
+| `publish`                 | `release.yml`            | `ubuntu-latest`       |
+| `delay_and_comment`       | `delayed-pr-comment.yml` | `ubuntu-latest`       |
+| `build-native-wheels`     | `build-wheels.yml`       | `${{ matrix.os }}`    |
 
 `ubicloud-standard-2` (2 vCPU, 8 GB, Ubuntu 24.04 amd64) is the default shape
 and the only self-hosted label registered in `.github/actionlint.yaml`.
@@ -239,6 +240,7 @@ extra.
 | `typecheck-test` 3.12, 3.14, 3.15a | each   | none                           | `make test-python`     | absent    |
 | `typecheck-test` 3.13              | 3.13   | none                           | none, coverage runs it | absent    |
 | `extension-tests`                  | 3.13   | none                           | 12 gated modules       | **built** |
+| `extension-tests-windows`          | 3.13   | none                           | 12 gated modules       | **built** |
 
 The coverage jobs run
 `cargo llvm-cov nextest --workspace --all-targets --all-features` under
@@ -271,7 +273,9 @@ Two jobs survive that look like duplicates and are not:
 - **`extension-tests`** runs the same interpreter as the coverage job, but with
   the compiled extension present. Coverage runs without it and the gated
   modules skip there; run 33752095108 logged its `rust-backend` cases as
-  `SKIPPED`. The two runs execute different code.
+  `SKIPPED`. The two runs execute different code. Its Windows counterpart,
+  `extension-tests-windows`, runs the same gated modules against the native
+  Windows boundary rather than duplicating the Linux run.
 - **`typecheck-test` on 3.13** keeps the typechecker and its required check
   name while running neither suite. Dropping its pytest run is only safe
   because the typechecker stands alone: `make typecheck` depends on `build`,
@@ -2589,15 +2593,17 @@ make develop
 That runs `maturin develop` against `rust/cuprum-rust/Cargo.toml` in the
 project virtual environment, preceded by `ensurepip` because maturin resolves
 its own script through the interpreter's `sysconfig` scheme, which needs pip
-present in the environment. CI's `extension-tests` job runs the same target, so
-a local run and a CI run build the extension identically. The Makefile keeps
-only a pointer to this section rather than repeating the reasoning.
+present in the environment. CI's `extension-tests` and
+`extension-tests-windows` jobs run the same target, so local and CI runs build
+the extension identically. The Makefile keeps only a pointer to this section
+rather than repeating the reasoning.
 
 Every CI job that installs the extension and then runs against it goes through
-this target — `extension-tests` and `benchmark-ratchet`, and no others. The
-wheel build is not one of them: `.github/workflows/build-wheels.yml` runs
-`maturin build` to produce a distributable artefact rather than installing it
-into a virtual environment, so it neither uses nor needs this target.
+this target — `extension-tests`, `extension-tests-windows`, and
+`benchmark-ratchet`, and no others. The wheel build is not one of them:
+`.github/workflows/build-wheels.yml` runs `maturin build` to produce a
+distributable artefact rather than installing it into a virtual environment, so
+it neither uses nor needs this target.
 
 The `benchmark-ratchet` job needs an optimized, in-place build of the mixed
 Python/Rust project. It passes
@@ -2643,8 +2649,8 @@ invoked it rather than on the repository — passing or failing according to the
 command line rather than the wiring. Stripping `MAKEFLAGS` alone does not
 prevent that, because the override travels under its own name as well.
 
-`test_extension_ci_contract.py` covers `ci.yml`: that the `extension-tests` job
-runs `make develop` before `make test-extension`, that `benchmark-ratchet`
+`test_extension_ci_contract.py` covers `ci.yml`: that both extension-test jobs
+run `make develop` before `make test-extension`, that `benchmark-ratchet`
 builds through the same target with `--release`, and that no job reintroduces a
 second copy of the build sequence.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2109,10 +2109,17 @@ leaf, not the inclusive tally of every caller on the path.
 
 ## Makefile tooling changes
 
-`LOCAL_TOOL_ENV` prepends `~/.local/bin` and `~/.bun/bin` to `PATH` for `uv`
-and tool-discovery recipes only. This supports non-interactive Continuous
-Integration/Continuous Delivery (CI/CD) hook environments without globally
-shadowing system tools for unrelated Makefile workflows.
+On POSIX platforms, `LOCAL_TOOL_ENV` prepends `~/.local/bin` and `~/.bun/bin` to
+`PATH` for `uv` and tool-discovery recipes only. This supports non-interactive
+Continuous Integration/Continuous Delivery (CI/CD) hook environments without
+globally shadowing system tools for unrelated Makefile workflows.
+
+On Windows, `make` sees `OS=Windows_NT` and leaves `LOCAL_TOOL_ENV` empty. Git
+Bash discovers commands with colon-separated paths, whereas the Windows PATH
+installed by `setup-uv` uses semicolons; reconstructing it with the POSIX
+prefix would hide `uv`. Leaving the environment untouched preserves the path
+that `setup-uv` supplied. `UV_RUN_ENV` still adds the repository-local `uv`
+cache and tool directories on both platforms.
 
 ## Rust error taxonomy (`PumpError`)
 
@@ -2598,6 +2605,13 @@ present in the environment. CI's `extension-tests` and
 the extension identically. The Makefile keeps only a pointer to this section
 rather than repeating the reasoning.
 
+The Windows job provisions Python 3.13, `uv`, Rust 1.85.0, and GNU Make before
+it runs those targets in Git Bash. To reproduce it from a Windows checkout,
+make those tools available in Git Bash, let `setup-uv` (or an equivalent
+installation) add `uv` to PATH, then run `make develop` and
+`make test-extension`. `LOCAL_TOOL_ENV` deliberately leaves that PATH unchanged
+on `Windows_NT`; see [Makefile tooling changes](#makefile-tooling-changes).
+
 Every CI job that installs the extension and then runs against it goes through
 this target — `extension-tests`, `extension-tests-windows`, and
 `benchmark-ratchet`, and no others. The wheel build is not one of them:
@@ -2995,7 +3009,7 @@ Table: Lint-related Makefile variables and their defaults.
 | `DF12_PYLINT_MESSAGES`  | All v0.3.0 message IDs, including `R9112`                                    | Explicit allowlist for the df12 Pylint pass.                                                                                |
 | `DF12_PYLINT`           | Derived command                                                              | CPython 3.14 Pylint command loading `df12_python_lints`.                                                                    |
 | `AMBRLEAKS`             | Derived command                                                              | Lock-backed snapshot-scanner command used by `make lint`.                                                                   |
-| `LOCAL_TOOL_ENV`        | Derived `PATH`                                                               | Adds local binary directories before invoking host and `uv`-managed tools.                                                  |
+| `LOCAL_TOOL_ENV`        | POSIX: derived `PATH`; Windows: empty                                        | On POSIX, adds local binary directories before invoking tools; on `Windows_NT`, preserves the PATH `setup-uv` configured.   |
 | `UV_ENV`                | `UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools`                               | Keeps `uv` cache and tool installs local to the worktree.                                                                   |
 | `UV_RUN_ENV`            | `$(LOCAL_TOOL_ENV) $(UV_ENV)`                                                | Shared environment prefix for locked `uv run` commands and the pinned `uv tool run` commands used by `$(RUFF)` and `$(TY)`. |
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -21,6 +21,8 @@ Everything else runs on GitHub-hosted runners. Ubicloud offers Linux only, and
 a job that sleeps, calls an API, or publishes an artefact somebody else built
 gains nothing from a metered build slot.
 
+Table 1: GitHub Actions jobs, workflows, and runners
+
 | Job                       | Workflow                 | Runner                |
 | ------------------------- | ------------------------ | --------------------- |
 | `typecheck-test`          | `ci.yml`                 | `ubicloud-standard-2` |
@@ -232,6 +234,8 @@ Each suite runs once per event. The coverage job is the only place the Rust
 suite executes, and no interpreter runs the Python suite both there and in the
 matrix. A suite that runs twice costs runner minutes twice and gates nothing
 extra.
+
+Table 2: CI suite execution by job and interpreter
 
 | Job                                | Python | Rust suite                     | Python suite           | Extension |
 | ---------------------------------- | ------ | ------------------------------ | ---------------------- | --------- |

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2187,14 +2187,19 @@ run as coverage of both arms:
   so CI's `extension-tests` job runs them with
   `CUPRUM_REQUIRE_RUST_EXTENSION=1`: a build that never produced the extension
   fails rather than skipping quietly (`#258`).
-- **Windows** — the `#[cfg(windows)]` arm is compiled natively on
-  `windows-2022` by the wheel build (`.github/workflows/build-wheels.yml`,
-  reached unconditionally from `ci.yml`, so it runs on every pull request),
-  which catches a Windows arm that does not build or type-check. No job runs
-  the Python suite on Windows, so nothing executes the `winerror` assertions;
-  that gap is tracked by `#277`.
+- **Windows** — the `CI` workflow's `extension-tests-windows` job builds the
+  extension and runs the extension-gated modules on `windows-2022`. This is
+  deliberately not the full suite because of the `#124` interpreter-abort
+  constraint; it does execute `test_rust_errno_windows.py`, including the
+  `winerror`, derived `errno`, exception-subclass, and message-formatting
+  assertions. Reproduce the native check from a Windows checkout with:
 
-That wheel build is a plain `maturin build`, so it compiles the Windows arm
+  ```bash
+  make develop
+  make test-extension
+  ```
+
+The wheel build is a plain `maturin build`, so it compiles the Windows arm
 without `-D warnings`. It therefore catches a Windows arm that fails to
 compile, and only that. Warn-level regressions pass it — and the cheapest way
 to introduce one is to gate a helper on `#[cfg(unix)]` incorrectly, which makes

--- a/tests/helpers/ci_runners.py
+++ b/tests/helpers/ci_runners.py
@@ -57,6 +57,7 @@ UBICLOUD_LABEL = "ubicloud-standard-2"
 #: this number because the job is billed for exactly these cores.
 UBICLOUD_VCPUS = 2
 GITHUB_LABEL = "ubuntu-latest"
+WINDOWS_LABEL = "windows-2022"
 
 CACHE_KEYS_ACTION = "./.github/actions/cache-keys"
 CACHE_KEYS_ACTION_FILE = ROOT / ".github" / "actions" / "cache-keys" / "action.yml"
@@ -104,6 +105,11 @@ GITHUB_HOSTED_JOBS: typ.Final[cabc.Mapping[str, tuple[str, ...]]] = {
     "delayed-pr-comment.yml": ("delay_and_comment",),
     "get-codescene-sha.yml": ("refresh-sha",),
     "release.yml": ("publish",),
+}
+#: Windows-native validation needs GitHub's hosted Windows image; Ubicloud
+#: offers Linux capacity only.
+WINDOWS_HOSTED_JOBS: typ.Final[cabc.Mapping[str, tuple[str, ...]]] = {
+    "ci.yml": ("extension-tests-windows",),
 }
 #: Jobs that restore at least one cache through the shared renderer.
 CACHED_JOBS: typ.Final[cabc.Mapping[str, tuple[str, ...]]] = {

--- a/tests/test_ci_runner_placement.py
+++ b/tests/test_ci_runner_placement.py
@@ -22,6 +22,8 @@ from tests.helpers.ci_runners import (
     UBICLOUD_JOBS,
     UBICLOUD_LABEL,
     UBICLOUD_VCPUS,
+    WINDOWS_HOSTED_JOBS,
+    WINDOWS_LABEL,
     expand,
     job,
     step_inputs,
@@ -54,6 +56,7 @@ PARALLELISM_OVERRIDES = ("PYTEST_CARGO_BUILD_JOBS",)
 
 UBICLOUD_CASES = expand(UBICLOUD_JOBS)
 GITHUB_HOSTED_CASES = expand(GITHUB_HOSTED_JOBS)
+WINDOWS_HOSTED_CASES = expand(WINDOWS_HOSTED_JOBS)
 
 
 @pytest.mark.parametrize(("workflow_name", "job_name"), UBICLOUD_CASES)
@@ -88,6 +91,17 @@ def test_administrative_and_serial_jobs_stay_github_hosted(
     )
 
 
+@pytest.mark.parametrize(("workflow_name", "job_name"), WINDOWS_HOSTED_CASES)
+def test_windows_native_jobs_stay_on_github_hosted_windows(
+    workflow_name: str, job_name: str
+) -> None:
+    """Keep native Windows validation on the reviewed hosted runner image."""
+    runner = job(workflow_name, job_name).get("runs-on")
+    assert runner == WINDOWS_LABEL, (
+        f"{workflow_name}:{job_name} must stay on {WINDOWS_LABEL}, got {runner!r}"
+    )
+
+
 def test_native_wheel_matrix_keeps_its_platform_runners() -> None:
     """Ubicloud has no Windows or macOS capacity, so the matrix stays hosted."""
     matrix_job = job("build-wheels.yml", "build-native-wheels")
@@ -116,6 +130,7 @@ def test_every_workflow_job_appears_in_one_placement_manifest() -> None:
     known = (
         set(UBICLOUD_CASES)
         | set(GITHUB_HOSTED_CASES)
+        | set(WINDOWS_HOSTED_CASES)
         | {
             ("build-wheels.yml", "build-native-wheels"),
             # Callers of a reusable workflow declare no runner of their own.


### PR DESCRIPTION
## Summary

Closes #277

- Add the native [extension-tests-windows job](https://github.com/leynos/cuprum/blob/issue-277-run-the-python-suite-natively-on-windows-to-cover-the-winerror-conversion/.github/workflows/ci.yml#L213), which builds through make develop then runs the shared extension-gated target on windows-2022.
- Preserve the setup-uv Windows PATH in [the Makefile](https://github.com/leynos/cuprum/blob/issue-277-run-the-python-suite-natively-on-windows-to-cover-the-winerror-conversion/Makefile#L63), so Git Bash can discover uv without a mixed-separator replacement.
- Keep the build-before-test invariant under test in [the CI contract test](https://github.com/leynos/cuprum/blob/issue-277-run-the-python-suite-natively-on-windows-to-cover-the-winerror-conversion/cuprum/unittests/test_extension_ci_contract.py#L165).
- Skip only the three [unreachable Win32 buffer properties](https://github.com/leynos/cuprum/blob/issue-277-run-the-python-suite-natively-on-windows-to-cover-the-winerror-conversion/cuprum/unittests/test_rust_streams_boundary_property.py#L54), where descriptor conversion happens before Rust can validate buffer size.
- Document the native Win32 winerror, derived-errno, exception-subclass, and message-formatting coverage in [the developers guide](https://github.com/leynos/cuprum/blob/issue-277-run-the-python-suite-natively-on-windows-to-cover-the-winerror-conversion/docs/developers-guide.md#L1675).

## Validation

- make check-fmt, make lint, and make typecheck
- Focused Makefile and Rust stream-boundary tests: 17 passed
- [Windows extension-gated job](https://github.com/leynos/cuprum/actions/runs/33369001101/job/99415626668) completed successfully, including make develop and make test-extension.
- coderabbit review --agent (zero findings)

## References

- [Lody session](https://lody.ai/leynos/sessions/bf8dd2ba-ce26-4bd3-bc56-ed50b753101b)

## Summary by Sourcery

Run the extension-gated test suite natively on Windows to validate the Python/Rust boundary and Win32 error handling.

New Features:
- Add native Windows CI coverage for extension-gated Python tests, including Win32 error conversion and exception behavior.

Bug Fixes:
- Correct Windows handle API declarations to preserve pointer-sized Win32 handle values.

Enhancements:
- Preserve the Windows PATH configured by setup-uv while retaining POSIX local-tool path behavior.
- Skip only stream boundary properties that cannot reach Rust validation on Windows and enforce the Windows extension job's build-before-test contract.

CI:
- Run the extension build and gated tests on a windows-2022 GitHub-hosted runner and validate its runner placement.

Documentation:
- Document Windows extension-test coverage, local reproduction steps, and platform-specific Makefile behavior.

Tests:
- Extend CI contract and stream/handle tests for Windows behavior and native extension coverage.