### PR TITLE
Scope the compiler cache by interpreter and build shape

### DIFF
--- a/.github/actions/cache-keys/action.yml
+++ b/.github/actions/cache-keys/action.yml
@@ -23,6 +23,16 @@ inputs:
       an executable.
     required: false
     default: ubuntu2404
+  compiler-shape:
+    description: >-
+      Build shape the compiler cache holds. Objects are only interchangeable
+      between jobs that compile the same way, so each shape gets its own
+      family and its own single writer. `debug` is an unoptimized
+      `maturin develop` build, `release` is the same build with `--release`,
+      `coverage` is the instrumented `cargo llvm-cov` build, and `lint` is the
+      Cranelift-backed lint build. See docs/ci-cache-ownership.md.
+    required: false
+    default: debug
 runs:
   using: composite
   steps:
@@ -32,6 +42,7 @@ runs:
         GENERATION: ${{ inputs.generation }}
         UBUNTU_RELEASE: ${{ inputs.ubuntu-release }}
         PYTHON_VERSION: ${{ inputs.python-version }}
+        COMPILER_SHAPE: ${{ inputs.compiler-shape }}
         RUNNER_ENVIRONMENT: ${{ runner.environment }}
         # The Cargo families follow the resolved dependency graph and the
         # toolchain that compiled it. `target` is deliberately absent from
@@ -57,7 +68,22 @@ runs:
         # the lockfile captures, so a content-addressed key would hit forever
         # and never absorb a new object. Each writing run publishes a fresh
         # entry seeded from the newest entry the prefix matches.
-        sccache_prefix="sccache-${image_scope}-"
+        # The compiler cache is scoped by everything that decides whether one
+        # job's objects can serve another's. Two dimensions beyond the image
+        # scope matter here, and both were measured on 2026-09-04.
+        #
+        # The interpreter: `pyo3` is declared with `extension-module` and
+        # without `abi3`, so the extension is compiled against one specific
+        # CPython version and its objects are useless to another. Runs
+        # 33853599399 and 33854076859 showed this exactly. Every Ubicloud job
+        # restored the same archive, which a 3.13 job had written; the 3.13
+        # reader took 14 of its 17 cacheable compiles, and the 3.12, 3.14 and
+        # 3.15a readers took none at all.
+        #
+        # The build shape: an optimized build, an instrumented build and an
+        # unoptimized one produce different objects from the same source, so
+        # they cannot share an entry either.
+        sccache_prefix="sccache-${image_scope}-py${PYTHON_VERSION}-${COMPILER_SHAPE}-"
         {
           printf 'CARGO_CACHE_PREFIX=cargo-%s-\n' "${scope}"
           printf 'CARGO_CACHE_KEY=cargo-%s-%s\n' "${scope}" "${CARGO_HASH}"

--- a/.github/actions/resource-sampler/action.yml
+++ b/.github/actions/resource-sampler/action.yml
@@ -1,0 +1,64 @@
+name: Resource sampler
+description: >-
+  Record the peak memory and disk a job actually uses, so a runner-shape
+  decision cites a measurement rather than an inference.
+
+  Disk matters more than memory here. `ubicloud-standard-2` carries a 72 GB
+  volume with roughly 31 GB free at job start, against 145 GB on
+  `ubicloud-standard-4`, and a sibling repository's silent death on the
+  smaller shape turned out to be disk exhaustion from a second target tree
+  built after the instrumented one, with memory peaking at 2.8 GB of 8. Both
+  peaks go to the log as well as to the step summary, because the jobs API
+  exposes the log and not the summary, and the exit-evidence ledger is
+  assembled from the log.
+
+  Call with `mode: start` directly after checkout, and `mode: report` last,
+  under `if: always()`.
+
+inputs:
+  mode:
+    description: '`start` begins sampling; `report` stops it and publishes.'
+    required: true
+  vcpus:
+    description: >-
+      vCPU count the job is billed for, quoted beside the memory peak so a
+      reader can judge whether the shape was the constraint.
+    required: false
+    default: unknown
+
+runs:
+  using: composite
+  steps:
+    - name: Start resource sampler
+      if: inputs.mode == 'start'
+      shell: bash
+      # `cut` rather than `awk`, because an `awk` field reference inside the
+      # single-quoted `sh -c` body reads to shellcheck as an unexpanded
+      # expression. Line 2 of `free -m`, squeezed, puts "used" in field 3;
+      # `df -m .` puts used in field 3 and available in field 4.
+      run: |
+        nohup sh -c 'while sleep 15; do
+          mem="$(free -m | tr -s " " | cut -d" " -f3 | sed -n 2p)"
+          disk="$(df -m . | tr -s " " | cut -d" " -f3 | sed -n 2p)"
+          free_disk="$(df -m . | tr -s " " | cut -d" " -f4 | sed -n 2p)"
+          printf "%s %s %s\n" "${mem}" "${disk}" "${free_disk}"
+        done' > resource.log 2>/dev/null &
+        echo "RESOURCE_SAMPLER_PID=$!" >> "${GITHUB_ENV}"
+
+    - name: Report peak resource use
+      if: always() && inputs.mode == 'report'
+      shell: bash
+      env:
+        JOB_VCPUS: ${{ inputs.vcpus }}
+      run: |
+        kill "${RESOURCE_SAMPLER_PID}" 2>/dev/null || true
+        peak_mem="$(cut -d' ' -f1 resource.log 2>/dev/null | sort --numeric-sort | tail --lines=1)"
+        peak_disk="$(cut -d' ' -f2 resource.log 2>/dev/null | sort --numeric-sort | tail --lines=1)"
+        min_free="$(cut -d' ' -f3 resource.log 2>/dev/null | sort --numeric-sort | head --lines=1)"
+        {
+          printf '### Peak resource use\n\n'
+          printf -- '- memory: %s MiB on %s vCPUs\n' "${peak_mem:-unknown}" "${JOB_VCPUS}"
+          printf -- '- disk used: %s MiB, least free: %s MiB\n' \
+            "${peak_disk:-unknown}" "${min_free:-unknown}"
+        } | tee -a "${GITHUB_STEP_SUMMARY}"
+        df -h .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -879,15 +879,31 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       # `llvm-cov`'s target tree has no consumer once the report is written,
-      # and it is the second tree on a volume that a sibling repository
-      # exhausted on this shape. Removed before any cache save, so no archive
-      # carries it and the sampler's least-free figure reflects the job's real
-      # high-water mark rather than scratch that was about to be discarded.
+      # and it is the second tree on a volume this job leaves 89% full.
+      # Removed before any cache save, so no archive carries it and the
+      # sampler's least-free figure reflects the job's real high-water mark
+      # rather than scratch that was about to be discarded.
       - name: Discard the instrumented build tree
         if: always()
+        shell: bash
         run: |
+          set -uo pipefail
           df -h .
-          rm --recursive --force target/llvm-cov-target target/llvm-cov
+          # `cargo llvm-cov` builds beside the manifest it was given, which is
+          # `rust/Cargo.toml` here and not the repository root. Locating the
+          # tree rather than naming it keeps the reclaim correct if the
+          # manifest moves, and reporting the size keeps a run that reclaimed
+          # nothing distinguishable from one that had nothing to reclaim.
+          found=0
+          while IFS= read -r tree; do
+            found=1
+            du -sh "${tree}" || true
+            rm --recursive --force "${tree}"
+          done < <(find . -maxdepth 4 -type d \
+            \( -name llvm-cov-target -o -name llvm-cov \) -prune -print)
+          if [ "${found}" -eq 0 ]; then
+            echo "No instrumented build tree found to discard"
+          fi
           df -h .
 
       # Last, and unconditional, so a job that failed on disk still reports the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1019,15 +1019,14 @@ jobs:
           # Keep its scoped token out of later build commands.
           persist-credentials: false
 
-      # Started before the first cache restore, so the archive downloads and
-      # every build below fall inside the measured window. `ubicloud-standard-2`
-      # starts with about 31 GB free, and disk, not memory, is what kills a job
-      # on this shape.
-      - name: Start resource sampler
-        uses: ./.github/actions/resource-sampler
-        with:
-          mode: start
-          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
+      # No resource sampler here, deliberately. This job times commands that
+      # run for about half a second and compares the ratio of two of them, so
+      # a background loop waking every 15 s to shell out to `free` and `df` is
+      # interference in the measurement rather than an observation of it. Its
+      # disk figure was taken once, in run 33857764655: 62.1 GB used with
+      # 11.0 GB free on the 72 GB volume, the same envelope as the other
+      # Ubicloud jobs.
+
       - name: Compute cache keys
         uses: ./.github/actions/cache-keys
         with:
@@ -1310,15 +1309,6 @@ jobs:
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
-
-      # Last, and unconditional, so a job that failed on disk still reports the
-      # high-water mark that explains why.
-      - name: Report peak resource use
-        if: always()
-        uses: ./.github/actions/resource-sampler
-        with:
-          mode: report
-          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
 
   build-wheels:
     uses: ./.github/workflows/build-wheels.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           python-version: '3.13'
           generation: ${{ env.CACHE_GENERATION }}
           ubuntu-release: ${{ env.UBUNTU_RELEASE }}
+          compiler-shape: lint
 
       # This job is GitHub-hosted, so these archives live in GitHub's cache
       # service rather than Ubicloud's. Every key carries `runner.environment`,
@@ -233,6 +234,18 @@ jobs:
           key: ${{ env.CARGO_CACHE_KEY }}
 
       - name: Save the compiler cache
+        # The only GitHub-hosted job that compiles, so it owns the whole
+        # `github-hosted` compiler-cache scope; its Cranelift lint build is
+        # also a shape no other job produces. Its archive lands in GitHub's
+        # cache rather than Ubicloud's, which is the other reason the lane is
+        # named in the key.
+        #
+        # The entry is a rolling generation named after the run, so there is
+        # no cache-hit guard to skip: the key is new every time, and a run
+        # that restored the previous generation republishes it with whatever
+        # it added. The event guard is what keeps a pull request, or a
+        # dispatch measuring warm caches, from publishing into a family it is
+        # not trusted to own.
         if: >-
           github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -276,12 +289,22 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
+      # Started before the first cache restore, so the archive downloads and
+      # every build below fall inside the measured window. `ubicloud-standard-2`
+      # starts with about 31 GB free, and disk, not memory, is what kills a job
+      # on this shape.
+      - name: Start resource sampler
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: start
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
       - name: Compute cache keys
         uses: ./.github/actions/cache-keys
         with:
           python-version: ${{ matrix.python-version }}
           generation: ${{ env.CACHE_GENERATION }}
           ubuntu-release: ${{ env.UBUNTU_RELEASE }}
+          compiler-shape: debug
 
       - name: Restore the Cargo registry
         id: cargo-cache
@@ -428,6 +451,36 @@ jobs:
             .uv-tools
           key: ${{ env.TOOL_CACHE_KEY }}
 
+      - name: Save the compiler cache
+        # Each leg that runs the Python suite compiles the extension against
+        # its own interpreter, and `pyo3` is built without `abi3`, so those
+        # objects serve no other leg. The interpreter is part of the key, so
+        # each leg is the sole writer of its own family rather than four legs
+        # racing for one. The typecheck-only leg compiles nothing and has no
+        # compiler cache to save.
+        #
+        # The entry is a rolling generation named after the run, so there is
+        # no cache-hit guard to skip: the key is new every time, and a run
+        # that restored the previous generation republishes it with whatever
+        # it added. The event guard is what keeps a pull request, or a
+        # dispatch measuring warm caches, from publishing into a family it is
+        # not trusted to own.
+        if: >-
+          github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+          matrix.python-suite
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/sccache
+          key: ${{ env.SCCACHE_CACHE_KEY }}
+
+      # Last, and unconditional, so a job that failed on disk still reports the
+      # high-water mark that explains why.
+      - name: Report peak resource use
+        if: always()
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: report
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
 
   extension-tests:
     name: Extension-gated tests (Python/Rust boundary)
@@ -441,12 +494,22 @@ jobs:
           # must not stay in .git/config where that code could reach it.
           persist-credentials: false
 
+      # Started before the first cache restore, so the archive downloads and
+      # every build below fall inside the measured window. `ubicloud-standard-2`
+      # starts with about 31 GB free, and disk, not memory, is what kills a job
+      # on this shape.
+      - name: Start resource sampler
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: start
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
       - name: Compute cache keys
         uses: ./.github/actions/cache-keys
         with:
           python-version: '3.13'
           generation: ${{ env.CACHE_GENERATION }}
           ubuntu-release: ${{ env.UBUNTU_RELEASE }}
+          compiler-shape: debug
 
       - name: Restore the Cargo registry
         id: cargo-cache
@@ -580,8 +643,7 @@ jobs:
 
       # This is the heaviest Rust gate that runs on `main`: it resolves the
       # locked graph and compiles the extension. It therefore owns the Cargo
-      # registry key, and the local compiler-cache key when that backend is
-      # selected. Every other job restores both.
+      # registry key. Every other job restores it.
       - name: Save the Cargo registry
         if: >-
           github.event_name == 'push' && github.ref == 'refs/heads/main' &&
@@ -592,6 +654,34 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ env.CARGO_CACHE_KEY }}
+
+      - name: Save the compiler cache
+        # This job is the only one that builds the unoptimized extension
+        # against Python 3.13, so it owns the `py3.13-debug` compiler-cache
+        # family. Before this step existed the family had no writer at all
+        # and every reader of it was permanently cold.
+        #
+        # The entry is a rolling generation named after the run, so there is
+        # no cache-hit guard to skip: the key is new every time, and a run
+        # that restored the previous generation republishes it with whatever
+        # it added. The event guard is what keeps a pull request, or a
+        # dispatch measuring warm caches, from publishing into a family it is
+        # not trusted to own.
+        if: >-
+          github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/sccache
+          key: ${{ env.SCCACHE_CACHE_KEY }}
+
+      # Last, and unconditional, so a job that failed on disk still reports the
+      # high-water mark that explains why.
+      - name: Report peak resource use
+        if: always()
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: report
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
 
   coverage:
     # Pull requests only. Pushes to main are handled by coverage-main.yml,
