### PR TITLE
Move compatible Linux jobs to Namespace

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - namespace-profile-default
+    - ubicloud-standard-4-ubuntu-2404

--- a/.github/actions/build-wheels/action.yml
+++ b/.github/actions/build-wheels/action.yml
@@ -25,6 +25,7 @@ runs:
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:

--- a/.github/actions/pure-python-wheel/action.yml
+++ b/.github/actions/pure-python-wheel/action.yml
@@ -17,6 +17,7 @@ runs:
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-pure-wheel:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - uses: ./.github/actions/pure-python-wheel
@@ -108,7 +108,7 @@ jobs:
           path: wheelhouse/*.whl
 
   verify-wheel-install:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     needs:
       - build-pure-wheel
       - build-native-wheels

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -7,6 +7,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 env:
   # Keep in sync with .github/actions/build-wheels/action.yml and pyproject.toml.
   MATURIN_VERSION: "1.13.3"
@@ -17,6 +20,8 @@ jobs:
     runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/pure-python-wheel
         with:
           python-version: ${{ inputs['python-version'] }}
@@ -48,6 +53,8 @@ jobs:
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          persist-credentials: false
       - name: Compute Python tag for manylinux interpreter path
         if: startsWith(matrix.os, 'ubuntu')
         id: pytag
@@ -114,6 +121,8 @@ jobs:
       - build-native-wheels
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,9 +258,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             rust/target
-          key: cargo-coverage-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}
+          key: cargo-coverage-${{ runner.os }}-${{ runner.arch }}-namespace-profile-default-${{ hashFiles('rust/Cargo.lock') }}
           restore-keys: |
-            cargo-coverage-${{ runner.os }}-
+            cargo-coverage-${{ runner.os }}-${{ runner.arch }}-namespace-profile-default-
 
       - name: Prepare Cargo dependencies
         run: cargo fetch --locked --manifest-path rust/cuprum-rust/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   lint-test:
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     env:
       MBAKE_VERSION: '1.4.6'
       WHITAKER_INSTALLER_VERSION: '0.2.7'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   lint-test:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     env:
       MBAKE_VERSION: '1.4.6'
       WHITAKER_INSTALLER_VERSION: '0.2.7'
@@ -98,7 +98,7 @@ jobs:
   typecheck-test:
     name: Typecheck and test (Python ${{ matrix.python-label }})
     continue-on-error: ${{ matrix.experimental }}
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     strategy:
       fail-fast: false
       matrix:
@@ -160,7 +160,7 @@ jobs:
 
   extension-tests:
     name: Extension-gated tests (Python/Rust boundary)
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -222,7 +222,7 @@ jobs:
     # which also uploads the report to CodeScene; guarding here stops
     # coverage being generated twice on main.
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     needs:
       - lint-test
       - typecheck-test

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   coverage-upload:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/delayed-pr-comment.yml
+++ b/.github/workflows/delayed-pr-comment.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   delay_and_comment:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     permissions:
       pull-requests: write   # needed to post comments
     steps:

--- a/.github/workflows/get-codescene-sha.yml
+++ b/.github/workflows/get-codescene-sha.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   refresh-sha:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     permissions:
       actions: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
   publish:
     needs:
       - build-wheels
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ TEST_CARGO_BUILD_JOBS ?= 1
 # and parallel batches contend on the Cargo build cache with little benefit.
 PYTEST_WORKERS ?= 0
 PYTEST_TARGETS ?= cuprum/unittests/test_*.py \
+  tests/test_namespace_runners.py \
   tests/behaviour/test_[a-h]*.py \
   tests/behaviour/test_[i-r]*.py \
   tests/behaviour/test_[s-z]*.py

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -14,7 +14,6 @@ of truth for day-to-day contributor expectations. For the system design, see the
 - [ADR-007: Subprocess execution module boundaries](adr-007-subprocess-execution-module-boundaries.md)
 - [ADR-009: Enforce Oxford spelling in source](adr-009-enforce-oxford-spelling-in-source.md)
 
-
 ## GitHub Actions runner profiles
 
 Compatible repository-owned Linux jobs run on the shared uncached

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1771,6 +1771,13 @@ descriptor the Python side still owns is never closed by Rust. `pump_stream` and
 `consume_stream` both route their reader through the helper, keeping the
 "borrow this FD without owning it" rule in a single place.
 
+The private `stream_pyfunctions::run_stream_operation` helper is limited to
+the two PyO3 stream exports. It owns their shared buffer validation, GIL
+release, and `PumpError` conversion; each export must prepare only the
+ownership-specific descriptors and supply its stream operation. Do not reuse
+it outside this FFI adapter boundary or move descriptor ownership into the
+helper, because that would blur the distinct borrow-versus-consume contract.
+
 This supersedes an earlier pattern that reconstructed the handle and called
 `std::mem::forget` after the inner operation returned. Because a panic unwinds
 past the trailing `forget`, that pattern dropped — and therefore closed — the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -14,6 +14,19 @@ of truth for day-to-day contributor expectations. For the system design, see the
 - [ADR-007: Subprocess execution module boundaries](adr-007-subprocess-execution-module-boundaries.md)
 - [ADR-009: Enforce Oxford spelling in source](adr-009-enforce-oxford-spelling-in-source.md)
 
+
+## GitHub Actions runner profiles
+
+Repository-owned Linux jobs that do not require a native wheel platform run on
+the shared uncached `namespace-profile-default` profile (Ubuntu 22.04, amd64, 4
+vCPU, and 16 GB). The profile has no cache volume; existing GitHub Actions
+caches remain their own backend during this baseline measurement.
+
+The native-wheel matrix keeps its existing runner selection because it includes
+Linux container and QEMU work plus Windows and macOS targets. The benchmark
+ratchet also remains on its existing `ubicloud-standard-4-ubuntu-2404` runner:
+its Ubuntu 24.04 image and benchmark baseline are part of that contract.
+
 ## Rust availability probing
 
 Stream backend availability is resolved through one cached entry point:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -17,10 +17,14 @@ of truth for day-to-day contributor expectations. For the system design, see the
 
 ## GitHub Actions runner profiles
 
-Repository-owned Linux jobs that do not require a native wheel platform run on
-the shared uncached `namespace-profile-default` profile (Ubuntu 22.04, amd64, 4
-vCPU, and 16 GB). The profile has no cache volume; existing GitHub Actions
-caches remain their own backend during this baseline measurement.
+Compatible repository-owned Linux jobs run on the shared uncached
+`namespace-profile-default` profile (Ubuntu 22.04, amd64, 4 vCPU, and 16 GB).
+The profile has no cache volume; existing GitHub Actions caches remain their
+own backend during this baseline measurement.
+
+The lint job remains on `ubuntu-latest`. Whitaker's prebuilt native tooling
+requires a newer GLIBC than the shared Ubuntu 22.04 profile supplies, and cache
+isolation does not make the cold installation compatible.
 
 The native-wheel matrix keeps its existing runner selection because it includes
 Linux container and QEMU work plus Windows and macOS targets. The benchmark

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1772,11 +1772,12 @@ descriptor the Python side still owns is never closed by Rust. `pump_stream` and
 "borrow this FD without owning it" rule in a single place.
 
 The private `stream_pyfunctions::run_stream_operation` helper is limited to
-the two PyO3 stream exports. It owns their shared buffer validation, GIL
-release, and `PumpError` conversion; each export must prepare only the
-ownership-specific descriptors and supply its stream operation. Do not reuse
-it outside this FFI adapter boundary or move descriptor ownership into the
-helper, because that would blur the distinct borrow-versus-consume contract.
+the two PyO3 stream exports. It owns their shared buffer validation, reader
+descriptor preparation, GIL release, and `PumpError` conversion; the pump
+export alone prepares its ownership-consuming writer and both exports supply
+their stream operation. Do not reuse it outside this FFI adapter boundary or
+move writer ownership into the helper, because that would blur the distinct
+borrow-versus-consume contract.
 
 This supersedes an earlier pattern that reconstructed the handle and called
 `std::mem::forget` after the inner operation returned. Because a panic unwinds

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -89,16 +89,18 @@ mod stream_pyfunctions {
     /// and map `PumpError` back to the exported Python exception type.
     fn run_stream_operation<T, Operation>(
         py: Python<'_>,
+        reader_fd: i64,
         buffer_size: i64,
-        prepare_operation: impl FnOnce(BufferSize) -> PyResult<Operation>,
+        prepare_operation: impl FnOnce() -> PyResult<Operation>,
     ) -> PyResult<T>
     where
         T: Send,
-        Operation: FnOnce() -> Result<T, PumpError> + Send,
+        Operation: FnOnce(ReaderFd, BufferSize) -> Result<T, PumpError> + Send,
     {
         let validated_buffer_size = validate_buffer_size(buffer_size)?;
-        let operation = prepare_operation(validated_buffer_size)?;
-        let result = py.detach(operation);
+        let reader = ReaderFd(convert_fd(reader_fd)?);
+        let operation = prepare_operation()?;
+        let result = py.detach(move || operation(reader, validated_buffer_size));
         result.map_err(PyErr::from)
     }
 
@@ -120,10 +122,11 @@ mod stream_pyfunctions {
         writer_fd: i64,
         buffer_size: i64,
     ) -> PyResult<u64> {
-        run_stream_operation(py, buffer_size, |validated_buffer_size| {
-            let reader = ReaderFd(convert_fd(reader_fd)?);
+        run_stream_operation(py, reader_fd, buffer_size, || {
             let writer = WriterFd(convert_fd(writer_fd)?);
-            Ok(move || pump_stream(reader, writer, validated_buffer_size))
+            Ok(move |reader, validated_buffer_size| {
+                pump_stream(reader, writer, validated_buffer_size)
+            })
         })
     }
 
@@ -149,10 +152,7 @@ mod stream_pyfunctions {
         reader_fd: i64,
         buffer_size: i64,
     ) -> PyResult<String> {
-        run_stream_operation(py, buffer_size, |validated_buffer_size| {
-            let reader = ReaderFd(convert_fd(reader_fd)?);
-            Ok(move || consume_stream(reader, validated_buffer_size))
-        })
+        run_stream_operation(py, reader_fd, buffer_size, || Ok(consume_stream))
     }
 }
 

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -78,9 +78,29 @@ mod stream_pyfunctions {
     //! Contain the Python stream exports and their generated `PyO3` wrappers.
 
     use super::{
-        PyErr, PyResult, Python, ReaderFd, WriterFd, consume_stream, convert_fd, pump_stream,
-        pyfunction, validate_buffer_size,
+        BufferSize, PumpError, PyErr, PyResult, Python, ReaderFd, WriterFd, consume_stream,
+        convert_fd, pump_stream, pyfunction, validate_buffer_size,
     };
+
+    /// Run a prepared stream operation after validating its buffer size.
+    ///
+    /// Keep the common `PyO3` boundary behaviour in one place: validate the
+    /// Python argument, prepare descriptor ownership, release the GIL for I/O,
+    /// and map `PumpError` back to the exported Python exception type.
+    fn run_stream_operation<T, Operation>(
+        py: Python<'_>,
+        buffer_size: i64,
+        prepare_operation: impl FnOnce(BufferSize) -> PyResult<Operation>,
+    ) -> PyResult<T>
+    where
+        T: Send,
+        Operation: FnOnce() -> Result<T, PumpError> + Send,
+    {
+        let validated_buffer_size = validate_buffer_size(buffer_size)?;
+        let operation = prepare_operation(validated_buffer_size)?;
+        let result = py.detach(operation);
+        result.map_err(PyErr::from)
+    }
 
     /// Pump bytes between file descriptors outside the GIL.
     ///
@@ -100,13 +120,11 @@ mod stream_pyfunctions {
         writer_fd: i64,
         buffer_size: i64,
     ) -> PyResult<u64> {
-        let validated_buffer_size = validate_buffer_size(buffer_size)?;
-
-        let reader = ReaderFd(convert_fd(reader_fd)?);
-        let writer = WriterFd(convert_fd(writer_fd)?);
-
-        let result = py.detach(|| pump_stream(reader, writer, validated_buffer_size));
-        result.map_err(PyErr::from)
+        run_stream_operation(py, buffer_size, |validated_buffer_size| {
+            let reader = ReaderFd(convert_fd(reader_fd)?);
+            let writer = WriterFd(convert_fd(writer_fd)?);
+            Ok(move || pump_stream(reader, writer, validated_buffer_size))
+        })
     }
 
     /// Consume a stream and decode it as UTF-8 with replacement semantics.
@@ -131,11 +149,10 @@ mod stream_pyfunctions {
         reader_fd: i64,
         buffer_size: i64,
     ) -> PyResult<String> {
-        let validated_buffer_size = validate_buffer_size(buffer_size)?;
-
-        let reader = ReaderFd(convert_fd(reader_fd)?);
-        let result = py.detach(|| consume_stream(reader, validated_buffer_size));
-        result.map_err(PyErr::from)
+        run_stream_operation(py, buffer_size, |validated_buffer_size| {
+            let reader = ReaderFd(convert_fd(reader_fd)?);
+            Ok(move || consume_stream(reader, validated_buffer_size))
+        })
     }
 }
 

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -67,6 +67,10 @@ pub fn is_available() -> bool {
 }
 
 #[expect(
+    clippy::allow_attributes,
+    reason = "PyO3 emits the argument-count lint only in some build configurations"
+)]
+#[allow(
     clippy::too_many_arguments,
     reason = "PyO3 generates five-parameter wrappers for these stable Python FFI functions"
 )]

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -66,57 +66,76 @@ pub fn is_available() -> bool {
     true
 }
 
-/// Pump bytes between file descriptors outside the GIL.
-///
-/// # Parameters
-/// - `reader_fd`: File descriptor for the upstream stdout.
-/// - `writer_fd`: File descriptor for the downstream stdin.
-/// - `buffer_size`: Size of the internal transfer buffer in bytes.
-///
-/// # Errors
-/// Returns a Python `ValueError` for invalid buffer sizes and `OSError` for
-/// I/O failures.
-#[pyfunction]
-#[pyo3(signature = (reader_fd, writer_fd, buffer_size = 65536))]
-fn rust_pump_stream(
-    py: Python<'_>,
-    reader_fd: i64,
-    writer_fd: i64,
-    buffer_size: i64,
-) -> PyResult<u64> {
-    let validated_buffer_size = validate_buffer_size(buffer_size)?;
+#[expect(
+    clippy::too_many_arguments,
+    reason = "PyO3 generates five-parameter wrappers for these stable Python FFI functions"
+)]
+mod stream_pyfunctions {
+    //! Contain the Python stream exports and their generated `PyO3` wrappers.
 
-    let reader = ReaderFd(convert_fd(reader_fd)?);
-    let writer = WriterFd(convert_fd(writer_fd)?);
+    use super::{
+        PyErr, PyResult, Python, ReaderFd, WriterFd, consume_stream, convert_fd, pump_stream,
+        pyfunction, validate_buffer_size,
+    };
 
-    let result = py.detach(|| pump_stream(reader, writer, validated_buffer_size));
-    result.map_err(PyErr::from)
+    /// Pump bytes between file descriptors outside the GIL.
+    ///
+    /// # Parameters
+    /// - `reader_fd`: File descriptor for the upstream stdout.
+    /// - `writer_fd`: File descriptor for the downstream stdin.
+    /// - `buffer_size`: Size of the internal transfer buffer in bytes.
+    ///
+    /// # Errors
+    /// Returns a Python `ValueError` for invalid buffer sizes and `OSError` for
+    /// I/O failures.
+    #[pyfunction]
+    #[pyo3(signature = (reader_fd, writer_fd, buffer_size = 65536))]
+    pub(super) fn rust_pump_stream(
+        py: Python<'_>,
+        reader_fd: i64,
+        writer_fd: i64,
+        buffer_size: i64,
+    ) -> PyResult<u64> {
+        let validated_buffer_size = validate_buffer_size(buffer_size)?;
+
+        let reader = ReaderFd(convert_fd(reader_fd)?);
+        let writer = WriterFd(convert_fd(writer_fd)?);
+
+        let result = py.detach(|| pump_stream(reader, writer, validated_buffer_size));
+        result.map_err(PyErr::from)
+    }
+
+    /// Consume a stream and decode it as UTF-8 with replacement semantics.
+    ///
+    /// This helper always uses UTF-8 and replaces invalid sequences with the
+    /// Unicode replacement character.
+    ///
+    /// # Parameters
+    /// - `reader_fd`: File descriptor to read from.
+    /// - `buffer_size`: Size of the internal read buffer in bytes.
+    ///
+    /// # Returns
+    /// The decoded stream content.
+    ///
+    /// # Errors
+    /// Returns a Python `ValueError` for invalid arguments and `OSError` for
+    /// I/O failures.
+    #[pyfunction]
+    #[pyo3(signature = (reader_fd, buffer_size = 65536))]
+    pub(super) fn rust_consume_stream(
+        py: Python<'_>,
+        reader_fd: i64,
+        buffer_size: i64,
+    ) -> PyResult<String> {
+        let validated_buffer_size = validate_buffer_size(buffer_size)?;
+
+        let reader = ReaderFd(convert_fd(reader_fd)?);
+        let result = py.detach(|| consume_stream(reader, validated_buffer_size));
+        result.map_err(PyErr::from)
+    }
 }
 
-/// Consume a stream and decode it as UTF-8 with replacement semantics.
-///
-/// This helper always uses UTF-8 and replaces invalid sequences with the
-/// Unicode replacement character.
-///
-/// # Parameters
-/// - `reader_fd`: File descriptor to read from.
-/// - `buffer_size`: Size of the internal read buffer in bytes.
-///
-/// # Returns
-/// The decoded stream content.
-///
-/// # Errors
-/// Returns a Python `ValueError` for invalid arguments and `OSError` for
-/// I/O failures.
-#[pyfunction]
-#[pyo3(signature = (reader_fd, buffer_size = 65536))]
-fn rust_consume_stream(py: Python<'_>, reader_fd: i64, buffer_size: i64) -> PyResult<String> {
-    let validated_buffer_size = validate_buffer_size(buffer_size)?;
-
-    let reader = ReaderFd(convert_fd(reader_fd)?);
-    let result = py.detach(|| consume_stream(reader, validated_buffer_size));
-    result.map_err(PyErr::from)
-}
+use stream_pyfunctions::{rust_consume_stream, rust_pump_stream};
 
 #[cfg(unix)]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -141,7 +141,7 @@ mod stream_pyfunctions {
 
 use stream_pyfunctions::{rust_consume_stream, rust_pump_stream};
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn convert_fd(value: i64) -> PyResult<PlatformFd> {
     convert_platform_fd(value).map_err(PyValueError::new_err)
 }
@@ -166,10 +166,6 @@ fn convert_platform_fd(value: i64) -> Result<PlatformFd, &'static str> {
     usize::try_from(value).map_err(|_| "file handle out of range")
 }
 
-#[cfg(windows)]
-fn convert_fd(value: i64) -> PyResult<PlatformFd> {
-    convert_platform_fd(value).map_err(PyValueError::new_err)
-}
 /// Maximum accepted stream buffer size, in bytes (1 GiB).
 ///
 /// This guards against absurd allocations from a bad `buffer_size` while

--- a/tests/test_namespace_runners.py
+++ b/tests/test_namespace_runners.py
@@ -1,0 +1,68 @@
+"""Contract tests for Cuprum's shared Namespace Linux runner slice.
+
+The initial migration intentionally covers ordinary repository-owned Linux
+jobs only. Native-platform wheel builds and the Ubuntu 24.04 benchmark ratchet
+remain on their existing runners until an equivalent profile is measured.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE = "namespace-profile-default"
+MIGRATED_JOBS = {
+    "build-wheels.yml": ("build-pure-wheel", "verify-wheel-install"),
+    "ci.yml": ("lint-test", "typecheck-test", "extension-tests", "coverage"),
+    "coverage-main.yml": ("coverage-upload",),
+    "delayed-pr-comment.yml": ("delay_and_comment",),
+    "get-codescene-sha.yml": ("refresh-sha",),
+    "release.yml": ("publish",),
+}
+
+
+def _jobs(workflow_name: str) -> dict[str, object]:
+    """Load the jobs mapping from one repository workflow."""
+    path = ROOT / ".github" / "workflows" / workflow_name
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict), f"{workflow_name} must parse to a mapping"
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), f"{workflow_name} must declare jobs"
+    return jobs
+
+
+def _job(workflow_name: str, job_name: str) -> dict[str, object]:
+    """Return one named job from a repository workflow."""
+    job = _jobs(workflow_name).get(job_name)
+    assert isinstance(job, dict), f"{workflow_name} must define {job_name}"
+    return typ.cast("dict[str, object]", job)
+
+
+@pytest.mark.parametrize(("workflow_name", "job_names"), MIGRATED_JOBS.items())
+def test_compatible_linux_jobs_use_the_shared_namespace_profile(
+    workflow_name: str, job_names: tuple[str, ...]
+) -> None:
+    """Keep the approved uncached runner assignment from drifting."""
+    for job_name in job_names:
+        actual_runner = _job(workflow_name, job_name).get("runs-on")
+        assert actual_runner == PROFILE, (
+            f"{workflow_name}:{job_name} must run on {PROFILE}, got {actual_runner!r}"
+        )
+
+
+def test_native_wheel_and_benchmark_runners_remain_specialized() -> None:
+    """Preserve platform and benchmark runner contracts outside the pilot slice."""
+    native_runner = _job("build-wheels.yml", "build-native-wheels").get("runs-on")
+    assert native_runner == "${{ matrix.os }}", (
+        "build-wheels.yml:build-native-wheels must keep its platform matrix, "
+        f"got {native_runner!r}"
+    )
+    benchmark_runner = _job("ci.yml", "benchmark-ratchet").get("runs-on")
+    assert benchmark_runner == "ubicloud-standard-4-ubuntu-2404", (
+        "ci.yml:benchmark-ratchet must retain its Ubuntu 24.04 benchmark "
+        f"runner, got {benchmark_runner!r}"
+    )

--- a/tests/test_namespace_runners.py
+++ b/tests/test_namespace_runners.py
@@ -17,7 +17,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PROFILE = "namespace-profile-default"
 MIGRATED_JOBS = {
     "build-wheels.yml": ("build-pure-wheel", "verify-wheel-install"),
-    "ci.yml": ("lint-test", "typecheck-test", "extension-tests", "coverage"),
+    "ci.yml": ("typecheck-test", "extension-tests", "coverage"),
     "coverage-main.yml": ("coverage-upload",),
     "delayed-pr-comment.yml": ("delay_and_comment",),
     "get-codescene-sha.yml": ("refresh-sha",),
@@ -54,8 +54,13 @@ def test_compatible_linux_jobs_use_the_shared_namespace_profile(
         )
 
 
-def test_native_wheel_and_benchmark_runners_remain_specialized() -> None:
-    """Preserve platform and benchmark runner contracts outside the pilot slice."""
+def test_specialized_jobs_retain_compatible_runners() -> None:
+    """Preserve platform and toolchain contracts outside the pilot slice."""
+    lint_runner = _job("ci.yml", "lint-test").get("runs-on")
+    assert lint_runner == "ubuntu-latest", (
+        "ci.yml:lint-test must retain the Whitaker-compatible GitHub image, "
+        f"got {lint_runner!r}"
+    )
     native_runner = _job("build-wheels.yml", "build-native-wheels").get("runs-on")
     assert native_runner == "${{ matrix.os }}", (
         "build-wheels.yml:build-native-wheels must keep its platform matrix, "


### PR DESCRIPTION
## Summary

Move compatible repository-owned Linux jobs to the shared, uncached Namespace
runner profile while preserving the native wheel matrix and benchmark runner
contracts.

The branch also scopes Clippy's `too_many_arguments` expectation to the private
module containing PyO3-generated wrappers. The stable Python API remains
unchanged, and handwritten Rust code remains subject to the lint.

## Review walkthrough

- Start with [`rust/cuprum-rust/src/lib.rs`](https://github.com/leynos/cuprum/blob/00549f539c461b66b252397f64c020b823b8d862/rust/cuprum-rust/src/lib.rs) for the narrowly scoped PyO3 lint boundary.
- Review [`.github/workflows/ci.yml`](https://github.com/leynos/cuprum/blob/00549f539c461b66b252397f64c020b823b8d862/.github/workflows/ci.yml) and [`.github/workflows/build-wheels.yml`](https://github.com/leynos/cuprum/blob/00549f539c461b66b252397f64c020b823b8d862/.github/workflows/build-wheels.yml) for the runner-selection rules.
- Finish with [`tests/test_namespace_runners.py`](https://github.com/leynos/cuprum/blob/00549f539c461b66b252397f64c020b823b8d862/tests/test_namespace_runners.py) and [`docs/developers-guide.md`](https://github.com/leynos/cuprum/blob/00549f539c461b66b252397f64c020b823b8d862/docs/developers-guide.md) for the executable contracts and operator guidance.

## Validation

- `make check-fmt lint` — passed
- `make typecheck` — passed
- `make test` — passed (1,262 Python tests passed, 56 skipped; all behavioural suites passed; 104 Rust nextest tests passed)
- `make markdownlint nixie` — passed
- `uv run pytest -q tests/test_namespace_runners.py` — 7 passed
- `actionlint -ignore shellcheck` — passed

## Notes

- The Namespace profile has cache volumes disabled. Existing GitHub-managed
  action caches are retained.
- Native wheel jobs continue to use their matrix-selected platforms.
- The benchmark ratchet continues to use its explicitly selected UbiCloud
  runner.
- Unfiltered `actionlint` still reports pre-existing `SC2206` findings in the
  unchanged wheel-build shell script; the repository's runner-label check uses
  `-ignore shellcheck`.

## Summary by Sourcery

Migrate compatible Linux automation to the shared Namespace runner profile while preserving platform-specific workflow contracts and tightening the PyO3 lint boundary.

New Features:
- Add executable contract tests and actionlint configuration to enforce approved GitHub Actions runner assignments.

Enhancements:
- Move compatible repository-owned Linux jobs to the shared uncached Namespace runner profile while preserving specialized wheel, benchmark, and lint runner contracts.
- Scope the Clippy argument-count exception to the private PyO3 stream-wrapper module without changing the stable Python API.
- Harden workflow checkouts by disabling persisted credentials and constrain workflow permissions to read-only contents where applicable.
- Document the runner-profile policy and exceptions for contributors.

CI:
- Update CI, coverage, release, and auxiliary workflows to use the Namespace profile for compatible Linux jobs.

Documentation:
- Document GitHub Actions runner profiles, retained specialized runners, and the PyO3 stream adapter boundary.

Tests:
- Add tests covering migrated Namespace jobs and preservation of specialized runner assignments.