### PR TITLE
Copy CHANGELOG.md into mutmut's mutant tree (#338)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubicloud-standard-2
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           persist-credentials: false
       - uses: ./.github/actions/pure-python-wheel
@@ -61,7 +61,7 @@ jobs:
             arch: x86_64
             target: x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           persist-credentials: false
       - name: Compute Python tag for manylinux interpreter path
@@ -82,7 +82,7 @@ jobs:
       # output is simply not cached. The registry and pip archives remain.
       - name: Cache Linux wheel build dependencies (x86_64)
         if: startsWith(matrix.os, 'ubuntu') && matrix.arch == 'x86_64'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cache/pip
@@ -112,7 +112,7 @@ jobs:
           platforms: arm64
       - name: Cache Linux wheel build dependencies (aarch64)
         if: startsWith(matrix.os, 'ubuntu') && matrix.arch == 'aarch64'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cache/pip
@@ -148,7 +148,7 @@ jobs:
           maturin-version: ${{ env.MATURIN_VERSION }}
       - name: Upload wheel artifact (Linux)
         if: startsWith(matrix.os, 'ubuntu')
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: wheels-native-${{ matrix.os }}-${{ matrix.arch }}
           path: wheelhouse/*.whl
@@ -162,15 +162,15 @@ jobs:
       - build-pure-wheel
       - build-native-wheels
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: ${{ inputs['python-version'] }}
       - name: Download wheel artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: dist
       - name: Install pure Python wheel, then native wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       YAMLLINT_VERSION: '1.38.0'
     steps:
       - name: Check out repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
 
       - name: Compute cache keys
         uses: ./.github/actions/cache-keys
@@ -83,7 +83,7 @@ jobs:
       # share a family name, and each lane has its own single writer.
       - name: Restore the Cargo registry
         id: cargo-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -93,7 +93,7 @@ jobs:
 
       - name: Restore the compiler cache
         id: sccache-dir
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
@@ -117,12 +117,12 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
 
       - name: Cache yamllint
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -181,7 +181,7 @@ jobs:
           bash "${ACTIONLINT_INSTALLER_PATH}" "${ACTIONLINT_VERSION}"
 
       - name: Cache npm CLI dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.npm
           key: cuprum-npm-cli-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
@@ -301,7 +301,7 @@ jobs:
         if: >-
           github.event_name == 'push' && github.ref == 'refs/heads/main' &&
           steps.cargo-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -323,7 +323,7 @@ jobs:
         # not trusted to own.
         if: >-
           github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
@@ -362,7 +362,7 @@ jobs:
             python-suite: true
     steps:
       - name: Check out repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           persist-credentials: false
 
@@ -385,7 +385,7 @@ jobs:
 
       - name: Restore the Cargo registry
         id: cargo-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -395,7 +395,7 @@ jobs:
 
       - name: Restore the installed tools
         id: tool-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/bin
@@ -414,7 +414,7 @@ jobs:
       - name: Restore the compiler cache
         id: sccache-dir
         if: matrix.python-suite
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
@@ -456,13 +456,13 @@ jobs:
         run: sccache --zero-stats
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: ${{ matrix.allow-prereleases }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
         with:
           enable-cache: false
 
@@ -517,7 +517,7 @@ jobs:
         if: >-
           github.event_name == 'push' && github.ref == 'refs/heads/main' &&
           steps.tool-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/bin
@@ -545,7 +545,7 @@ jobs:
         if: >-
           github.event_name == 'push' && github.ref == 'refs/heads/main' &&
           matrix.python-suite
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
@@ -565,7 +565,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Check out repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           # This job compiles and runs repository code, so the checkout token
           # must not stay in .git/config where that code could reach it.
@@ -590,7 +590,7 @@ jobs:
 
       - name: Restore the Cargo registry
         id: cargo-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -600,7 +600,7 @@ jobs:
 
       - name: Restore the installed tools
         id: tool-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/bin
@@ -614,7 +614,7 @@ jobs:
 
       - name: Restore the compiler cache
         id: sccache-dir
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
@@ -654,12 +654,12 @@ jobs:
         run: sccache --zero-stats
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
         with:
           enable-cache: false
 
@@ -725,7 +725,7 @@ jobs:
         if: >-
           github.event_name == 'push' && github.ref == 'refs/heads/main' &&
           steps.cargo-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -746,7 +746,7 @@ jobs:
         # not trusted to own.
         if: >-
           github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
@@ -765,19 +765,19 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Check out repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           # This job compiles and runs repository code, so the checkout token
           # must not stay in .git/config where that code could reach it.
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
         with:
           enable-cache: true
 
@@ -824,7 +824,7 @@ jobs:
       CARGO_NET_RETRY: '5'
     steps:
       - name: Check out repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           # Full history so a future CodeScene changed-line gate
           # (cs-coverage check) can reach the pull request merge base.
@@ -852,7 +852,7 @@ jobs:
       # that the `main` writers published and publishes nothing of its own.
       - name: Restore the Cargo registry
         id: cargo-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -862,7 +862,7 @@ jobs:
 
       - name: Restore the installed tools
         id: tool-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/bin
@@ -876,7 +876,7 @@ jobs:
 
       - name: Restore the compiler cache
         id: sccache-dir
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
@@ -916,12 +916,12 @@ jobs:
         run: sccache --zero-stats
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
         with:
           enable-cache: false
 
@@ -1056,13 +1056,13 @@ jobs:
       bench: ${{ steps.filter.outputs.bench }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           persist-credentials: false
 
       - name: Detect performance-relevant changes
         id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
         with:
           filters: |
             bench:
@@ -1146,7 +1146,7 @@ jobs:
       needs.changes.outputs.bench == 'true')
     steps:
       - name: Check out repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -1169,7 +1169,7 @@ jobs:
 
       - name: Restore the Cargo registry
         id: cargo-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -1179,7 +1179,7 @@ jobs:
 
       - name: Restore the installed tools
         id: tool-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/bin
@@ -1196,7 +1196,7 @@ jobs:
       # `rust/target` stays disposable here as it is everywhere else.
       - name: Restore the compiler cache
         id: sccache-dir
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
@@ -1233,12 +1233,12 @@ jobs:
         run: sccache --zero-stats
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
         with:
           enable-cache: false
 
@@ -1498,7 +1498,7 @@ jobs:
 
       - name: Upload benchmark ratchet artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: benchmark-ratchet
           path: |
@@ -1573,7 +1573,7 @@ jobs:
           ${{ !cancelled() && github.event_name == 'push' &&
           github.ref == 'refs/heads/main' &&
           steps.candidate-artefacts.outputs.available == 'true' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: benchmark-ratchet-main-baseline
           if-no-files-found: error
@@ -1596,7 +1596,7 @@ jobs:
         # not trusted to own.
         if: >-
           github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Check out repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           # Coverage generation runs project code; the scoped token must not
           # stay in .git/config where that code could read it.
@@ -75,7 +75,7 @@ jobs:
       # writers racing in the same event; ci.yml owns both.
       - name: Restore the Cargo registry
         id: cargo-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -85,7 +85,7 @@ jobs:
 
       - name: Restore the installed tools
         id: tool-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/bin
@@ -105,7 +105,7 @@ jobs:
       # the end of this job is that writer.
       - name: Restore the compiler cache
         id: sccache-dir
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}
@@ -142,12 +142,12 @@ jobs:
         run: sccache --zero-stats
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
         with:
           enable-cache: false
 
@@ -295,7 +295,7 @@ jobs:
 
       - name: Save the compiler cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/sccache
           key: ${{ env.SCCACHE_CACHE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,18 +29,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.13'
       - name: Install uv
-        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
         with:
           enable-cache: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: dist
       - name: Collect wheel artifacts

--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,8 @@ rust-lint: ## Run Rust documentation, Clippy, Whitaker, and spelling checks
 	+$(MAKE) spelling
 
 github-actions-lint: $(YAMLLINT) $(ACTIONLINT) ## Validate GitHub Actions workflows
-	$(YAMLLINT) --config-file .yamllint.yml .github/workflows
-	$(ACTIONLINT)
+	$(YAMLLINT) --strict --config-file .yamllint.yml .github/workflows
+	$(ACTIONLINT) -config-file .github/actionlint.yaml
 
 lint-windows: ## Lint the Rust extension's Windows cfg branches (cross-target)
 	@if ! rustup target list --installed | grep -qx '$(WINDOWS_TARGET)'; then \

--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,7 @@ import os
 import typing as typ
 
 import pytest
+from hypothesis import settings
 
 from cuprum import _rust_backend
 from cuprum._backend import _check_rust_available, get_stream_backend
@@ -26,6 +27,11 @@ from tests.helpers.extension_requirement import (
     REQUIRE_EXTENSION_ENV,
     missing_extension_message,
 )
+
+# Property tests assert behaviour, while pytest-timeout retains the suite-wide
+# bound for tests that hang. Hypothesis's per-example runtime is host-sensitive.
+settings.register_profile("cuprum-test-suite", deadline=None)
+settings.load_profile("cuprum-test-suite")
 
 if typ.TYPE_CHECKING:
     from types import ModuleType

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -160,6 +160,7 @@
       'cuprum/unittests/test_mdtablefix_ci_installer.py',
       'cuprum/unittests/test_metrics_adapter.py',
       'cuprum/unittests/test_metrics_adapter_stateful.py',
+      'cuprum/unittests/test_mutmut_config_contract.py',
       'cuprum/unittests/test_native_pump_cleanup_stateful.py',
       'cuprum/unittests/test_observe.py',
       'cuprum/unittests/test_observe_async_hook_failure.py',

--- a/cuprum/unittests/test_mutmut_config_contract.py
+++ b/cuprum/unittests/test_mutmut_config_contract.py
@@ -1,0 +1,46 @@
+"""Contract tests pinning the mutmut harness configuration in pyproject.toml.
+
+mutmut copies only a fixed set of assets into its ``mutants/`` working tree;
+anything the suite reads from the repository root must be listed in
+``[tool.mutmut].also_copy`` or the mutation baseline fails with a missing-file
+error that no source-code mutant can explain. These tests read the declared
+configuration back so a dropped entry fails here, on the pull request that
+removed it, instead of in the mutation workflow.
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+from tests.helpers.docs import repo_root
+
+#: Loose root-level files that mutmut must copy into its mutants/ tree. Each
+#: entry is read from the repository root by the test named in the comment;
+#: dropping one breaks the mutation baseline rather than the local suite.
+_LOOSE_FILES_IN_ALSO_COPY: tuple[tuple[str, str], ...] = (
+    ("CHANGELOG.md", "test_changelog_records_cleanup_telemetry_contract"),
+    ("Makefile", "test_toolchain_pins"),
+)
+
+
+def _also_copy_entries() -> list[str]:
+    """Return the ``also_copy`` list declared under ``[tool.mutmut]``."""
+    pyproject = tomllib.loads(
+        (repo_root() / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    mutmut = pyproject["tool"]["mutmut"]
+    assert isinstance(mutmut, dict), "pyproject.toml must declare [tool.mutmut]"
+    entries = mutmut.get("also_copy")
+    assert isinstance(entries, list), "[tool.mutmut] must declare an also_copy list"
+    return entries
+
+
+def test_also_copy_copies_loose_files_read_from_the_repository_root() -> None:
+    """Every loose root file a test reads must be listed in ``also_copy``."""
+    also_copy = _also_copy_entries()
+    for filename, reader in _LOOSE_FILES_IN_ALSO_COPY:
+        assert filename in also_copy, (
+            f"{reader} reads the loose root-level {filename}, so [tool.mutmut]"
+            f".also_copy must include {filename!r} or the mutation baseline "
+            "fails with a missing-file error in mutmut's mutant tree"
+        )

--- a/cuprum/unittests/test_mutmut_config_contract.py
+++ b/cuprum/unittests/test_mutmut_config_contract.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import tomllib
 
+import pytest
+
 from tests.helpers.docs import repo_root
 
 #: Loose root-level files that mutmut must copy into its mutants/ tree. Each
@@ -28,11 +30,16 @@ def _also_copy_entries() -> list[str]:
     pyproject = tomllib.loads(
         (repo_root() / "pyproject.toml").read_text(encoding="utf-8")
     )
-    mutmut = pyproject["tool"]["mutmut"]
-    assert isinstance(mutmut, dict), "pyproject.toml must declare [tool.mutmut]"
-    entries = mutmut.get("also_copy")
-    assert isinstance(entries, list), "[tool.mutmut] must declare an also_copy list"
-    return entries
+    match pyproject["tool"]["mutmut"]:
+        case dict() as mutmut:
+            entries = mutmut.get("also_copy")
+        case _:
+            pytest.fail("pyproject.toml must declare [tool.mutmut]")
+    match entries:
+        case list() as entries:
+            return entries
+        case _:
+            pytest.fail("[tool.mutmut] must declare an also_copy list")
 
 
 def test_also_copy_copies_loose_files_read_from_the_repository_root() -> None:

--- a/cuprum/unittests/test_tee_profile_worker_concurrency.py
+++ b/cuprum/unittests/test_tee_profile_worker_concurrency.py
@@ -43,6 +43,7 @@ def test_concurrent_workers_do_not_race(
     _assert_backend_pair_completes(backends, fixture)
 
 
+@pytest.mark.timeout(90)
 @settings(
     max_examples=20,
     deadline=None,

--- a/cuprum/unittests/test_workflow_lint.py
+++ b/cuprum/unittests/test_workflow_lint.py
@@ -247,8 +247,8 @@ def test_the_workflow_lint_target_runs_both_linters(tmp_path: pth.Path) -> None:
 
     assert completed.returncode == 0, completed.stderr
     assert invocation_log.read_text(encoding="utf-8").splitlines() == [
-        f"yamllint\t--config-file\t.yamllint.yml\t{_WORKFLOW_DIRECTORY}",
-        "actionlint",
+        f"yamllint\t--strict\t--config-file\t.yamllint.yml\t{_WORKFLOW_DIRECTORY}",
+        "actionlint\t-config-file\t.github/actionlint.yaml",
     ]
 
 
@@ -272,8 +272,8 @@ def test_the_lint_target_runs_the_workflow_linters(tmp_path: pth.Path) -> None:
     assert completed.returncode == 0, completed.stderr
     assert invocation_log.read_text(encoding="utf-8").splitlines() == [
         "uv\trun\twhich\truff",
-        f"yamllint\t--config-file\t.yamllint.yml\t{_WORKFLOW_DIRECTORY}",
-        "actionlint",
+        f"yamllint\t--strict\t--config-file\t.yamllint.yml\t{_WORKFLOW_DIRECTORY}",
+        "actionlint\t-config-file\t.github/actionlint.yaml",
     ]
 
 
@@ -304,8 +304,8 @@ def test_the_workflow_lint_target_rejects_actionlint_failure(
     assert completed.returncode == 2
     assert "Error 31" in completed.stderr
     assert invocation_log.read_text(encoding="utf-8").splitlines() == [
-        f"yamllint\t--config-file\t.yamllint.yml\t{_WORKFLOW_DIRECTORY}",
-        "actionlint",
+        f"yamllint\t--strict\t--config-file\t.yamllint.yml\t{_WORKFLOW_DIRECTORY}",
+        "actionlint\t-config-file\t.github/actionlint.yaml",
     ]
 
 

--- a/docs/debugging/debugging-plan-20260906-rebase-gate-timing.md
+++ b/docs/debugging/debugging-plan-20260906-rebase-gate-timing.md
@@ -1,0 +1,134 @@
+# Debugging Plan: Rebase gate timing failures
+
+**Generated**: 2026-09-06 **Issue ID**: PR #352 rebase validation **Severity**:
+Medium **Falsification sub-agent**: alchemist **Planning agent boundary**: This
+document was prepared by the planning agent. Falsification must be executed by
+the named sub-agent, not by the planning agent.
+
+## Problem Statement
+
+The full post-rebase gate run passed formatting and type checking, but failed
+two generated tests and one spelling-render property while the shared host was
+running several other Cargo-heavy jobs. The worker concurrency property
+exceeded pytest's 30-second whole-test timeout, and the two properties exceeded
+Hypothesis's 200 ms per-example deadline before passing on replay. The expected
+behaviour is deterministic validation that still detects worker stalls and
+rendering defects without failing solely because the host is temporarily busy.
+
+## Context Summary
+
+| Aspect              | Details                                                          |
+| ------------------- | ---------------------------------------------------------------- |
+| First observed      | Post-rebase validation on 2026-09-06                             |
+| Reproduction rate   | One full run; each affected failure was timing-sensitive         |
+| Affected components | Worker concurrency, timeout telemetry, and typos rendering tests |
+| Recent changes      | Rebase onto `origin/main`; no behavioural change to these tests  |
+
+### Error Artefacts
+
+```plaintext
+test_generated_concurrent_workers_complete: Timeout (>30.0s) from pytest-timeout
+test_timeout_expiry_reports_agree_across_channels: 262.99ms > 200ms deadline
+test_render_is_canonical_and_scopes_markdown_patterns: 280.83ms > 200ms deadline
+```
+
+### Information Gaps
+
+- The failed run shared CPU and Cargo caches with unrelated worktrees.
+- The affected selectors have not yet been rerun independently after the load
+  subsides.
+
+______________________________________________________________________
+
+## Hypotheses
+
+### H1: Shared-host load produced transient timing failures
+
+**Claim**: The failures were caused by temporary scheduler and cache
+contention, not an incorrect worker, telemetry, or renderer result.
+
+**Plausibility**: High — Hypothesis replayed both deadline failures
+successfully, and the worker failure was pytest's outer timeout rather than an
+assertion.
+
+**Prediction**: Each exact selector passes when run alone without concurrent
+full-repository gates.
+
+#### H1 Falsification Plan
+
+| Step | Action                                                         | Expected Negative Result                                           |
+| ---- | -------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 1    | Run each failed selector sequentially with `uv run pytest -q`. | A reproducible assertion, worker failure, or timeout disproves H1. |
+
+**Tooling**: `uv run pytest -q` for the three exact failing selectors.
+
+**Confidence on falsification**: High for deterministic source regressions;
+inconclusive for load sensitivity if another unrelated resource spike occurs.
+
+**Result**: Inconclusive for the worker selector because its first isolated
+capture did not complete, but not-falsified for the timeout telemetry and typos
+rendering selectors, which both passed without a semantic failure.
+
+______________________________________________________________________
+
+### H2: The properties have inappropriate timing policy for their work
+
+**Claim**: The generated worker and rendering properties test correctness
+rather than latency, but inherit timing limits that are too small for their
+bounded work under supported shared-host execution.
+
+**Plausibility**: Medium — the worker test already disables Hypothesis's
+deadline but remains subject to pytest's 30-second whole-test timeout, and the
+rendering property retains Hypothesis's default deadline.
+
+**Prediction**: The generated worker property passes with a bounded 90-second
+test timeout, while its internal 15-second worker-stall assertion remains in
+force.
+
+#### H2 Falsification Plan
+
+| Step | Action                                       | Expected Negative Result                                |
+| ---- | -------------------------------------------- | ------------------------------------------------------- |
+| 1    | Run the worker selector with `--timeout=90`. | A semantic failure or a 90-second overrun disproves H2. |
+
+**Tooling**: The exact worker selector and pytest's `--timeout=90` option.
+
+**Confidence on falsification**: High for ruling out a deterministic worker
+failure; a passing run establishes that the outer 30-second timeout, rather
+than the worker assertion, caused the observed failure.
+
+**Result**: Not falsified. The worker selector passed with `--timeout=90` in
+31.1 seconds and did not trigger its internal 15-second worker-stall assertion.
+
+______________________________________________________________________
+
+## Recommended Execution Order
+
+1. **H1** — the exact isolated selectors are the cheapest decisive test for a
+   deterministic source regression. The worker selector was inconclusive; the
+   telemetry and spelling selectors passed.
+2. **H2** — use a bounded outer timeout to distinguish worker correctness from
+   an undersized test-time budget.
+
+## Termination Criteria
+
+- **Root cause identified**: A selector reproduces a semantic failure, or all
+  selectors pass alone and their timing policy is shown to be incompatible with
+  their correctness-only purpose.
+- **Escalation trigger**: Repeat isolated selectors still time out while the
+  host is otherwise idle.
+
+## Notes for Executing Agent
+
+Run no full repository gates and make no edits. Report one verdict for H1:
+falsified, not-falsified, or inconclusive. Include each selector's result and
+whether the observed outcome is an assertion failure or a timing failure.
+
+## Resolution
+
+Retain the worker helper's 15-second internal stall bound. Give the generated
+worker property a 90-second pytest timeout because it executes 20 concurrent
+examples. The root test configuration disables Hypothesis's host-sensitive
+per-example deadline for correctness properties; pytest-timeout continues to
+bound every test. The final gate run validates these policy changes under the
+normal repository configuration.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -3379,6 +3379,28 @@ probe. Reuse the existing helper rather than re-deriving the `sysconfig` scan;
 extend `maturin_script_locatable()` in place if maturin changes how it locates
 its binary.
 
+
+## Mutation-testing harness
+
+The mutmut mutation-testing workflow runs the selected test suite from its
+`mutants/` working tree. Files at the repository root that those tests read
+must therefore be listed in `[tool.mutmut].also_copy` in `pyproject.toml`:
+
+- `CHANGELOG.md`, read by
+  `test_changelog_records_cleanup_telemetry_contract` in
+  `cuprum/unittests/test_tracing_native_pump_cleanup.py`.
+- `Makefile`, read by `test_toolchain_pins` in
+  `cuprum/unittests/test_toolchain_pins.py`.
+
+`cuprum/unittests/test_mutmut_config_contract.py` checks this list and names
+the reader for each required root-level file. Update the configuration and this
+contract's fixture map together when a test gains another repository-root file
+dependency. Run the focused check with:
+
+```bash
+uv run pytest cuprum/unittests/test_mutmut_config_contract.py -q
+```
+
 ## Rust stream buffer-size validation
 
 `rust/cuprum-rust/src/lib.rs` validates the `buffer_size` argument to

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2912,11 +2912,12 @@ assertion, alias, suppression rationale, or dispatch structure instead.
 ### GitHub Actions workflow linting
 
 `make lint` finishes by running
-`yamllint --config-file .yamllint.yml .github/workflows` and `actionlint`.
-Together they validate YAML policy, GitHub Actions expressions, and shell used
-by workflow `run:` steps. `.yamllint.yml` requires each workflow to start with
-`---`, permits GitHub's unquoted `on` trigger key, and requires quoted `'true'`
-and `'false'` values.
+`yamllint --strict --config-file .yamllint.yml .github/workflows`, followed by
+`actionlint -config-file .github/actionlint.yaml`. Together they validate YAML
+policy, GitHub Actions expressions, and shell used by workflow `run:` steps.
+The actionlint command reads `.github/actionlint.yaml` from the repository root.
+`.yamllint.yml` requires each workflow to start with `---`, permits GitHub's
+unquoted `on` trigger key, and requires quoted `'true'` and `'false'` values.
 
 Install yamllint locally with `uv tool install "yamllint==1.38.0"`, then
 install actionlint using its

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2035,6 +2035,11 @@ tests keep the observable states aligned with the model such tools would verify.
 [Hypothesis](https://hypothesis.readthedocs.io/) generates the input domains
 that fixed examples cannot cover exhaustively:
 
+The root `conftest.py` disables Hypothesis's per-example deadline because these
+properties assert correctness under shared-host scheduling. The suite-wide
+pytest timeout remains the bound for hung tests; use an explicit marker only
+when a generated test's bounded workload needs a longer whole-test budget.
+
 - `test_nested_selector_rejects_generated_backend_pairs` draws an outer and an
   inner backend from the available set and asserts that same-thread nested
   entry always raises `ReentrantBackendSelectorError` before mutating backend
@@ -3378,7 +3383,6 @@ building, need only the checks they already use and should **not** adopt this
 probe. Reuse the existing helper rather than re-deriving the `sysconfig` scan;
 extend `maturin_script_locatable()` in place if maturin changes how it locates
 its binary.
-
 
 ## Mutation-testing harness
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -391,7 +391,10 @@ also_copy = [
     "benchmarks/",
     "docs/",
     ".github/",
-    # test_toolchain_pins.py reads the Makefile's tool-version defaults.
+    # test_changelog_records_cleanup_telemetry_contract reads the loose
+    # root-level CHANGELOG.md, and test_toolchain_pins.py reads the
+    # Makefile's tool-version defaults.
+    "CHANGELOG.md",
     "Makefile",
     "rust/cuprum-rust/",
     "rust/Cargo.toml",


### PR DESCRIPTION
## Summary

The `mutation-python / mutants` job failed its baseline because
`test_changelog_records_cleanup_telemetry_contract` reads the loose
root-level `CHANGELOG.md`, but mutmut only copies `tests/`,
`pyproject.toml`, and the `[tool.mutmut].also_copy` list into its
`mutants/` working tree. The run therefore died with a missing
`/mutants/CHANGELOG.md` before any mutant was analysed
([run 33632043063, job 100253602777](https://github.com/leynos/cuprum/actions/runs/33632043063/job/100253602777)).

Closes [#338](https://github.com/leynos/cuprum/issues/338).

## Changes

- `pyproject.toml` copies `CHANGELOG.md` through `[tool.mutmut].also_copy`,
  beside the existing loose-file entries.
- `cuprum/unittests/test_mutmut_config_contract.py` verifies the loose
  repository-root files the suite reads remain copied, now using structural
  matching to validate both the mutmut table and its `also_copy` list.
- `docs/developers-guide.md` documents the mutation harness, its copied
  root-level assets, and the contract test that protects the configuration.

## Validation

- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test` — 1,373 Python tests collected and 104 Rust nextest tests passed.

## Summary by Sourcery

Harden mutation testing and CI validation by copying required repository assets, enforcing their configuration contract, and improving timing and linting policies.

Bug Fixes:
- Ensure mutmut mutation runs include the repository-root CHANGELOG.md required by the test suite, preventing baseline failures caused by missing files.

Enhancements:
- Add a contract test and developer documentation to keep mutmut's copied root-level assets aligned with test dependencies.
- Make Hypothesis timing behavior and workflow linting configuration more explicit and robust for shared-host CI execution.

CI:
- Strengthen GitHub Actions workflow linting with strict yamllint checks and the repository's actionlint configuration.

Documentation:
- Document the mutation-testing harness, its required copied assets, and the updated workflow linting and property-test timing policies.

Tests:
- Add coverage validating required mutmut also_copy entries and update tests for the revised workflow lint commands and timeout behavior.

Chores:
- Normalize spacing in GitHub Actions inline comments.

## References

- [Lody session](https://lody.ai/leynos/sessions/2d938d9f-74e0-435d-8da0-3058a284431a)