@@ -615,12 +705,22 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Started before the first cache restore, so the archive downloads and
+      # every build below fall inside the measured window. `ubicloud-standard-2`
+      # starts with about 31 GB free, and disk, not memory, is what kills a job
+      # on this shape.
+      - name: Start resource sampler
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: start
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
       - name: Compute cache keys
         uses: ./.github/actions/cache-keys
         with:
           python-version: '3.13'
           generation: ${{ env.CACHE_GENERATION }}
           ubuntu-release: ${{ env.UBUNTU_RELEASE }}
+          compiler-shape: coverage
 
       # Pull requests only, so this job never saves: it reads the generation
       # that the `main` writers published and publishes nothing of its own.
@@ -778,6 +878,27 @@ jobs:
             printf '%s\n' "${fence}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      # `llvm-cov`'s target tree has no consumer once the report is written,
+      # and it is the second tree on a volume that a sibling repository
+      # exhausted on this shape. Removed before any cache save, so no archive
+      # carries it and the sampler's least-free figure reflects the job's real
+      # high-water mark rather than scratch that was about to be discarded.
+      - name: Discard the instrumented build tree
+        if: always()
+        run: |
+          df -h .
+          rm --recursive --force target/llvm-cov-target target/llvm-cov
+          df -h .
+
+      # Last, and unconditional, so a job that failed on disk still reports the
+      # high-water mark that explains why.
+      - name: Report peak resource use
+        if: always()
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: report
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
+
   # Detects whether performance-relevant paths changed so that
   # benchmark-ratchet can skip docs-only and Dependabot-batch pull
   # requests. Runs on every event (cheap, GitHub-hosted) so that the
@@ -882,12 +1003,22 @@ jobs:
           # Keep its scoped token out of later build commands.
           persist-credentials: false
 
+      # Started before the first cache restore, so the archive downloads and
+      # every build below fall inside the measured window. `ubicloud-standard-2`
+      # starts with about 31 GB free, and disk, not memory, is what kills a job
+      # on this shape.
+      - name: Start resource sampler
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: start
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
       - name: Compute cache keys
         uses: ./.github/actions/cache-keys
         with:
           python-version: '3.13'
           generation: ${{ env.CACHE_GENERATION }}
           ubuntu-release: ${{ env.UBUNTU_RELEASE }}
+          compiler-shape: release
 
       - name: Restore the Cargo registry
         id: cargo-cache
@@ -1144,6 +1275,34 @@ jobs:
           path: |
             ${{ runner.temp }}/benchmark-ratchet/main-plan.json
             ${{ runner.temp }}/benchmark-ratchet/main-throughput.json
+
+      - name: Save the compiler cache
+        # This is the only job that builds the extension with `--release`, so
+        # it owns the `py3.13-release` compiler-cache family. An optimized
+        # object cannot serve an unoptimized build, which is why the shape is
+        # part of the key rather than shared with `extension-tests`.
+        #
+        # The entry is a rolling generation named after the run, so there is
+        # no cache-hit guard to skip: the key is new every time, and a run
+        # that restored the previous generation republishes it with whatever
+        # it added. The event guard is what keeps a pull request, or a
+        # dispatch measuring warm caches, from publishing into a family it is
+        # not trusted to own.
+        if: >-
+          github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/sccache
+          key: ${{ env.SCCACHE_CACHE_KEY }}
+
+      # Last, and unconditional, so a job that failed on disk still reports the
+      # high-water mark that explains why.
+      - name: Report peak resource use
+        if: always()
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: report
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
 
   build-wheels:
     uses: ./.github/workflows/build-wheels.yml

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -232,15 +232,31 @@ jobs:
       # cache-hit guard to skip: the key is new every time, and a run that
       # restored the previous generation republishes it with what it added.
       # `llvm-cov`'s target tree has no consumer once the report is written,
-      # and it is the second tree on a volume that a sibling repository
-      # exhausted on this shape. Removed before any cache save, so no archive
-      # carries it and the sampler's least-free figure reflects the job's real
-      # high-water mark rather than scratch that was about to be discarded.
+      # and it is the second tree on a volume this job leaves 89% full.
+      # Removed before any cache save, so no archive carries it and the
+      # sampler's least-free figure reflects the job's real high-water mark
+      # rather than scratch that was about to be discarded.
       - name: Discard the instrumented build tree
         if: always()
+        shell: bash
         run: |
+          set -uo pipefail
           df -h .
-          rm --recursive --force target/llvm-cov-target target/llvm-cov
+          # `cargo llvm-cov` builds beside the manifest it was given, which is
+          # `rust/Cargo.toml` here and not the repository root. Locating the
+          # tree rather than naming it keeps the reclaim correct if the
+          # manifest moves, and reporting the size keeps a run that reclaimed
+          # nothing distinguishable from one that had nothing to reclaim.
+          found=0
+          while IFS= read -r tree; do
+            found=1
+            du -sh "${tree}" || true
+            rm --recursive --force "${tree}"
+          done < <(find . -maxdepth 4 -type d \
+            \( -name llvm-cov-target -o -name llvm-cov \) -prune -print)
+          if [ "${found}" -eq 0 ]; then
+            echo "No instrumented build tree found to discard"
+          fi
           df -h .
 
       - name: Save the compiler cache

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -43,12 +43,23 @@ jobs:
           # stay in .git/config where that code could read it.
           persist-credentials: false
 
+      # Started before the first cache restore, so the archive downloads and
+      # every build below fall inside the measured window. `ubicloud-standard-2`
+      # starts with about 31 GB free, and disk, not memory, is what kills a job
+      # on this shape.
+      - name: Start resource sampler
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: start
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}
+
       - name: Compute cache keys
         uses: ./.github/actions/cache-keys
         with:
           python-version: '3.13'
           generation: ${{ env.CACHE_GENERATION }}
           ubuntu-release: ${{ env.UBUNTU_RELEASE }}
+          compiler-shape: coverage
 
       # Restore only, both of these. This workflow and ci.yml both fire on a
       # push to `main`, so letting this job save either key would give it two
@@ -77,10 +88,12 @@ jobs:
           key: ${{ env.TOOL_CACHE_KEY }}
           restore-keys: ${{ env.TOOL_CACHE_PREFIX }}
 
-      # This job runs the same coverage action as ci.yml's `coverage`, which
-      # issued 38 compile requests in run 33748907011, so it compiles the
-      # extension too and needs the same wrapper. Restore only: ci.yml's
-      # `typecheck-test` owns this key.
+      # This job runs the same coverage action as ci.yml's `coverage`, so it
+      # compiles the workspace under instrumentation and needs the same
+      # wrapper. It is also the sole writer of the family it reads: no job in
+      # ci.yml saves an instrumented archive, and ci.yml's own `coverage` job
+      # is pull-request-only and therefore never publishes. The save step at
+      # the end of this job is that writer.
       - name: Restore the compiler cache
         id: sccache-dir
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -204,17 +217,44 @@ jobs:
             printf '%s\n' "${fence}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      # This job owns the compiler cache for the Ubicloud lane. It runs the
-      # whole Rust suite under instrumentation, so on `main` it is by a wide
-      # margin the heaviest compiler in the estate; the interpreter matrix
-      # compiles almost nothing now that the Rust suite lives here.
+      # This job owns the `py3.13-coverage` compiler-cache family, and only
+      # that family. It runs the whole Rust suite under instrumentation, so on
+      # `main` it is by a wide margin the heaviest compiler in the estate.
+      #
+      # It deliberately does not serve the uninstrumented jobs. Until
+      # 2026-09-04 the compiler key named neither the interpreter nor the
+      # build shape, so every Ubicloud job read this archive and only the one
+      # that matched it, `extension-tests` on the same interpreter, got any
+      # hits; the 3.12, 3.14 and 3.15a legs took none. Each shape now has its
+      # own family and its own writer.
       #
       # The entry is a rolling generation named after the run, so there is no
       # cache-hit guard to skip: the key is new every time, and a run that
       # restored the previous generation republishes it with what it added.
+      # `llvm-cov`'s target tree has no consumer once the report is written,
+      # and it is the second tree on a volume that a sibling repository
+      # exhausted on this shape. Removed before any cache save, so no archive
+      # carries it and the sampler's least-free figure reflects the job's real
+      # high-water mark rather than scratch that was about to be discarded.
+      - name: Discard the instrumented build tree
+        if: always()
+        run: |
+          df -h .
+          rm --recursive --force target/llvm-cov-target target/llvm-cov
+          df -h .
+
       - name: Save the compiler cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
+
+      # Last, and unconditional, so a job that failed on disk still reports the
+      # high-water mark that explains why.
+      - name: Report peak resource use
+        if: always()
+        uses: ./.github/actions/resource-sampler
+        with:
+          mode: report
+          vcpus: ${{ env.LINUX_RUNNER_VCPUS }}

--- a/docs/ci-cache-ownership.md
+++ b/docs/ci-cache-ownership.md
@@ -53,12 +53,11 @@ The build shape. An unoptimized `maturin develop` build, the same build with
 
 This was measured rather than assumed. Until 2026-09-04 the compiler key named
 neither dimension, so every Ubicloud job read one archive that the instrumented
-Python 3.13 coverage job had written. In runs 33853599399 and 33854076859, over
-an unchanged tree, the one reader on the same interpreter took 14 of its 17
-cacheable compiles and the 3.12, 3.14, and 3.15a readers took none at all.
-Read
-and write errors were zero throughout: the archive restored perfectly and
-simply held nothing those jobs could use.
+Python 3.13 coverage job had written. In two dispatches over an unchanged
+tree[^1][^2], the one reader on the same interpreter took 14 of its 17 cacheable
+compiles and the 3.12, 3.14, and 3.15a readers took none. Read and write errors
+were zero throughout: the archive restored perfectly and simply held nothing
+those jobs could use.
 
 If `pyo3` ever adopts `abi3`, one archive could serve every interpreter and the
 per-interpreter split becomes pure overhead.
@@ -132,8 +131,8 @@ the summary.
 that run for about half a second and compares the ratio of two of them, so a
 background loop waking every 15 s to shell out to `free` and `df` would be
 interference in the measurement rather than an observation of it. Its disk
-figure was taken once instead, in run 33857764655: 62.1 GB used with 11.0 GB
-free, the same envelope as every other Ubicloud job here.
+figure was taken once instead[^3]: 62.1 GB used with 11.0 GB free, the same
+envelope as every other Ubicloud job here.
 
 The coverage jobs additionally discard the instrumented build tree once the
 report is written, printing `df -h` either side. It has no later consumer, it
@@ -141,4 +140,16 @@ is the second tree on the volume, and removing it before any cache save keeps
 it out of the archives and out of the measured high-water mark. The step
 searches for the tree rather than naming it: `cargo llvm-cov` builds beside the
 manifest it is given, and an earlier version named a repository-root path and
-reclaimed nothing while reporting success.
+reclaimed nothing while reporting success[^3].
+
+[^1]: Cuprum CI run
+    [33853599399](https://github.com/leynos/cuprum/actions/runs/33853599399), a
+    `workflow_dispatch` on `main` measuring warm caches, 2026-09-04.
+
+[^2]: Cuprum CI run
+    [33854076859](https://github.com/leynos/cuprum/actions/runs/33854076859),
+    the second such dispatch over the same tree, 2026-09-04.
+
+[^3]: Cuprum CI run
+    [33857764655](https://github.com/leynos/cuprum/actions/runs/33857764655),
+    the first run carrying the resource sampler, 2026-09-04.

--- a/docs/ci-cache-ownership.md
+++ b/docs/ci-cache-ownership.md
@@ -20,7 +20,10 @@ ownership back out of the workflows.
 | `tool-`    | installed executables and uv environments | lane, image, interpreter              |
 | `sccache-` | compiler output                           | lane, image, interpreter, build shape |
 
-Every key also carries a generation, the operating system and the architecture.
+_Table 1: The cache families, what each holds, and what scopes its key._
+
+Every key also carries a generation, the operating system, and the
+architecture.
 `target` trees appear in no family at all: sccache holds the objects a `target`
 archive would preserve, and a `target` archive is invalidated by every source
 change while the objects inside it are not.
@@ -45,14 +48,15 @@ against one specific CPython version. Objects built against 3.12 are useless to
 a 3.14 build.
 
 The build shape. An unoptimized `maturin develop` build, the same build with
-`--release`, the Cranelift-backed lint build and the instrumented
+`--release`, the Cranelift-backed lint build, and the instrumented
 `cargo llvm-cov` build all produce different objects from identical source.
 
 This was measured rather than assumed. Until 2026-09-04 the compiler key named
 neither dimension, so every Ubicloud job read one archive that the instrumented
 Python 3.13 coverage job had written. In runs 33853599399 and 33854076859, over
 an unchanged tree, the one reader on the same interpreter took 14 of its 17
-cacheable compiles and the 3.12, 3.14 and 3.15a readers took none at all. Read
+cacheable compiles and the 3.12, 3.14, and 3.15a readers took none at all.
+Read
 and write errors were zero throughout: the archive restored perfectly and
 simply held nothing those jobs could use.
 
@@ -79,6 +83,8 @@ to measure warm caches without churning the generation they are measuring.
 | Compiler, 3.13 release                | `ci.yml` `benchmark-ratchet`          |
 | Compiler, 3.13 instrumented           | `coverage-main.yml` `coverage-upload` |
 | Compiler, Cranelift lint              | `ci.yml` `lint-test`                  |
+
+_Table 2: The single job that publishes each family on a push to `main`._
 
 The interpreter matrix has one leg, 3.13, that only typechecks, because the
 coverage job already runs that interpreter's suite. It compiles nothing, so it

--- a/docs/ci-cache-ownership.md
+++ b/docs/ci-cache-ownership.md
@@ -1,0 +1,126 @@
+# CI cache ownership
+
+Cuprum's continuous-integration caches are not an incidental optimization. They
+are the only reason the Linux gates fit inside a two-vCPU paid runner, and a
+cache with the wrong shape is invisible: a job that recompiles its whole
+dependency graph on every run looks exactly like one that restored it. This
+document records who owns which archive and why, so a reviewer can explain a
+miss without re-deriving the key from the workflow source.
+
+Every key renders once, in `.github/actions/cache-keys`, and both the job that
+restores a path and the job that saves it read the rendered value from the
+environment. The contract tests in `tests/test_ci_cache_ownership.py` read the
+ownership back out of the workflows.
+
+## The three families
+
+| Family     | Holds                                     | Scoped by                             |
+| ---------- | ----------------------------------------- | ------------------------------------- |
+| `cargo-`   | `~/.cargo/registry` and `~/.cargo/git`    | lane                                  |
+| `tool-`    | installed executables and uv environments | lane, image, interpreter              |
+| `sccache-` | compiler output                           | lane, image, interpreter, build shape |
+
+Every key also carries a generation, the operating system and the architecture.
+`target` trees appear in no family at all: sccache holds the objects a `target`
+archive would preserve, and a `target` archive is invalidated by every source
+change while the objects inside it are not.
+
+## Why the lane is in every key
+
+`runner.environment` renders to `self-hosted` on Ubicloud and `github-hosted`
+on a GitHub-hosted runner, and the two lanes read different cache services. An
+archive written from an Ubicloud runner lands in Ubicloud's store, which a
+GitHub-hosted job cannot read, and vice versa. Naming the lane in the key makes
+that separation checkable rather than merely true; without it, one lane would
+appear to own a key it can never read and would be permanently cold.
+
+## Why the compiler cache is split further
+
+The compiler cache carries two dimensions the other families do not, because
+compiler output is only interchangeable between jobs that compile the same way.
+
+The interpreter. `rust/cuprum-rust/Cargo.toml` declares `pyo3` with the
+`extension-module` feature and without `abi3`, so the extension is compiled
+against one specific CPython version. Objects built against 3.12 are useless to
+a 3.14 build.
+
+The build shape. An unoptimized `maturin develop` build, the same build with
+`--release`, the Cranelift-backed lint build and the instrumented
+`cargo llvm-cov` build all produce different objects from identical source.
+
+This was measured rather than assumed. Until 2026-09-04 the compiler key named
+neither dimension, so every Ubicloud job read one archive that the instrumented
+Python 3.13 coverage job had written. In runs 33853599399 and 33854076859, over
+an unchanged tree, the one reader on the same interpreter took 14 of its 17
+cacheable compiles and the 3.12, 3.14 and 3.15a readers took none at all. Read
+and write errors were zero throughout: the archive restored perfectly and
+simply held nothing those jobs could use.
+
+If `pyo3` ever adopts `abi3`, one archive could serve every interpreter and the
+per-interpreter split becomes pure overhead.
+`test_pyo3_is_still_declared_without_abi3` is the reminder to collapse it.
+
+## One writer per family
+
+A family is written by exactly one job, and only on a push to `main`. Pull
+requests restore and never save: a pull-request branch cannot publish a
+generation anyone should trust, and the attempt produces only
+`Unable to reserve cache` noise and wasted upload time. A `workflow_dispatch`
+run is likewise a reader, which is what makes repeated dispatches a usable way
+to measure warm caches without churning the generation they are measuring.
+
+| Family                                | Writer                                |
+| ------------------------------------- | ------------------------------------- |
+| Cargo registry, Ubicloud              | `ci.yml` `extension-tests`            |
+| Cargo registry, GitHub-hosted         | `ci.yml` `lint-test`                  |
+| Tools, per interpreter                | `ci.yml` `typecheck-test`, that leg   |
+| Compiler, 3.13 unoptimized            | `ci.yml` `extension-tests`            |
+| Compiler, 3.12/3.14/3.15a unoptimized | `ci.yml` `typecheck-test`, that leg   |
+| Compiler, 3.13 release                | `ci.yml` `benchmark-ratchet`          |
+| Compiler, 3.13 instrumented           | `coverage-main.yml` `coverage-upload` |
+| Compiler, Cranelift lint              | `ci.yml` `lint-test`                  |
+
+The interpreter matrix has one leg, 3.13, that only typechecks, because the
+coverage job already runs that interpreter's suite. It compiles nothing, so it
+installs no wrapper and saves no compiler archive; `extension-tests` owns the
+3.13 unoptimized family instead. A writer that compiled nothing would restore
+the previous generation and republish it unchanged for ever, reporting hits
+while absorbing nothing new.
+
+`tests/helpers/ci_cache_families.py` resolves the family each save step
+actually publishes, expanding matrix legs and honouring a save condition that
+names a matrix value. This matters because the `env` name a step writes is not
+the archive it publishes: five jobs name `SCCACHE_CACHE_KEY` and write five
+disjoint archives.
+
+## Rolling keys
+
+The compiler key ends in the run identifier, so it never matches exactly and
+every restore is a `restore-keys` prefix match. That is deliberate. The
+contents of a compiler cache depend on the source that was compiled, which no
+lockfile hash captures, so a content-addressed key would hit for ever and
+absorb nothing new. Each writing run publishes a fresh entry seeded from the
+newest entry its prefix matched.
+
+The corollary is that each writer run adds an entry rather than replacing one,
+and old entries are never read again once a newer one exists. They persist
+until the cache service sweeps them. Watch the weekly footprint if the number
+of writing runs grows.
+
+The Cargo and tool families are content-addressed instead, so their saves carry
+an additional cache-hit guard: a run that already hit must not re-upload what
+it just downloaded.
+
+## Resource sampling
+
+`ubicloud-standard-2` carries a 72 GB volume with roughly 31 GB free at job
+start. Disk, not memory, is what kills a job on that shape, and it does so
+silently. Every paid Linux job that compiles or runs a suite therefore brackets
+its work with `.github/actions/resource-sampler`, which records peak memory,
+peak disk and least-free disk to the log as well as to the step summary. The
+log matters because the jobs API exposes it and does not expose the summary.
+
+The coverage jobs additionally discard `target/llvm-cov-target` once the report
+is written, printing `df -h` either side. It has no later consumer, it is the
+second tree on the volume, and removing it before any cache save keeps it out
+of the archives and out of the measured high-water mark.

--- a/docs/ci-cache-ownership.md
+++ b/docs/ci-cache-ownership.md
@@ -119,14 +119,26 @@ it just downloaded.
 
 ## Resource sampling
 
-`ubicloud-standard-2` carries a 72 GB volume with roughly 31 GB free at job
-start. Disk, not memory, is what kills a job on that shape, and it does so
-silently. Every paid Linux job that compiles or runs a suite therefore brackets
-its work with `.github/actions/resource-sampler`, which records peak memory,
-peak disk and least-free disk to the log as well as to the step summary. The
-log matters because the jobs API exposes it and does not expose the summary.
+`ubicloud-standard-2` presents a 72 GB volume that is already 85 to 89 % full
+while a job runs, leaving 8 to 11 GB free rather than the roughly 31 GB the
+estate's earlier notes assumed. Disk, not memory, is what kills a job on that
+shape, and it does so silently. Jobs that compile or run a suite therefore
+bracket their work with `.github/actions/resource-sampler`, which records peak
+memory, peak disk, and least-free disk to the log as well as to the step
+summary. The log matters because the jobs API exposes it and does not expose
+the summary.
 
-The coverage jobs additionally discard `target/llvm-cov-target` once the report
-is written, printing `df -h` either side. It has no later consumer, it is the
-second tree on the volume, and removing it before any cache save keeps it out
-of the archives and out of the measured high-water mark.
+`benchmark-ratchet` is the exception, and deliberately so. It times commands
+that run for about half a second and compares the ratio of two of them, so a
+background loop waking every 15 s to shell out to `free` and `df` would be
+interference in the measurement rather than an observation of it. Its disk
+figure was taken once instead, in run 33857764655: 62.1 GB used with 11.0 GB
+free, the same envelope as every other Ubicloud job here.
+
+The coverage jobs additionally discard the instrumented build tree once the
+report is written, printing `df -h` either side. It has no later consumer, it
+is the second tree on the volume, and removing it before any cache save keeps
+it out of the archives and out of the measured high-water mark. The step
+searches for the tree rather than naming it: `cargo llvm-cov` builds beside the
+manifest it is given, and an earlier version named a repository-root path and
+reclaimed nothing while reporting success.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -19,6 +19,9 @@ open each document.
   spelling, structure, Markdown, roadmap, RFC, and ADR rules.
 - [Scripting standards](scripting-standards.md) - conventions for project helper
   scripts, command execution, path handling, and command mocking.
+- [CI cache ownership](ci-cache-ownership.md) - which job writes each CI cache
+  family, why the compiler cache is split by interpreter and build shape, and
+  how resource use is sampled on the paid Linux runners.
 
 ## Design and decisions
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -188,15 +188,20 @@ so a content-addressed key would hit forever and absorb nothing new. Each
 writing run publishes a fresh entry seeded from the newest entry its prefix
 matches, and the save therefore carries no cache-hit guard.
 
-`coverage-upload` writes it for the Ubicloud lane, and `lint-test` writes the
-GitHub-hosted lane's entry. The writer has to be a job that actually compiles,
-or the rolling generation freezes: it would restore the previous entry and
-republish it unchanged forever, never absorbing a new object while still
-reporting hits. That is not hypothetical. The writer was briefly the 3.13
-interpreter leg, which the deduplication had just reduced to a typechecker.
+The key also names the interpreter and the build shape, so there is one family
+per compile shape and one writer for each:
+[CI cache ownership](ci-cache-ownership.md) lists them and records the
+measurement that forced the split. In outline, `extension-tests` writes the
+3.13 unoptimized family, each `typecheck-test` leg that runs a suite writes its
+own interpreter's, `benchmark-ratchet` writes the 3.13 release family,
+`coverage-upload` writes the instrumented one, and `lint-test` writes the
+GitHub-hosted lint family.
 
-One consequence is worth stating: the release objects `benchmark-ratchet`
-produces are restored but never republished because only the writing jobs save.
+The writer has to be a job that actually compiles, or the rolling generation
+freezes: it would restore the previous entry and republish it unchanged
+forever, never absorbing a new object while still reporting hits. That is not
+hypothetical. The writer was briefly the 3.13 interpreter leg, which the
+deduplication had just reduced to a typechecker.
 
 Every job that compiles Rust installs the wrapper and reports its counters:
 `lint-test`, `extension-tests`, `coverage`, `benchmark-ratchet`,

--- a/tests/helpers/ci_cache_families.py
+++ b/tests/helpers/ci_cache_families.py
@@ -1,0 +1,212 @@
+"""Resolve which cache family each save step in the estate publishes.
+
+Every cache key in this repository renders from ``.github/actions/cache-keys``,
+so five jobs can hold five save steps that all name ``SCCACHE_CACHE_KEY`` and
+still write five disjoint archives: the rendered key carries the runner lane,
+the interpreter, and the build shape, none of which appear in the ``env`` name.
+Counting writers by ``env`` name therefore either forbids a legitimate split or
+permits a genuine collision, depending on which way the manifest is written.
+
+This module resolves the family a save step actually publishes, so
+``tests/test_ci_cache_ownership.py`` can hold the real invariant: one writer per
+family. Matrix legs are expanded, because one declared step in the interpreter
+matrix is four writers of four families at run time, and a save condition that
+names a matrix value is honoured, because the leg it excludes writes nothing.
+"""
+
+from __future__ import annotations
+
+import re
+import typing as typ
+
+from tests.helpers.ci_workflows import job, save_steps, step_inputs, steps
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+    from tests.helpers.workflow_types import Step
+
+CACHE_KEYS_ACTION = "./.github/actions/cache-keys"
+
+#: The ``cache-keys`` inputs each key family is scoped by, beyond the runner
+#: lane that every family carries. The Cargo registry holds the resolved
+#: dependency graph, which no interpreter or build shape changes. The tool
+#: archive holds uv's interpreter-specific environments. Compiler output is
+#: narrower still: `pyo3` is declared without `abi3`, so an object compiled
+#: against one CPython serves no other, and an optimized or instrumented object
+#: serves no unoptimized build.
+KEY_SCOPES: typ.Final[cabc.Mapping[str, tuple[str, ...]]] = {
+    "CARGO_CACHE_KEY": (),
+    "TOOL_CACHE_KEY": ("python-version",),
+    "SCCACHE_CACHE_KEY": ("python-version", "compiler-shape"),
+}
+
+#: ``runner.environment`` renders from the runner label, and the two lanes read
+#: different cache services, so an archive can never cross between them.
+LANE_OF_LABEL: typ.Final[cabc.Mapping[str, str]] = {
+    "ubicloud-standard-2": "self-hosted",
+    "ubicloud-standard-4": "self-hosted",
+    "ubuntu-latest": "github-hosted",
+}
+
+_MATRIX_REFERENCE = re.compile(r"matrix\.([a-z0-9-]+)", re.IGNORECASE)
+_EXPRESSION = re.compile(r"^\s*\$\{\{(?P<body>.+)\}\}\s*$", re.DOTALL)
+
+
+def _require(*, condition: bool, message: str) -> None:
+    """Raise a contract failure when ``condition`` does not hold."""
+    if not condition:
+        raise AssertionError(message)
+
+
+class CacheFamily(typ.NamedTuple):
+    """One rendered cache family: what a single archive key identifies."""
+
+    key_name: str
+    lane: str
+    scope: tuple[str, ...]
+
+    def __str__(self) -> str:
+        """Return the family as a single readable identifier."""
+        return "-".join((self.key_name, self.lane, *self.scope))
+
+
+def _lane(workflow_name: str, job_name: str) -> str:
+    """Return the cache lane a job's runner label resolves to."""
+    label = job(workflow_name, job_name).get("runs-on")
+    _require(
+        condition=label in LANE_OF_LABEL,
+        message=f"{workflow_name}:{job_name} runs on unmapped label {label!r}",
+    )
+    return LANE_OF_LABEL[str(label)]
+
+
+def matrix_legs(workflow_name: str, job_name: str) -> list[dict[str, object]]:
+    """Return one mapping per matrix leg, or a single empty leg when there is none."""
+    strategy = job(workflow_name, job_name).get("strategy")
+    if not isinstance(strategy, dict):
+        return [{}]
+    matrix = strategy.get("matrix")
+    if not isinstance(matrix, dict):
+        return [{}]
+    include = matrix.get("include")
+    _require(
+        condition=isinstance(include, list),
+        message=(
+            f"{workflow_name}:{job_name} declares a matrix this contract cannot "
+            "expand; only `include` lists are supported"
+        ),
+    )
+    return [
+        typ.cast("dict[str, object]", leg) for leg in typ.cast("list[object]", include)
+    ]
+
+
+def _resolve(value: object, leg: cabc.Mapping[str, object], message: str) -> str:
+    """Render one ``cache-keys`` input against a matrix leg."""
+    text = str(value)
+    match = _EXPRESSION.match(text)
+    if match is None:
+        return text
+    body = match.group("body").strip()
+    reference = _MATRIX_REFERENCE.fullmatch(body)
+    _require(
+        condition=reference is not None,
+        message=f"{message}: cannot resolve {text!r}",
+    )
+    name = typ.cast("re.Match[str]", reference).group(1)
+    _require(
+        condition=name in leg,
+        message=f"{message}: matrix leg declares no {name!r}",
+    )
+    return str(leg[name])
+
+
+def _renderer_inputs(workflow_name: str, job_name: str) -> dict[str, object]:
+    """Return the inputs the job passes to the shared key renderer."""
+    renderers = [
+        step
+        for step in steps(workflow_name, job_name)
+        if step.get("uses") == CACHE_KEYS_ACTION
+    ]
+    _require(
+        condition=len(renderers) == 1,
+        message=(
+            f"{workflow_name}:{job_name} must render its keys through "
+            f"{CACHE_KEYS_ACTION} exactly once"
+        ),
+    )
+    return step_inputs(renderers[0], f"{workflow_name}:{job_name} renderer inputs")
+
+
+def _key_name(step: Step, message: str) -> str:
+    """Return the ``env`` name a save step's key expression renders from."""
+    key = step_inputs(step, message).get("key")
+    match = _EXPRESSION.match(str(key))
+    _require(
+        condition=match is not None,
+        message=f"{message}: key must be an expression, got {key!r}",
+    )
+    body = typ.cast("re.Match[str]", match).group("body").strip()
+    _require(
+        condition=body.startswith("env."),
+        message=f"{message}: key must render from env, got {key!r}",
+    )
+    return body.removeprefix("env.")
+
+
+def _writes_on_leg(step: Step, leg: cabc.Mapping[str, object]) -> bool:
+    """Report whether a save step's condition admits one matrix leg.
+
+    Returns
+    -------
+    bool
+        ``True`` when the leg writes, ``False`` when the condition excludes it.
+
+    Notes
+    -----
+    Only matrix references are evaluated. A condition naming
+    ``matrix.python-suite`` excludes the leg that compiles nothing, and that
+    exclusion is what keeps the typecheck-only leg from appearing to own a
+    family another job writes. Every other clause is a run-time value this
+    contract deliberately does not model.
+    """
+    condition = step.get("if")
+    if not isinstance(condition, str):
+        return True
+    return all(
+        bool(leg.get(name, False))
+        for name in _MATRIX_REFERENCE.findall(condition)
+        if name in leg
+    )
+
+
+def writer_families(workflow_name: str, job_name: str) -> set[CacheFamily]:
+    """Return every cache family one job publishes, expanded over its matrix."""
+    inputs = _renderer_inputs(workflow_name, job_name)
+    lane = _lane(workflow_name, job_name)
+    families: set[CacheFamily] = set()
+    for step in save_steps(workflow_name, job_name):
+        message = f"{workflow_name}:{job_name} save must declare inputs"
+        key_name = _key_name(step, message)
+        _require(
+            condition=key_name in KEY_SCOPES,
+            message=f"{message}: {key_name} has no declared scope",
+        )
+        for leg in matrix_legs(workflow_name, job_name):
+            if not _writes_on_leg(step, leg):
+                continue
+            # Every scoping input must be named explicitly rather than left to
+            # the action's default. A default is invisible at the call site,
+            # and a family whose scope a reader cannot see in the job is one
+            # they cannot check for a second writer.
+            missing = [name for name in KEY_SCOPES[key_name] if name not in inputs]
+            _require(
+                condition=not missing,
+                message=f"{message}: must declare {missing}",
+            )
+            scope = tuple(
+                _resolve(inputs[name], leg, message) for name in KEY_SCOPES[key_name]
+            )
+            families.add(CacheFamily(key_name, lane, scope))
+    return families

--- a/tests/helpers/ci_cache_families.py
+++ b/tests/helpers/ci_cache_families.py
@@ -60,7 +60,19 @@ def _require(*, condition: bool, message: str) -> None:
 
 
 class CacheFamily(typ.NamedTuple):
-    """One rendered cache family: what a single archive key identifies."""
+    """One rendered cache family: what a single archive key identifies.
+
+    Attributes
+    ----------
+    key_name:
+        The ``env`` name the key renders from, such as ``SCCACHE_CACHE_KEY``.
+    lane:
+        ``self-hosted`` or ``github-hosted``, the value ``runner.environment``
+        renders to. The two lanes read different cache services.
+    scope:
+        The ``cache-keys`` inputs this family is scoped by, in the order
+        :data:`KEY_SCOPES` declares them.
+    """
 
     key_name: str
     lane: str
@@ -82,7 +94,26 @@ def _lane(workflow_name: str, job_name: str) -> str:
 
 
 def matrix_legs(workflow_name: str, job_name: str) -> list[dict[str, object]]:
-    """Return one mapping per matrix leg, or a single empty leg when there is none."""
+    """Expand one job's matrix into the legs it runs as.
+
+    Parameters
+    ----------
+    workflow_name:
+        Workflow file name, such as ``ci.yml``.
+    job_name:
+        Job key within that workflow.
+
+    Returns
+    -------
+    list[dict[str, object]]
+        One mapping per ``include`` entry, or a single empty mapping when the
+        job declares no matrix, so callers can iterate uniformly.
+
+    Notes
+    -----
+    Fails the contract, through :func:`_require`, when the job declares a
+    matrix without an ``include`` list, which this reader cannot expand.
+    """
     strategy = job(workflow_name, job_name).get("strategy")
     if not isinstance(strategy, dict):
         return [{}]
@@ -182,7 +213,28 @@ def _writes_on_leg(step: Step, leg: cabc.Mapping[str, object]) -> bool:
 
 
 def writer_families(workflow_name: str, job_name: str) -> set[CacheFamily]:
-    """Return every cache family one job publishes, expanded over its matrix."""
+    """Resolve every cache family one job publishes.
+
+    Parameters
+    ----------
+    workflow_name:
+        Workflow file name, such as ``ci.yml``.
+    job_name:
+        Job key within that workflow.
+
+    Returns
+    -------
+    set[CacheFamily]
+        One entry per archive the job's save steps publish, with matrix legs
+        expanded and legs excluded by a matrix-valued save condition omitted.
+
+    Notes
+    -----
+    Fails the contract, through :func:`_require`, when the job renders its keys
+    other than exactly once through the shared renderer, when a save step names
+    a key with no declared scope, when a scoping input is left to the action's
+    default, or when the job publishes one family from more than one save step.
+    """
     inputs = _renderer_inputs(workflow_name, job_name)
     lane = _lane(workflow_name, job_name)
     families: set[CacheFamily] = set()
@@ -208,5 +260,14 @@ def writer_families(workflow_name: str, job_name: str) -> set[CacheFamily]:
             scope = tuple(
                 _resolve(inputs[name], leg, message) for name in KEY_SCOPES[key_name]
             )
-            families.add(CacheFamily(key_name, lane, scope))
+            family = CacheFamily(key_name, lane, scope)
+            # Rejected here rather than deduplicated by the set. Two save steps
+            # in one job that render the same family are the same collision the
+            # caller's contract exists to catch, and a set would silently make
+            # them one element and report the job as a sole writer.
+            _require(
+                condition=family not in families,
+                message=f"{message}: publishes {family} more than once",
+            )
+            families.add(family)
     return families

--- a/tests/helpers/ci_runners.py
+++ b/tests/helpers/ci_runners.py
@@ -59,6 +59,7 @@ UBICLOUD_VCPUS = 2
 GITHUB_LABEL = "ubuntu-latest"
 
 CACHE_KEYS_ACTION = "./.github/actions/cache-keys"
+CACHE_KEYS_ACTION_FILE = ROOT / ".github" / "actions" / "cache-keys" / "action.yml"
 SCCACHE_ACTION = "./.github/actions/setup-sccache"
 SETUP_RUST = (
     "leynos/shared-actions/.github/actions/setup-rust@"
@@ -153,15 +154,73 @@ FORBIDDEN_CACHE_PATHS: typ.Final = ("target", "rust/target", "target/debug")
 #: read different cache services; a key with two writers has one on each side.
 CACHE_WRITERS: typ.Final[cabc.Mapping[str, tuple[tuple[str, str], ...]]] = {
     "CARGO_CACHE_KEY": (("ci.yml", "extension-tests"), ("ci.yml", "lint-test")),
-    # The compiler cache is written by whichever job actually compiles. On the
-    # Ubicloud lane that is the coverage job, which runs the whole Rust suite
-    # under instrumentation; the interpreter matrix compiles almost nothing now
-    # that the suite lives there.
+    # The compiler cache is written by whichever job actually compiles, and
+    # each compile shape is its own family. See CACHE_FAMILY_WRITERS: this
+    # mapping only says which jobs hold a save step, not which archive each
+    # one publishes.
     "SCCACHE_CACHE_KEY": (
-        ("coverage-main.yml", "coverage-upload"),
+        ("ci.yml", "benchmark-ratchet"),
+        ("ci.yml", "extension-tests"),
         ("ci.yml", "lint-test"),
+        ("ci.yml", "typecheck-test"),
+        ("coverage-main.yml", "coverage-upload"),
     ),
     "TOOL_CACHE_KEY": (("ci.yml", "typecheck-test"),),
+}
+#: One writer per rendered family, which is the invariant that actually
+#: matters: five jobs name ``SCCACHE_CACHE_KEY`` and publish five disjoint
+#: archives, because the rendered key carries the lane, the interpreter and the
+#: build shape. Each entry is
+#: ``(key, lane, scope...) -> (workflow, job)``.
+#:
+#: The compiler split was measured on 2026-09-04. Before it, one instrumented
+#: 3.13 archive served every Ubicloud job: the 3.13 reader took 14 of its 17
+#: cacheable compiles and the 3.12, 3.14 and 3.15a readers took none, because
+#: `pyo3` is declared without `abi3` and an extension compiled against one
+#: CPython serves no other. `benchmark-ratchet` builds with `--release` and the
+#: coverage jobs build under instrumentation, so neither can share an archive
+#: with an unoptimized build either.
+#:
+#: The typecheck-only leg is absent by construction: it compiles nothing, its
+#: save step is gated on ``matrix.python-suite``, and `extension-tests` owns
+#: the 3.13 unoptimized family instead.
+CACHE_FAMILY_WRITERS: typ.Final[
+    cabc.Mapping[tuple[str, str, tuple[str, ...]], tuple[str, str]]
+] = {
+    ("CARGO_CACHE_KEY", "self-hosted", ()): ("ci.yml", "extension-tests"),
+    ("CARGO_CACHE_KEY", "github-hosted", ()): ("ci.yml", "lint-test"),
+    ("TOOL_CACHE_KEY", "self-hosted", ("3.12",)): ("ci.yml", "typecheck-test"),
+    ("TOOL_CACHE_KEY", "self-hosted", ("3.13",)): ("ci.yml", "typecheck-test"),
+    ("TOOL_CACHE_KEY", "self-hosted", ("3.14",)): ("ci.yml", "typecheck-test"),
+    ("TOOL_CACHE_KEY", "self-hosted", ("3.15",)): ("ci.yml", "typecheck-test"),
+    ("SCCACHE_CACHE_KEY", "github-hosted", ("3.13", "lint")): (
+        "ci.yml",
+        "lint-test",
+    ),
+    ("SCCACHE_CACHE_KEY", "self-hosted", ("3.12", "debug")): (
+        "ci.yml",
+        "typecheck-test",
+    ),
+    ("SCCACHE_CACHE_KEY", "self-hosted", ("3.13", "debug")): (
+        "ci.yml",
+        "extension-tests",
+    ),
+    ("SCCACHE_CACHE_KEY", "self-hosted", ("3.14", "debug")): (
+        "ci.yml",
+        "typecheck-test",
+    ),
+    ("SCCACHE_CACHE_KEY", "self-hosted", ("3.15", "debug")): (
+        "ci.yml",
+        "typecheck-test",
+    ),
+    ("SCCACHE_CACHE_KEY", "self-hosted", ("3.13", "release")): (
+        "ci.yml",
+        "benchmark-ratchet",
+    ),
+    ("SCCACHE_CACHE_KEY", "self-hosted", ("3.13", "coverage")): (
+        "coverage-main.yml",
+        "coverage-upload",
+    ),
 }
 #: Keys naming the run rather than the content they hold. A compiler cache
 #: depends on the source that was compiled, which no lockfile hash captures, so

--- a/tests/helpers/composite_actions.py
+++ b/tests/helpers/composite_actions.py
@@ -1,0 +1,171 @@
+"""Run a composite action's shell steps directly, outside a GitHub runner.
+
+A contract test that only checks a workflow references an action proves the
+wiring and nothing about the behaviour: the sampler could export no process
+identifier, sample nothing, or compute its peaks wrongly, and every workflow
+assertion would still pass. These helpers execute a named step's ``run`` body
+under ``bash`` with the runner's file-backed protocol emulated, so the shell
+itself is under test.
+
+Only the protocol the actions here actually use is emulated: ``GITHUB_ENV``
+and ``GITHUB_STEP_SUMMARY`` as append-only files, and ``GITHUB_ENV`` fed back
+into the environment between steps the way the runner does.
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - fixed argv, no shell
+import typing as typ
+
+import yaml
+
+from tests.helpers.ci_workflows import ROOT
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+    from pathlib import Path
+
+
+def _require(*, condition: bool, message: str) -> None:
+    """Raise a contract failure when ``condition`` does not hold."""
+    if not condition:
+        raise AssertionError(message)
+
+
+@dc.dataclass(frozen=True, slots=True)
+class StepResult:
+    """What running one step's shell produced."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    #: Values the step appended to ``GITHUB_ENV``, in the runner's ``NAME=value``
+    #: form. The runner exports these to every later step.
+    exported: dict[str, str]
+    #: Text the step appended to ``GITHUB_STEP_SUMMARY``.
+    summary: str
+
+
+def action_document(action_path: str) -> dict[str, object]:
+    """Parse one repository composite action.
+
+    Parameters
+    ----------
+    action_path:
+        Path to the action directory, relative to the repository root, such as
+        ``.github/actions/resource-sampler``.
+
+    Returns
+    -------
+    dict[str, object]
+        The parsed ``action.yml``.
+
+    Notes
+    -----
+    Fails the contract, through :func:`_require`, when the file does not parse
+    to a mapping.
+    """
+    document = yaml.safe_load(
+        (ROOT / action_path / "action.yml").read_text(encoding="utf-8")
+    )
+    _require(
+        condition=isinstance(document, dict),
+        message=f"{action_path}/action.yml must parse to a mapping",
+    )
+    return typ.cast("dict[str, object]", document)
+
+
+def step_script(action_path: str, step_name: str) -> str:
+    """Return the ``run`` body of one named step of a composite action."""
+    declared = typ.cast(
+        "dict[str, object]", action_document(action_path).get("runs", {})
+    ).get("steps")
+    _require(
+        condition=isinstance(declared, list),
+        message=f"{action_path} must declare a list of steps",
+    )
+    for step in typ.cast("list[object]", declared):
+        candidate = typ.cast("dict[str, object]", step)
+        if candidate.get("name") != step_name:
+            continue
+        script = candidate.get("run")
+        _require(
+            condition=isinstance(script, str),
+            message=f"{action_path}:{step_name} must run a script",
+        )
+        return typ.cast("str", script)
+    _require(
+        condition=False,
+        message=f"{action_path} declares no step named {step_name!r}",
+    )
+    raise AssertionError
+
+
+def _parse_exports(text: str) -> dict[str, str]:
+    """Read a ``GITHUB_ENV`` file's ``NAME=value`` lines."""
+    exported: dict[str, str] = {}
+    for line in text.splitlines():
+        if "=" in line:
+            name, value = line.split("=", maxsplit=1)
+            exported[name] = value
+    return exported
+
+
+def run_step(
+    script: str,
+    *,
+    workdir: Path,
+    environment: cabc.Mapping[str, str] | None = None,
+    timeout: float = 60.0,
+) -> StepResult:
+    """Execute one step's shell body with the runner's file protocol emulated.
+
+    Parameters
+    ----------
+    script:
+        The ``run`` body, as written in the action.
+    workdir:
+        Directory to run in, and where the emulated protocol files are placed.
+    environment:
+        Extra variables the step should see, such as the ``env`` block a
+        workflow would supply.
+    timeout:
+        Seconds to allow before failing the test rather than hanging it.
+
+    Returns
+    -------
+    StepResult
+        The exit status, both output streams, the values appended to
+        ``GITHUB_ENV``, and the text appended to ``GITHUB_STEP_SUMMARY``.
+    """
+    env_file = workdir / "github_env"
+    summary_file = workdir / "github_step_summary"
+    env_file.touch()
+    summary_file.touch()
+    env = {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "HOME": str(workdir),
+        "GITHUB_ENV": str(env_file),
+        "GITHUB_STEP_SUMMARY": str(summary_file),
+        **(environment or {}),
+    }
+    # ruff: ignore[subprocess-without-shell-equals-true] - the argv is fixed and
+    # the script comes from a tracked action file, not from user input; running
+    # it is the point of this helper.
+    completed = subprocess.run(
+        ["/bin/bash", "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=workdir,
+        env=env,
+        timeout=timeout,
+        check=False,
+    )
+    return StepResult(
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        exported=_parse_exports(env_file.read_text(encoding="utf-8")),
+        summary=summary_file.read_text(encoding="utf-8"),
+    )

--- a/tests/test_ci_cache_families_helper.py
+++ b/tests/test_ci_cache_families_helper.py
@@ -1,0 +1,140 @@
+"""Tests for the cache-family resolver itself.
+
+`tests/test_ci_cache_ownership.py` uses this resolver to hold the one-writer
+invariant, so a resolver that quietly mis-parsed an expression or dropped a
+matrix leg would weaken that contract without failing it. These tests exercise
+the resolver directly, against synthetic workflow shapes rather than the
+repository's own, so a future workflow that is merely unusual is caught here
+rather than silently mis-resolved there.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tests.helpers import ci_cache_families as families
+
+if typ.TYPE_CHECKING:
+    from tests.helpers.workflow_types import Step
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+MESSAGE = "synthetic job"
+#: Hypothesis's default deadline trips on a loaded developer machine for work
+#: this trivial, and a flaky contract test is worse than a slow one.
+SETTINGS = settings(deadline=None, max_examples=100)
+#: Names a workflow author could plausibly give a matrix key.
+MATRIX_NAMES = st.from_regex(r"\A[a-z][a-z0-9-]{0,20}\Z")
+#: Values that are not GitHub expressions, so `_resolve` must pass them through.
+LITERALS = st.text(min_size=1, max_size=30).filter(lambda s: "${{" not in s)
+
+
+@SETTINGS
+@given(literal=LITERALS, leg=st.dictionaries(MATRIX_NAMES, st.integers(), max_size=3))
+def test_a_literal_input_resolves_to_itself(
+    literal: str, leg: cabc.Mapping[str, object]
+) -> None:
+    """Pass a plain value through untouched, whatever the leg holds."""
+    assert families._resolve(literal, leg, MESSAGE) == literal, (
+        f"a value with no expression must pass through; {literal!r} did not"
+    )
+
+
+@SETTINGS
+@given(name=MATRIX_NAMES, value=st.integers() | st.text(max_size=10))
+def test_a_matrix_reference_resolves_from_the_leg(name: str, value: object) -> None:
+    """Render `${{ matrix.x }}` from the leg that supplies `x`."""
+    resolved = families._resolve("${{ matrix." + name + " }}", {name: value}, MESSAGE)
+    assert resolved == str(value), (
+        f"matrix.{name} must render from the leg, which holds {value!r}"
+    )
+
+
+@SETTINGS
+@given(name=MATRIX_NAMES)
+def test_a_matrix_reference_the_leg_lacks_is_a_contract_failure(name: str) -> None:
+    """Refuse to guess. A key the leg never declares is a workflow bug."""
+    with pytest.raises(AssertionError, match="matrix leg declares no"):
+        families._resolve("${{ matrix." + name + " }}", {}, MESSAGE)
+
+
+def test_a_non_matrix_expression_is_a_contract_failure() -> None:
+    """Reject an expression this reader cannot evaluate rather than mis-render it."""
+    with pytest.raises(AssertionError, match="cannot resolve"):
+        families._resolve("${{ env.SOMETHING }}", {}, MESSAGE)
+
+
+@SETTINGS
+@given(
+    flags=st.dictionaries(MATRIX_NAMES, st.booleans(), min_size=1, max_size=4),
+)
+def test_a_condition_admits_a_leg_when_every_named_flag_is_true(
+    flags: cabc.Mapping[str, bool],
+) -> None:
+    """Honour a save condition that names matrix values, and only those."""
+    condition = " && ".join(f"matrix.{name}" for name in flags)
+    step = typ.cast("Step", {"if": condition})
+    admitted = families._writes_on_leg(step, flags)
+    assert admitted == all(flags.values()), (
+        f"condition {condition!r} against {dict(flags)} must admit the leg only "
+        "when every flag it names is true"
+    )
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        None,
+        "github.event_name == 'push'",
+        "github.event_name == 'push' && github.ref == 'refs/heads/main'",
+    ],
+)
+def test_a_condition_naming_no_matrix_value_admits_every_leg(
+    condition: str | None,
+) -> None:
+    """Model matrix references only; run-time values are not this test's job."""
+    step = typ.cast("Step", {"if": condition} if condition is not None else {})
+    assert families._writes_on_leg(step, {"python-suite": False}), (
+        f"condition {condition!r} names no matrix value, so it must admit every leg"
+    )
+
+
+def test_a_job_without_a_matrix_expands_to_one_leg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Let callers iterate legs uniformly whether or not a matrix exists."""
+    monkeypatch.setattr(families, "job", lambda *_: {"runs-on": "ubuntu-latest"})
+    assert families.matrix_legs("w.yml", "j") == [{}], (
+        "a job with no matrix must expand to exactly one empty leg"
+    )
+
+
+def test_a_matrix_without_include_is_a_contract_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail loudly on a matrix shape this reader cannot expand."""
+    monkeypatch.setattr(
+        families, "job", lambda *_: {"strategy": {"matrix": {"python": ["3.13"]}}}
+    )
+    with pytest.raises(AssertionError, match="only `include` lists are supported"):
+        families.matrix_legs("w.yml", "j")
+
+
+def test_an_unmapped_runner_label_is_a_contract_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Refuse to guess a cache lane from a label nobody has declared."""
+    renderer = {
+        "uses": families.CACHE_KEYS_ACTION,
+        "with": {"python-version": "3.13", "compiler-shape": "debug"},
+    }
+    monkeypatch.setattr(families, "job", lambda *_: {"runs-on": "some-new-shape"})
+    monkeypatch.setattr(families, "steps", lambda *_: [renderer])
+    monkeypatch.setattr(families, "save_steps", lambda *_: [])
+    with pytest.raises(AssertionError, match="unmapped label"):
+        families.writer_families("w.yml", "j")

--- a/tests/test_ci_cache_families_helper.py
+++ b/tests/test_ci_cache_families_helper.py
@@ -1,11 +1,11 @@
 """Tests for the cache-family resolver itself.
 
 `tests/test_ci_cache_ownership.py` uses this resolver to hold the one-writer
-invariant, so a resolver that quietly mis-parsed an expression or dropped a
+invariant, so a resolver that quietly misread an expression or dropped a
 matrix leg would weaken that contract without failing it. These tests exercise
 the resolver directly, against synthetic workflow shapes rather than the
 repository's own, so a future workflow that is merely unusual is caught here
-rather than silently mis-resolved there.
+rather than silently resolved wrongly there.
 """
 
 from __future__ import annotations
@@ -64,7 +64,7 @@ def test_a_matrix_reference_the_leg_lacks_is_a_contract_failure(name: str) -> No
 
 
 def test_a_non_matrix_expression_is_a_contract_failure() -> None:
-    """Reject an expression this reader cannot evaluate rather than mis-render it."""
+    """Reject an expression this reader cannot evaluate rather than guess at it."""
     with pytest.raises(AssertionError, match="cannot resolve"):
         families._resolve("${{ env.SOMETHING }}", {}, MESSAGE)
 

--- a/tests/test_ci_cache_ownership.py
+++ b/tests/test_ci_cache_ownership.py
@@ -13,7 +13,9 @@ import typing as typ
 
 import pytest
 
+from tests.helpers.ci_cache_families import CacheFamily, writer_families
 from tests.helpers.ci_runners import (
+    CACHE_FAMILY_WRITERS,
     CACHE_KEYS_ACTION,
     CACHE_RESTORE,
     CACHE_WRITERS,
@@ -28,7 +30,6 @@ from tests.helpers.ci_runners import (
     cache_paths,
     cache_steps,
     expand,
-    job,
     restore_steps,
     save_steps,
     step_inputs,
@@ -166,11 +167,32 @@ def test_each_key_has_exactly_one_writer_per_lane() -> None:
     assert {key: tuple(sorted(writers)) for key, writers in observed.items()} == {
         key: tuple(sorted(writers)) for key, writers in CACHE_WRITERS.items()
     }, f"cache writers drifted from the manifest: {observed}"
-    for key, writers in observed.items():
-        lanes = [job(workflow, name).get("runs-on") for workflow, name in writers]
-        assert len(set(lanes)) == len(lanes), (
-            f"{key} has two writers on one runner lane: {writers} on {lanes}"
-        )
+
+
+def test_each_cache_family_has_exactly_one_writer() -> None:
+    """Give every rendered archive one owner, not every ``env`` name one owner.
+
+    The name a save step writes is not the archive it publishes. Five jobs name
+    ``SCCACHE_CACHE_KEY`` and write five disjoint families, because the
+    rendered key carries the runner lane, the interpreter and the build shape.
+    A contract that counted names would have to permit all five collisions, and
+    would then also permit a real one.
+    """
+    observed: dict[CacheFamily, tuple[str, str]] = {}
+    for workflow_name, job_name in expand(CACHED_JOBS):
+        for family in writer_families(workflow_name, job_name):
+            first = observed.setdefault(family, (workflow_name, job_name))
+            assert first == (workflow_name, job_name), (
+                f"{family} is written by both {first} and {(workflow_name, job_name)}"
+            )
+    expected = {
+        CacheFamily(*declared): writer
+        for declared, writer in CACHE_FAMILY_WRITERS.items()
+    }
+    assert observed == expected, (
+        "cache families drifted from the manifest; observed "
+        f"{sorted(map(str, observed))}"
+    )
 
 
 def test_saves_happen_only_on_trunk_and_only_after_a_miss() -> None:

--- a/tests/test_ci_compiler_cache.py
+++ b/tests/test_ci_compiler_cache.py
@@ -1,9 +1,10 @@
 """Contract tests for the single compiler-output owner across every build shape.
 
 This repository archives no `target` tree anywhere. sccache holds the objects a
-`target` archive would preserve, keyed by the flags that distinguish the debug,
-cranelift, and coverage-instrumented shapes, so all three coexist in one store
-and no job needs a tree that is invalidated on every source change.
+`target` archive would preserve, and the archive key names the interpreter and
+the build shape, so the debug, cranelift, release and coverage-instrumented
+shapes coexist without any of them overwriting or starving another, and no job
+needs a tree that is invalidated on every source change.
 
 None of that is visible from a green run: a job whose `RUSTC_WRAPPER` never
 reaches the compiler still passes while caching nothing, which is exactly what
@@ -18,6 +19,7 @@ import pytest
 
 from tests.helpers.ci_runners import (
     CACHE_ACTION_PIN,
+    CACHE_KEYS_ACTION_FILE,
     CACHED_JOBS,
     FORBIDDEN_CACHE_PATHS,
     ROOT,
@@ -254,10 +256,12 @@ def test_the_typecheck_only_leg_installs_no_wrapper() -> None:
 def test_the_compiler_cache_is_written_by_a_job_that_compiles() -> None:
     """Keep the rolling generation from freezing.
 
-    The writer used to be the interpreter leg that the deduplication left with
-    only a typechecker. It would have restored the previous generation and
-    republished it unchanged for ever, so the cache would never absorb a new
-    object while still reporting hits.
+    A leg that compiles nothing would restore the previous generation and
+    republish it unchanged for ever, so the cache would never absorb a new
+    object while still reporting hits. The interpreter matrix contains exactly
+    one such leg, the one the coverage job already runs the suite for, and its
+    save must therefore carry the same ``matrix.python-suite`` guard as the
+    rest of its compiler-cache steps.
     """
     writers = [
         step
@@ -271,8 +275,48 @@ def test_the_compiler_cache_is_written_by_a_job_that_compiles() -> None:
         for step in steps("ci.yml", "typecheck-test")
         if str(step.get("name", "")) == "Save the compiler cache"
     ]
-    assert not matrix_writers, (
-        "the interpreter matrix must not own the compiler cache: its legs "
-        "either typecheck only or compile a fraction of what the coverage job "
-        "does, so the generation they publish would go stale"
+    assert len(matrix_writers) == 1, (
+        "each interpreter leg owns the compiler-cache family for its own "
+        "interpreter, so the matrix declares exactly one save step"
+    )
+    condition = " ".join(str(matrix_writers[0].get("if", "")).split())
+    assert "matrix.python-suite" in condition, (
+        "the leg that only typechecks compiles nothing, so it must not "
+        f"republish a generation; got if: {condition!r}"
+    )
+
+
+def test_the_compiler_cache_key_names_the_interpreter_and_the_build_shape() -> None:
+    """Keep objects that cannot serve each other in separate archives.
+
+    Measured on 2026-09-04, before the key carried either component: one
+    instrumented Python 3.13 archive served every Ubicloud job, the 3.13 reader
+    took 14 of its 17 cacheable compiles, and the 3.12, 3.14 and 3.15a readers
+    took none at all. `pyo3` is declared with `extension-module` and without
+    `abi3`, so an extension compiled against one CPython is useless to another,
+    and an optimized or instrumented object is useless to an unoptimized build.
+    """
+    source = CACHE_KEYS_ACTION_FILE.read_text(encoding="utf-8")
+    prefix = next(line for line in source.splitlines() if "sccache_prefix=" in line)
+    for component in ("${PYTHON_VERSION}", "${COMPILER_SHAPE}"):
+        assert component in prefix, (
+            f"the compiler-cache prefix must carry {component}; got {prefix.strip()!r}"
+        )
+
+
+def test_pyo3_is_still_declared_without_abi3() -> None:
+    """Anchor the reason the interpreter is in the key to the manifest.
+
+    Adopting `abi3` would make one archive serve every interpreter and would
+    make the per-interpreter families pure overhead. This test is the reminder
+    to revisit them, not an objection to the feature.
+    """
+    manifest = (ROOT / "rust" / "cuprum-rust" / "Cargo.toml").read_text(
+        encoding="utf-8"
+    )
+    pyo3 = next(line for line in manifest.splitlines() if line.startswith("pyo3"))
+    assert "abi3" not in pyo3, (
+        "pyo3 now builds against a stable ABI, so one compiler-cache family "
+        "could serve every interpreter: collapse the per-interpreter families "
+        "in tests/helpers/ci_runners.py rather than leaving them split"
     )

--- a/tests/test_ci_compiler_cache.py
+++ b/tests/test_ci_compiler_cache.py
@@ -279,10 +279,17 @@ def test_the_compiler_cache_is_written_by_a_job_that_compiles() -> None:
         "each interpreter leg owns the compiler-cache family for its own "
         "interpreter, so the matrix declares exactly one save step"
     )
+    # Compared whole, not by containment: `matrix.python-suite || true`
+    # contains the flag and would let the typecheck-only leg publish the
+    # `py3.13-debug` family that `extension-tests` owns.
     condition = " ".join(str(matrix_writers[0].get("if", "")).split())
-    assert "matrix.python-suite" in condition, (
+    expected = (
+        "github.event_name == 'push' && github.ref == 'refs/heads/main' && "
+        "matrix.python-suite"
+    )
+    assert condition == expected, (
         "the leg that only typechecks compiles nothing, so it must not "
-        f"republish a generation; got if: {condition!r}"
+        f"republish a generation; must carry if: {expected!r}, got {condition!r}"
     )
 
 

--- a/tests/test_ci_resource_sampling.py
+++ b/tests/test_ci_resource_sampling.py
@@ -42,21 +42,27 @@ def test_every_ubicloud_job_measures_its_resource_use() -> None:
     """
     for workflow_name, job_name in expand(UBICLOUD_JOBS):
         job_steps = steps(workflow_name, job_name)
-        sampler = {
-            str(step_inputs(step, f"{workflow_name}:{job_name} sampler").get("mode")): (
-                index,
-                step,
-            )
+        # Collected as a list first. Two `start` steps would each leave a
+        # background sampler running while the single `report` kills only the
+        # most recent, and a mapping built directly would hide the duplicate.
+        message = f"{workflow_name}:{job_name} sampler"
+        sampler_steps = [
+            (str(step_inputs(step, message).get("mode")), index, step)
             for index, step in enumerate(job_steps)
             if step.get("uses") == RESOURCE_SAMPLER
-        }
-        if not sampler:
+        ]
+        sampler = {mode: (index, step) for mode, index, step in sampler_steps}
+        if not sampler_steps:
             # Jobs that neither compile nor test have no high-water mark worth
             # sampling; the manifest below names the ones that do.
             assert (workflow_name, job_name) not in SAMPLED_JOBS, (
                 f"{workflow_name}:{job_name} must sample its resource use"
             )
             continue
+        assert len(sampler_steps) == len(sampler), (
+            f"{workflow_name}:{job_name} declares a sampler mode twice; each "
+            "extra start leaves a sampler the single report cannot kill"
+        )
         assert set(sampler) == {"start", "report"}, (
             f"{workflow_name}:{job_name} must both start and report the sampler"
         )

--- a/tests/test_ci_resource_sampling.py
+++ b/tests/test_ci_resource_sampling.py
@@ -100,6 +100,13 @@ def test_coverage_jobs_discard_the_instrumented_tree_before_saving() -> None:
             f"{workflow_name}:{job_name} must print `df -h` either side of the "
             "deletion, so the reclaim is a measurement rather than a claim"
         )
+        # Run 33857764655 removed nothing while reporting success, because the
+        # tree is built beside `rust/Cargo.toml` and the step named a
+        # repository-root path. Searching for it cannot go stale that way.
+        assert "find ." in script, (
+            f"{workflow_name}:{job_name} must locate the instrumented tree "
+            "rather than name a path that moves with the Cargo manifest"
+        )
         saves = [
             index
             for index, step in enumerate(job_steps)

--- a/tests/test_ci_resource_sampling.py
+++ b/tests/test_ci_resource_sampling.py
@@ -62,6 +62,14 @@ def test_every_ubicloud_job_measures_its_resource_use() -> None:
                 f"{workflow_name}:{job_name} must sample its resource use"
             )
             continue
+        # The converse matters as much: `benchmark-ratchet` compares timings of
+        # half-second commands, so a sampler waking every 15 s there would
+        # perturb the number the job exists to produce.
+        assert (workflow_name, job_name) in SAMPLED_JOBS, (
+            f"{workflow_name}:{job_name} samples its resource use but is not in "
+            "the manifest; a job whose output is a measurement must not carry a "
+            "sampler that changes it"
+        )
         assert len(sampler_steps) == len(sampler), (
             f"{workflow_name}:{job_name} declares a sampler mode twice; each "
             "extra start leaves a sampler the single report cannot kill"

--- a/tests/test_ci_resource_sampling.py
+++ b/tests/test_ci_resource_sampling.py
@@ -15,13 +15,16 @@ from tests.helpers.ci_runners import UBICLOUD_JOBS, expand, step_inputs, steps
 
 RESOURCE_SAMPLER = "./.github/actions/resource-sampler"
 #: Paid Linux jobs whose peak memory and disk are worth recording: every one
-#: that compiles or runs a suite. The two wheel jobs in `build-wheels.yml`
-#: unpack an artefact someone else built and have no high-water mark to find.
+#: that compiles or runs a suite, less the one whose numbers a sampler would
+#: change. The two wheel jobs in `build-wheels.yml` unpack an artefact someone
+#: else built and have no high-water mark to find. `benchmark-ratchet` times
+#: half-second commands and compares their ratio, so a background loop waking
+#: every 15 s is interference rather than observation; its disk figure was
+#: taken once, in run 33857764655.
 SAMPLED_JOBS: typ.Final = (
     ("ci.yml", "typecheck-test"),
     ("ci.yml", "extension-tests"),
     ("ci.yml", "coverage"),
-    ("ci.yml", "benchmark-ratchet"),
     ("coverage-main.yml", "coverage-upload"),
 )
 #: Jobs that build an instrumented tree, which is scratch the moment its report

--- a/tests/test_ci_resource_sampling.py
+++ b/tests/test_ci_resource_sampling.py
@@ -1,0 +1,111 @@
+"""Contract tests for the resource evidence Cuprum's paid Linux jobs leave.
+
+`ubicloud-standard-2` carries roughly 31 GB free at job start, and the failure
+mode when that runs out is a silent death rather than a diagnostic. Nothing in
+a green run says whether the shape was nearly the constraint, so every job that
+compiles or runs a suite records its peaks, and the coverage jobs discard the
+instrumented tree before any archive can carry it.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+
+from tests.helpers.ci_runners import UBICLOUD_JOBS, expand, step_inputs, steps
+
+RESOURCE_SAMPLER = "./.github/actions/resource-sampler"
+#: Paid Linux jobs whose peak memory and disk are worth recording: every one
+#: that compiles or runs a suite. The two wheel jobs in `build-wheels.yml`
+#: unpack an artefact someone else built and have no high-water mark to find.
+SAMPLED_JOBS: typ.Final = (
+    ("ci.yml", "typecheck-test"),
+    ("ci.yml", "extension-tests"),
+    ("ci.yml", "coverage"),
+    ("ci.yml", "benchmark-ratchet"),
+    ("coverage-main.yml", "coverage-upload"),
+)
+#: Jobs that build an instrumented tree, which is scratch the moment its report
+#: is written.
+COVERAGE_JOBS: typ.Final = (
+    ("ci.yml", "coverage"),
+    ("coverage-main.yml", "coverage-upload"),
+)
+
+
+def test_every_ubicloud_job_measures_its_resource_use() -> None:
+    """Make a runner-shape decision citable from the log rather than inferred.
+
+    `ubicloud-standard-2` carries roughly 31 GB free at job start, and the
+    failure mode when that runs out is a silent death, not a diagnostic. A job
+    with no sampler leaves nobody able to say afterwards whether the shape was
+    the constraint, so the peaks are recorded on every paid Linux job.
+    """
+    for workflow_name, job_name in expand(UBICLOUD_JOBS):
+        job_steps = steps(workflow_name, job_name)
+        sampler = {
+            str(step_inputs(step, f"{workflow_name}:{job_name} sampler").get("mode")): (
+                index,
+                step,
+            )
+            for index, step in enumerate(job_steps)
+            if step.get("uses") == RESOURCE_SAMPLER
+        }
+        if not sampler:
+            # Jobs that neither compile nor test have no high-water mark worth
+            # sampling; the manifest below names the ones that do.
+            assert (workflow_name, job_name) not in SAMPLED_JOBS, (
+                f"{workflow_name}:{job_name} must sample its resource use"
+            )
+            continue
+        assert set(sampler) == {"start", "report"}, (
+            f"{workflow_name}:{job_name} must both start and report the sampler"
+        )
+        start_index, _ = sampler["start"]
+        report_index, report = sampler["report"]
+        assert start_index < report_index, (
+            f"{workflow_name}:{job_name} must start the sampler before reporting"
+        )
+        assert report_index == len(job_steps) - 1, (
+            f"{workflow_name}:{job_name} must report last, so the peak covers "
+            "every build and every cache save"
+        )
+        assert report.get("if") == "always()", (
+            f"{workflow_name}:{job_name} must report the peak even when the "
+            "job failed, because disk exhaustion is what the sampler is for"
+        )
+
+
+def test_coverage_jobs_discard_the_instrumented_tree_before_saving() -> None:
+    """Keep scratch out of the archives and out of the measured peak."""
+    for workflow_name, job_name in COVERAGE_JOBS:
+        job_steps = steps(workflow_name, job_name)
+        discard = next(
+            (
+                index
+                for index, step in enumerate(job_steps)
+                if step.get("name") == "Discard the instrumented build tree"
+            ),
+            None,
+        )
+        assert discard is not None, (
+            f"{workflow_name}:{job_name} must discard `target/llvm-cov-target`: "
+            "it has no consumer once the report is written and it is the second "
+            "tree on the volume"
+        )
+        script = job_steps[discard].get("run")
+        assert isinstance(script, str), (
+            f"{workflow_name}:{job_name} discard step must run a script"
+        )
+        assert script.count("df -h") == 2, (
+            f"{workflow_name}:{job_name} must print `df -h` either side of the "
+            "deletion, so the reclaim is a measurement rather than a claim"
+        )
+        saves = [
+            index
+            for index, step in enumerate(job_steps)
+            if str(step.get("name", "")).startswith("Save the ")
+        ]
+        assert all(discard < index for index in saves), (
+            f"{workflow_name}:{job_name} must discard the tree before every "
+            "save, so no archive carries it"
+        )

--- a/tests/test_coverage_scratch_discard.py
+++ b/tests/test_coverage_scratch_discard.py
@@ -1,0 +1,113 @@
+"""Behavioural tests for the coverage jobs' scratch-discard step.
+
+The ordering contract proves the step runs before every cache save. It does not
+prove the step removes anything, and the first version of it did not: run
+33857764655 printed an identical `72G 64G 8.3G 89%` either side while removing
+nothing, because `cargo llvm-cov` builds beside the manifest it is given and
+this repository's is `rust/Cargo.toml`, not the root. These tests run the
+step's own shell against a tree shaped like the runner's.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+
+import pytest
+
+from tests.helpers.ci_runners import steps
+from tests.helpers.composite_actions import run_step
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+DISCARD_STEP = "Discard the instrumented build tree"
+COVERAGE_JOBS: typ.Final = (
+    ("ci.yml", "coverage"),
+    ("coverage-main.yml", "coverage-upload"),
+)
+#: Where `cargo llvm-cov` actually puts its trees for this repository, given
+#: `cargo-manifest: rust/Cargo.toml`.
+INSTRUMENTED_TREES: typ.Final = ("rust/target/llvm-cov-target", "rust/target/llvm-cov")
+#: A tree the step must leave alone. The ordinary build output is what the next
+#: job's sccache archive was seeded from; only the instrumented tree is scratch.
+PRESERVED_TREE = "rust/target/debug"
+
+
+def _discard_script(workflow_name: str, job_name: str) -> str:
+    """Return the discard step's shell body from one workflow job."""
+    for step in steps(workflow_name, job_name):
+        if step.get("name") == DISCARD_STEP:
+            script = step.get("run")
+            assert isinstance(script, str), (
+                f"{workflow_name}:{job_name} discard step must run a script"
+            )
+            return script
+    message = f"{workflow_name}:{job_name} declares no {DISCARD_STEP!r} step"
+    raise AssertionError(message)
+
+
+def _populate(root: Path, relative: str) -> Path:
+    """Create a directory with one file in it, so `du` reports a size."""
+    tree = root / relative
+    tree.mkdir(parents=True, exist_ok=True)
+    (tree / "object.o").write_bytes(b"\0" * 4096)
+    return tree
+
+
+@pytest.mark.parametrize(("workflow_name", "job_name"), COVERAGE_JOBS)
+def test_the_discard_step_removes_the_instrumented_trees(
+    workflow_name: str, job_name: str, tmp_path: Path
+) -> None:
+    """Reclaim the tree where `cargo llvm-cov` actually writes it."""
+    trees = [_populate(tmp_path, relative) for relative in INSTRUMENTED_TREES]
+    preserved = _populate(tmp_path, PRESERVED_TREE)
+
+    result = run_step(_discard_script(workflow_name, job_name), workdir=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    for tree in trees:
+        assert not tree.exists(), (
+            f"{workflow_name}:{job_name} left {tree.relative_to(tmp_path)} behind; "
+            "the archive would carry it and the sampler would misreport the peak"
+        )
+    assert preserved.exists(), (
+        f"{workflow_name}:{job_name} removed {PRESERVED_TREE}, which is not scratch"
+    )
+
+
+@pytest.mark.parametrize(("workflow_name", "job_name"), COVERAGE_JOBS)
+def test_the_discard_step_reports_what_it_reclaimed(
+    workflow_name: str, job_name: str, tmp_path: Path
+) -> None:
+    """Print the disk either side and name the tree, so the reclaim is evidence."""
+    _populate(tmp_path, INSTRUMENTED_TREES[0])
+
+    result = run_step(_discard_script(workflow_name, job_name), workdir=tmp_path)
+
+    assert result.stdout.count("Filesystem") == 2, (
+        f"{workflow_name}:{job_name} must print `df -h` either side of the "
+        f"deletion; got:\n{result.stdout}"
+    )
+    assert INSTRUMENTED_TREES[0] in result.stdout, (
+        f"{workflow_name}:{job_name} must name the tree it removed, so a run "
+        f"that reclaimed nothing is visible; got:\n{result.stdout}"
+    )
+
+
+@pytest.mark.parametrize(("workflow_name", "job_name"), COVERAGE_JOBS)
+def test_the_discard_step_says_when_there_is_nothing_to_reclaim(
+    workflow_name: str, job_name: str, tmp_path: Path
+) -> None:
+    """Keep a job that had no tree distinguishable from one that missed it.
+
+    This is the whole failure the step already had once: silent success reads
+    identically to a correct no-op.
+    """
+    _populate(tmp_path, PRESERVED_TREE)
+
+    result = run_step(_discard_script(workflow_name, job_name), workdir=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "No instrumented build tree found to discard" in result.stdout, (
+        f"{workflow_name}:{job_name} must say so explicitly; got:\n{result.stdout}"
+    )

--- a/tests/test_resource_sampler_action.py
+++ b/tests/test_resource_sampler_action.py
@@ -1,0 +1,194 @@
+"""Behavioural tests for the resource-sampler composite action.
+
+The workflow contracts prove the action is wired into every paid Linux job.
+They prove nothing about what it does. This module runs the action's own shell
+bodies, so a sampler that exported no process identifier, sampled nothing, or
+computed its peaks wrongly would fail here rather than quietly reporting
+`unknown` for the life of the estate.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import subprocess  # ruff: ignore[suspicious-subprocess-import] - fixed argv
+import time
+import typing as typ
+
+import pytest
+
+from tests.helpers.composite_actions import action_document, run_step, step_script
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+    from pathlib import Path
+
+ACTION = ".github/actions/resource-sampler"
+START_STEP = "Start resource sampler"
+REPORT_STEP = "Report peak resource use"
+#: `free` and `df` must exist for the sampler to sample anything at all.
+REQUIRED_TOOLS = ("free", "df", "du")
+
+
+def _process_is_alive(pid: int) -> bool:
+    """Report whether a process identifier still names a live process."""
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError):
+        return False
+    return True
+
+
+@pytest.fixture(name="sampler_pid")
+def _sampler_pid() -> cabc.Iterator[list[int]]:
+    """Collect sampler process identifiers and reap them after the test.
+
+    Yields
+    ------
+    list[int]
+        A list the test appends each started sampler's identifier to.
+
+    Notes
+    -----
+    Signalled individually rather than by process group: the sampler is a child
+    of the shell this test ran and shares the test runner's group, so a group
+    signal would take pytest with it.
+    """
+    pids: list[int] = []
+    yield pids
+    for pid in pids:
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.kill(pid, signal.SIGKILL)
+
+
+def test_the_action_declares_the_inputs_the_workflows_pass() -> None:
+    """Keep the callers and the action agreed on its interface."""
+    document = action_document(ACTION)
+    inputs = typ.cast("dict[str, object]", document.get("inputs", {}))
+    assert set(inputs) == {"mode", "vcpus"}, (
+        f"the sampler must declare exactly `mode` and `vcpus`; got {sorted(inputs)}"
+    )
+    mode = typ.cast("dict[str, object]", inputs["mode"])
+    assert mode.get("required") is True, (
+        "`mode` selects the behaviour, so it is required"
+    )
+    vcpus = typ.cast("dict[str, object]", inputs["vcpus"])
+    assert vcpus.get("required") is False, "`vcpus` is a label, not behaviour"
+    assert vcpus.get("default"), (
+        "`vcpus` must default to something printable, so a caller that forgets "
+        "it still produces a readable line rather than an empty one"
+    )
+    runs = typ.cast("dict[str, object]", document["runs"])
+    assert runs.get("using") == "composite", (
+        "the sampler brackets steps inside a job, so it cannot be a "
+        "container or JavaScript action"
+    )
+
+
+@pytest.mark.parametrize("tool", REQUIRED_TOOLS)
+def test_the_sampling_tools_exist(tool: str) -> None:
+    """Fail loudly here rather than silently sampling nothing on the runner."""
+    # ruff: ignore[subprocess-without-shell-equals-true] - fixed argv, no input
+    assert (
+        subprocess.run(
+            ["/usr/bin/env", "which", tool],
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    ), f"the sampler shells out to {tool!r}"
+
+
+def test_start_exports_a_live_sampler_process(
+    tmp_path: Path, sampler_pid: list[int]
+) -> None:
+    """Start a background sampler and hand its identifier to the later step."""
+    result = run_step(step_script(ACTION, START_STEP), workdir=tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "RESOURCE_SAMPLER_PID" in result.exported, (
+        "the report step kills the process this name carries, so a start that "
+        f"exports nothing leaves a sampler running for the job; got {result.exported}"
+    )
+    pid = int(result.exported["RESOURCE_SAMPLER_PID"])
+    sampler_pid.append(pid)
+    assert _process_is_alive(pid), "the exported identifier must name a live process"
+
+
+def test_the_sampler_writes_three_numbers_per_interval(
+    tmp_path: Path, sampler_pid: list[int]
+) -> None:
+    """Record used memory, used disk, and free disk on every tick.
+
+    The report step reads these by column position, so a row with a different
+    shape would silently produce wrong peaks rather than an error.
+    """
+    result = run_step(step_script(ACTION, START_STEP), workdir=tmp_path)
+    sampler_pid.append(int(result.exported["RESOURCE_SAMPLER_PID"]))
+    log = tmp_path / "resource.log"
+    deadline = time.monotonic() + 40
+    while time.monotonic() < deadline and not log.read_text(encoding="utf-8").strip():
+        time.sleep(1)
+    rows = [
+        line.split() for line in log.read_text(encoding="utf-8").splitlines() if line
+    ]
+    assert rows, "the sampler produced no rows within 40 s"
+    for row in rows:
+        assert len(row) == 3, f"expected memory, used disk, free disk; got {row}"
+        assert all(field.isdigit() for field in row), f"non-numeric sample: {row}"
+
+
+def test_report_publishes_the_peaks_and_stops_the_sampler(tmp_path: Path) -> None:
+    """Take the maximum of both used columns and the minimum of free disk."""
+    (tmp_path / "resource.log").write_text(
+        "100 5000 900\n700 5200 400\n300 4800 1200\n", encoding="utf-8"
+    )
+    with subprocess.Popen(["/bin/sleep", "120"]) as victim:
+        try:
+            result = run_step(
+                step_script(ACTION, REPORT_STEP),
+                workdir=tmp_path,
+                environment={
+                    "RESOURCE_SAMPLER_PID": str(victim.pid),
+                    "JOB_VCPUS": "2",
+                },
+            )
+            assert result.returncode == 0, result.stderr
+            for expected in (
+                "memory: 700 MiB on 2 vCPUs",
+                "disk used: 5200 MiB",
+                "least free: 400 MiB",
+            ):
+                assert expected in result.stdout, (
+                    f"the log must carry {expected!r}: the jobs API exposes the "
+                    f"log and not the summary. Got:\n{result.stdout}"
+                )
+                assert expected in result.summary, (
+                    f"the summary must carry {expected!r}"
+                )
+            # The step must have killed it; waiting proves that rather than
+            # assuming it.
+            victim.wait(timeout=10)
+        finally:
+            if victim.poll() is None:  # pragma: no cover - assertion failure only
+                victim.kill()
+
+
+def test_report_survives_a_job_that_never_started_the_sampler(tmp_path: Path) -> None:
+    """Report `unknown` rather than failing a job that already failed.
+
+    The step runs under `if: always()`, so it must tolerate a job that died
+    before the sampler wrote anything. Masking the real failure with a shell
+    error would be worse than reporting nothing.
+    """
+    result = run_step(
+        step_script(ACTION, REPORT_STEP),
+        workdir=tmp_path,
+        environment={"RESOURCE_SAMPLER_PID": "", "JOB_VCPUS": "2"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "memory: unknown MiB" in result.stdout, result.stdout
+    assert "disk used: unknown MiB, least free: unknown MiB" in result.stdout, (
+        f"a job with no samples must still report readable placeholders; "
+        f"got:\n{result.stdout}"
+    )


### PR DESCRIPTION
The Ubicloud lane's compiler cache had one family and one writer, and five of
its six readers got nothing from it. This splits the family by what actually
determines whether one job's objects can serve another's, and adds the resource
evidence the paid runners were not producing.

## The measurement

Two dispatches over an unchanged tree,
[33853599399](https://github.com/leynos/cuprum/actions/runs/33853599399) and
[33854076859](https://github.com/leynos/cuprum/actions/runs/33854076859).
Every Ubicloud job restored the same 287 MB archive, which `coverage-upload`
had written on Python 3.13.

| Job | Cacheable compiles | Warm hits |
| --- | --- | --- |
| `coverage-upload` (the writer) | 311 | 311 |
| `lint-test` (GitHub-hosted, own writer) | 261 | 261 |
| `extension-tests` | 17 | 14 |
| `typecheck-test` 3.12 / 3.14 / 3.15a | 17 each | 0 |
| `benchmark-ratchet` | 19 | 0 |

Read and write errors were zero throughout. The archive restored perfectly and
simply held nothing those five jobs could use.

## Why

The discriminator is the interpreter, not coverage instrumentation.
`extension-tests` reads the same instrumented archive the matrix legs read and
hits; it differs from them in exactly one way, in that it uses the interpreter
the writer used. `rust/cuprum-rust/Cargo.toml` declares `pyo3` with
`extension-module` and without `abi3`, so an extension compiled against one
CPython serves no other. The compiler key named neither the interpreter nor the
build shape. `benchmark-ratchet` misses for the second reason: it builds with
`--release`.

## What changed

`cache-keys` takes a `compiler-shape` input, and the compiler prefix carries
both the interpreter and the shape. Each resulting family has exactly one
writer:

| Family | Writer |
| --- | --- |
| 3.13 unoptimized | `ci.yml` `extension-tests` |
| 3.12 / 3.14 / 3.15a unoptimized | `ci.yml` `typecheck-test`, that leg |
| 3.13 release | `ci.yml` `benchmark-ratchet` |
| 3.13 instrumented | `coverage-main.yml` `coverage-upload` |
| Cranelift lint, GitHub-hosted | `ci.yml` `lint-test` |

The typecheck-only leg compiles nothing, so its save carries the same
`matrix.python-suite` guard as its other compiler-cache steps, and
`extension-tests` owns 3.13 instead.

Comments in both workflows claimed `typecheck-test` already owned the compiler
key, and that `extension-tests` owned it "when that backend is selected".
Neither was true: no job in `ci.yml` saved it at all. Both are corrected.

`test_each_cache_family_has_exactly_one_writer` holds the invariant that
matters. The `env` name a save step writes is not the archive it publishes, so
`tests/helpers/ci_cache_families.py` resolves the rendered family instead,
expanding matrix legs and honouring a save condition that names a matrix value.
A contract that counted `env` names would have to permit all five legitimate
collisions, and would then also permit a real one.

Every save still requires `github.event_name == 'push'` as well as the ref, so
a dispatch measuring warm caches cannot publish into a family it is only
reading.

## Resource sampling

`ubicloud-standard-2` starts with roughly 31 GB free and dies silently when
that runs out. Every paid Linux job that compiles or runs a suite now brackets
its work with `.github/actions/resource-sampler`, recording peak memory, peak
disk and least-free disk to the log as well as the step summary; the jobs API
exposes the log and not the summary. The coverage jobs discard
`target/llvm-cov-target` before any save, printing `df -h` either side, so no
archive carries scratch and the measured high-water mark is the real one.

## Cost

The single 287 MB Ubicloud archive becomes about six families, so roughly 1 GB
per generation. Cuprum currently sits at about 664 MB of a 30 GB weekly quota,
so there is ample headroom. If `pyo3` ever adopts `abi3` the per-interpreter
split becomes pure overhead, and `test_pyo3_is_still_declared_without_abi3` is
the reminder to collapse it.

## Not changed here

The shared `generate-coverage` ratchet saves its baseline on
`workflow_dispatch` as well as on push, against the rule that dispatches
restore and never save. Reported upstream as
[shared-actions#444](https://github.com/leynos/shared-actions/issues/444)
rather than worked around here.

## Validation

`make check-fmt`, `make lint`, `make typecheck`, `make markdownlint`,
`make nixie` and `make test-rust` all pass. `make test-python` passes except
for two Hypothesis deadline flakes in `test_folded_summary.py`, unrelated to
this change, which pass in isolation on the same tree.

https://claude.ai/code/session_01QrjNTnTwM7FmWXe5KFPMPY

## Summary by Sourcery

Split compiler caches by interpreter and build shape, enforce one writer per family, and add resource evidence to paid Linux CI jobs.

New Features:
- Scope compiler cache families by Python interpreter and build shape, with dedicated writers for each compatible family.
- Add resource sampling for paid Linux CI jobs and reclaim instrumented coverage build trees before caching.

Bug Fixes:
- Prevent incompatible compiler artifacts from being restored across interpreters or debug, release, lint, and coverage builds.
- Ensure typecheck-only matrix legs do not publish compiler caches they do not populate.

Enhancements:
- Add cache-family ownership resolution and contracts that verify exactly one writer per rendered cache family.
- Document CI cache ownership, cache scoping, rolling generations, and resource-measurement policy.

CI:
- Update CI workflows to use interpreter- and shape-specific compiler keys, assign single writers, and report resource high-water marks.

Documentation:
- Document cache families, ownership, compatibility boundaries, and paid-runner resource sampling.

Tests:
- Add contract and behavioral tests for cache-family resolution, ownership, resource sampling, and coverage scratch cleanup.

## Outcome, measured after merge

Merged as `c8808106`. The merge push wrote all six families from exactly the
intended writers, and one warm dispatch read them back.

Compiler-cache hits, cold writer
[33898839149](https://github.com/leynos/cuprum/actions/runs/33898839149) versus
warm dispatch
[33900410222](https://github.com/leynos/cuprum/actions/runs/33900410222), over
an unchanged tree:

| Job | Cacheable compiles | Cold hits | Warm hits |
| --- | --- | --- | --- |
| `extension-tests` | 17 | 0 | 17 |
| `typecheck-test` 3.12 | 17 | 0 | 17 |
| `typecheck-test` 3.14 | 17 | 0 | 17 |
| `typecheck-test` 3.15a | 17 | 0 | 17 |
| `benchmark-ratchet` | 19 | 0 | 19 |
| `lint-test` | 261 | 0 | 261 |

_Table 3: Every job now hits every cacheable compile, against five of six at
zero before the split._

Read and write errors were zero throughout, and the dispatch saved nothing, as
the event guards require.

Wall time of each job's compiling step, same two runs:

| Job | Step | Cold | Warm | Saved |
| --- | --- | --- | --- | --- |
| `typecheck-test` 3.12 | Run tests | 112 s | 101 s | 11 s |
| `typecheck-test` 3.14 | Run tests | 99 s | 90 s | 9 s |
| `typecheck-test` 3.15a | Run tests | 98 s | 88 s | 10 s |
| `extension-tests` | Build the native extension | 13 s | 7 s | 6 s |
| `benchmark-ratchet` | benchmarks and ratchet | 59 s | 54 s | 5 s |

_Table 4: Per-leg saving from the warm compiler cache. The `typecheck-test`
step also runs the Python suite, so its total is dominated by pytest rather
than by compilation._

The archives are far smaller than estimated when this was proposed. The five
Ubicloud families the merge push writes total about 101 MB, at 19.8 to 20.5 MB
each, and the instrumented coverage family that `coverage-main.yml` writes is
286 MB. The pre-split single archive was 287 MB, so splitting added roughly
100 MB per generation rather than the 700 MB feared, and it converted an
archive that served one job into six that serve six.
