### PR TITLE
Repin generate-coverage so a pull request stops moving the baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,7 +843,7 @@ jobs:
       # treats changes within one percentage point as measurement noise.
       #
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
+        uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         env:
           # The same warnings posture and the same core budget the
           # uninstrumented run used.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -16,6 +16,14 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      publish-baseline:
+        description: >-
+          Publish the ratchet baseline from this run; set false for
+          cache-warming or measurement dispatches.
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -164,15 +172,22 @@ jobs:
       # The pinned action writes a run-specific baseline cache entry and treats
       # changes within one percentage point as measurement noise.
       #
-      # publish-baseline: always is required here, not optional. From this pin
-      # the action publishes only on a push to refs/heads/main, and this
-      # repository's merges are performed by the automerge workflow's
-      # GITHUB_TOKEN, which fires no push event; see the header above. Under the
-      # default the manual dispatch that carries an automerged change would
-      # upload its coverage and publish no baseline, and the ratchet every pull
-      # request is measured against would stop advancing. This workflow runs
-      # only on main, so widening the guard here does not let any other ref
-      # publish.
+      # From this pin the action publishes only on a push to refs/heads/main.
+      # This repository's merges are performed by the automerge workflow's
+      # GITHUB_TOKEN, which fires no push event; see the header above. So the
+      # manual dispatch that carries an automerged change has to opt back in, or
+      # the ratchet every pull request is measured against stops advancing.
+      #
+      # A dispatch is also how warm-cache evidence is gathered, and such a run
+      # must read the generation it is measuring rather than replace it. The
+      # workflow_dispatch input decides which kind of dispatch this is: it
+      # defaults to publishing, because carrying an automerged change is the
+      # common case, and a measurement run sets it false.
+      #
+      # A push needs no opt-in, since the action's own guard already admits it;
+      # naming it here keeps the rule readable in one place. The push trigger is
+      # restricted to main, and a contract holds it there, so `always` cannot
+      # reach another ref.
       - name: Generate coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         env:
@@ -187,7 +202,9 @@ jobs:
           pytest-workers: ''
           cache-provider: external
           with-ratchet: 'true'
-          publish-baseline: always
+          publish-baseline: >-
+            ${{ (github.event_name == 'push' || inputs.publish-baseline)
+            && 'always' || 'auto' }}
           # This job is the only execution of the Rust suite for the event.
           # `language: mixed` and the workspace manifest are what make the
           # shared action run it: the repository root has no Cargo.toml, so

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -163,8 +163,18 @@ jobs:
       # against.
       # The pinned action writes a run-specific baseline cache entry and treats
       # changes within one percentage point as measurement noise.
+      #
+      # publish-baseline: always is required here, not optional. From this pin
+      # the action publishes only on a push to refs/heads/main, and this
+      # repository's merges are performed by the automerge workflow's
+      # GITHUB_TOKEN, which fires no push event; see the header above. Under the
+      # default the manual dispatch that carries an automerged change would
+      # upload its coverage and publish no baseline, and the ratchet every pull
+      # request is measured against would stop advancing. This workflow runs
+      # only on main, so widening the guard here does not let any other ref
+      # publish.
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
+        uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         env:
           # The same warnings posture and the same core budget the
           # uninstrumented run used.
@@ -177,6 +187,7 @@ jobs:
           pytest-workers: ''
           cache-provider: external
           with-ratchet: 'true'
+          publish-baseline: always
           # This job is the only execution of the Rust suite for the event.
           # `language: mixed` and the workspace manifest are what make the
           # shared action run it: the repository root has no Cargo.toml, so

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -185,9 +185,13 @@ jobs:
       # common case, and a measurement run sets it false.
       #
       # A push needs no opt-in, since the action's own guard already admits it;
-      # naming it here keeps the rule readable in one place. The push trigger is
-      # restricted to main, and a contract holds it there, so `always` cannot
-      # reach another ref.
+      # naming it here keeps the rule readable in one place.
+      #
+      # The ref is checked rather than inferred from the trigger. `push` is
+      # restricted to main, but `workflow_dispatch` is not: `gh workflow run
+      # coverage-main.yml --ref some-branch` runs this job against that branch,
+      # and without the check `always` would publish its coverage as the
+      # authoritative baseline.
       - name: Generate coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@77ea10341249024e22ec5d9069e3caa7596e0d4f
         env:
@@ -203,7 +207,8 @@ jobs:
           cache-provider: external
           with-ratchet: 'true'
           publish-baseline: >-
-            ${{ (github.event_name == 'push' || inputs.publish-baseline)
+            ${{ github.ref == 'refs/heads/main'
+            && (github.event_name == 'push' || inputs.publish-baseline)
             && 'always' || 'auto' }}
           # This job is the only execution of the Rust suite for the event.
           # `language: mixed` and the workspace manifest are what make the

--- a/tests/helpers/ci_runners.py
+++ b/tests/helpers/ci_runners.py
@@ -65,19 +65,27 @@ SETUP_RUST = (
     "leynos/shared-actions/.github/actions/setup-rust@"
     "c5a54701c8603a0fa756a6b34c49bc2af75a6c11"
 )
-#: Both shared actions are pinned to the same revision. It drops `target` from
-#: their own caches, so the no-target-archive rule holds even if a caller ever
-#: switches back to `cache-provider: github`; it adds the `all-features`,
-#: `all-targets`, and `doctests` inputs the coverage jobs depend on; and it
-#: installs cargo-nextest from checksummed official release archives with no
-#: source-build fallback, which matters because the coverage job is now the
-#: only place nextest runs. The revision itself is estate-wide rather than
-#: Cuprum-specific: its most recent change is to `install-whitaker`, which this
-#: repository does not consume, and both actions here are byte-identical to the
-#: previous pin. Holding one SHA across the estate is the point.
+#: The pinned shared coverage action. It drops `target` from its own cache, so
+#: the no-target-archive rule holds even if a caller ever switches back to
+#: `cache-provider: github`; it adds the `all-features`, `all-targets`, and
+#: `doctests` inputs the coverage jobs depend on; and it installs cargo-nextest
+#: from checksummed official release archives with no source-build fallback,
+#: which matters because the coverage job is now the only place nextest runs.
+#:
+#: It is deliberately ahead of `SETUP_RUST` for now. From this revision the
+#: ratchet baseline is published only on a push to `refs/heads/main` unless
+#: `publish-baseline` says otherwise, and cuprum needs that: without it a pull
+#: request advances the baseline it is then measured against. Holding one SHA
+#: across the estate is still the aim, and the next estate-wide bump should
+#: bring `SETUP_RUST` up to meet this one rather than pulling this one back.
+#:
+#: Asserted by value rather than by shape, unlike the Dependabot-owned pins in
+#: `test_workflow_contract.py`. A bump has to update this constant, which is
+#: the point: it makes someone confirm the new revision still keeps a pull
+#: request from publishing.
 GENERATE_COVERAGE = (
     "leynos/shared-actions/.github/actions/generate-coverage@"
-    "c5a54701c8603a0fa756a6b34c49bc2af75a6c11"
+    "77ea10341249024e22ec5d9069e3caa7596e0d4f"
 )
 OBSERVATION_STEP = "Record cache observations"
 

--- a/tests/test_ci_ratchet_publication.py
+++ b/tests/test_ci_ratchet_publication.py
@@ -1,0 +1,110 @@
+"""Contracts for which runs may publish the coverage ratchet baseline.
+
+A ratchet is only a ratchet while the baseline it compares against comes from
+somewhere a pull request cannot reach. Before the pinned revision the shared
+action published from every run that reached its save step, so a pull request
+advanced the baseline it was then measured against, and a dispatch gathering
+warm-cache evidence replaced the generation it was measuring.
+
+None of that is visible from a green run. A ratchet comparing each pull request
+against itself passes exactly as one comparing against trunk does, and it goes
+on passing while coverage falls.
+
+Two facts have to hold together, and neither is sufficient alone. The action
+must be pinned at or beyond the revision that added the guard, which
+``GENERATE_COVERAGE`` asserts by value. And this repository's merges land
+through the automerge workflow's ``GITHUB_TOKEN``, which fires no push event,
+so its trunk publisher has to opt back in explicitly or the baseline stops
+advancing altogether.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+
+import pytest
+
+from tests.helpers.ci_runners import GENERATE_COVERAGE, step_inputs, steps
+
+if typ.TYPE_CHECKING:
+    from tests.helpers.workflow_types import Step
+
+#: The workflow and job that publishes the trunk baseline, and the mode it
+#: must ask for. ``always`` is not a preference here: see the module docstring.
+TRUNK_PUBLISHER = ("coverage-main.yml", "coverage-upload")
+
+#: The pull-request lane, which must never publish whatever the run's coverage
+#: turned out to be.
+PULL_REQUEST_LANE = ("ci.yml", "coverage")
+
+
+def _coverage_step(workflow_name: str, job_name: str) -> Step:
+    """Return the single shared-coverage step of a job."""
+    matches = [
+        step
+        for step in steps(workflow_name, job_name)
+        if step.get("uses") == GENERATE_COVERAGE
+    ]
+    assert len(matches) == 1, (
+        f"{workflow_name}:{job_name} must invoke the coverage action exactly "
+        f"once, found {len(matches)}"
+    )
+    return matches[0]
+
+
+def test_the_trunk_publisher_opts_in_to_publishing() -> None:
+    """The workflow carrying an automerged change must publish its baseline.
+
+    Its merges fire no push event, so under the action's default guard the
+    dispatch that uploads an automerged change's coverage would publish
+    nothing, and the baseline every pull request is measured against would stop
+    advancing.
+    """
+    workflow_name, job_name = TRUNK_PUBLISHER
+    inputs = step_inputs(
+        _coverage_step(workflow_name, job_name),
+        f"{workflow_name}:{job_name} coverage must declare inputs",
+    )
+
+    assert inputs.get("publish-baseline") == "always", (
+        f"{workflow_name}:{job_name} must set publish-baseline: always, got "
+        f"{inputs.get('publish-baseline')!r}; without it an automerged change "
+        f"never advances the baseline"
+    )
+
+
+def test_the_pull_request_lane_does_not_opt_in() -> None:
+    """A pull request must not publish the baseline it is measured against.
+
+    Leaving the input unset is what keeps it out: the action then publishes
+    only on a push to ``refs/heads/main``.
+    """
+    workflow_name, job_name = PULL_REQUEST_LANE
+    inputs = step_inputs(
+        _coverage_step(workflow_name, job_name),
+        f"{workflow_name}:{job_name} coverage must declare inputs",
+    )
+
+    assert "publish-baseline" not in inputs, (
+        f"{workflow_name}:{job_name} sets publish-baseline="
+        f"{inputs.get('publish-baseline')!r}; a pull request would then "
+        f"advance the baseline it is measured against"
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow_name", "job_name"), [TRUNK_PUBLISHER, PULL_REQUEST_LANE]
+)
+def test_the_ratchet_is_enabled_where_publication_is_decided(
+    workflow_name: str, job_name: str
+) -> None:
+    """Both lanes must run the ratchet, or the guard governs nothing."""
+    inputs = step_inputs(
+        _coverage_step(workflow_name, job_name),
+        f"{workflow_name}:{job_name} coverage must declare inputs",
+    )
+
+    assert inputs.get("with-ratchet") == "true", (
+        f"{workflow_name}:{job_name} must enable the ratchet, got "
+        f"{inputs.get('with-ratchet')!r}"
+    )

--- a/tests/test_ci_ratchet_publication.py
+++ b/tests/test_ci_ratchet_publication.py
@@ -38,6 +38,9 @@ TRUNK_PUBLISHER = ("coverage-main.yml", "coverage-upload")
 #: turned out to be.
 PULL_REQUEST_LANE = ("ci.yml", "coverage")
 
+#: The only ref from which the baseline may be published.
+MAIN = "refs/heads/main"
+
 
 def _coverage_step(workflow_name: str, job_name: str) -> Step:
     """Return the single shared-coverage step of a job."""
@@ -69,7 +72,7 @@ def _truthy(value: object) -> bool:
     return value not in {False, "", None}
 
 
-def _operand(text: str, *, event_name: str, dispatch_input: object) -> object:
+def _operand(text: str, *, event_name: str, dispatch_input: object, ref: str) -> object:
     """Evaluate one leaf of the publication expression.
 
     Parameters
@@ -80,6 +83,8 @@ def _operand(text: str, *, event_name: str, dispatch_input: object) -> object:
         The event the run was triggered by.
     dispatch_input : object
         The dispatch input's value, or ``""`` when the event supplies none.
+    ref : str
+        The ref the run was triggered against.
 
     Returns
     -------
@@ -99,12 +104,14 @@ def _operand(text: str, *, event_name: str, dispatch_input: object) -> object:
         return dispatch_input
     if text == "github.event_name == 'push'":
         return event_name == "push"
+    if text == "github.ref == 'refs/heads/main'":
+        return ref == "refs/heads/main"
     message = f"unsupported operand in the publication expression: {text!r}"
     raise AssertionError(message)
 
 
 def _resolve_publication(
-    expression: str, *, event_name: str, dispatch_input: object
+    expression: str, *, event_name: str, dispatch_input: object, ref: str
 ) -> object:
     """Evaluate the workflow's publish-baseline expression.
 
@@ -121,6 +128,8 @@ def _resolve_publication(
         The event the run was triggered by.
     dispatch_input : object
         The dispatch input's value, or ``""`` when the event supplies none.
+    ref : str
+        The ref the run was triggered against.
 
     Returns
     -------
@@ -137,13 +146,17 @@ def _resolve_publication(
         before, _, rest = body.partition("(")
         grouped, _, after = rest.partition(")")
         resolved = _resolve_group(
-            grouped, event_name=event_name, dispatch_input=dispatch_input
+            grouped, event_name=event_name, dispatch_input=dispatch_input, ref=ref
         )
         body = f"{before} {'TRUE' if _truthy(resolved) else 'FALSE'} {after}"
-    return _resolve_group(body, event_name=event_name, dispatch_input=dispatch_input)
+    return _resolve_group(
+        body, event_name=event_name, dispatch_input=dispatch_input, ref=ref
+    )
 
 
-def _resolve_group(body: str, *, event_name: str, dispatch_input: object) -> object:
+def _resolve_group(
+    body: str, *, event_name: str, dispatch_input: object, ref: str
+) -> object:
     """Evaluate a bracket-free ``||`` of ``&&`` chains.
 
     Parameters
@@ -154,14 +167,21 @@ def _resolve_group(body: str, *, event_name: str, dispatch_input: object) -> obj
         The event the run was triggered by.
     dispatch_input : object
         The dispatch input's value, or ``""`` when the event supplies none.
+    ref : str
+        The ref the run was triggered against.
 
     Returns
     -------
     object
         The operand the group yields.
     """
+    # Actions yields the last operand it evaluated once every alternative is
+    # falsey, not the first. The shipped expression ends in a literal, so no
+    # case reaches that path today; getting it wrong anyway would make this
+    # evaluator report a mode the workflow does not resolve to, which is
+    # exactly the failure it exists to prevent.
     result: object = ""
-    for index, alternative in enumerate(body.split("||")):
+    for alternative in body.split("||"):
         value: object = True
         for term in alternative.split("&&"):
             term = term.strip()
@@ -169,7 +189,10 @@ def _resolve_group(body: str, *, event_name: str, dispatch_input: object) -> obj
                 candidate: object = term == "TRUE"
             else:
                 candidate = _operand(
-                    term, event_name=event_name, dispatch_input=dispatch_input
+                    term,
+                    event_name=event_name,
+                    dispatch_input=dispatch_input,
+                    ref=ref,
                 )
             if not _truthy(candidate):
                 value = candidate
@@ -177,11 +200,11 @@ def _resolve_group(body: str, *, event_name: str, dispatch_input: object) -> obj
             value = candidate
         if _truthy(value):
             return value
-        result = value if index == 0 else result
+        result = value
     return result
 
 
-def _triggers(workflow_name: str) -> dict[str, typ.Any]:
+def _triggers(workflow_name: str) -> dict[str, object]:
     """Return a workflow's ``on:`` mapping.
 
     Parameters
@@ -191,17 +214,17 @@ def _triggers(workflow_name: str) -> dict[str, typ.Any]:
 
     Returns
     -------
-    dict[str, typ.Any]
+    dict[str, object]
         The declared triggers.
     """
     document = workflow_document(workflow_name)
     # PyYAML parses the bare `on:` key as the boolean True.
     triggers = document.get("on", document.get(True))
     assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
-    return typ.cast("dict[str, typ.Any]", triggers)
+    return typ.cast("dict[str, object]", triggers)
 
 
-def _dispatch_input(workflow_name: str) -> dict[str, typ.Any]:
+def _dispatch_input(workflow_name: str) -> dict[str, object]:
     """Return the workflow's declared ``publish-baseline`` dispatch input.
 
     Parameters
@@ -211,31 +234,40 @@ def _dispatch_input(workflow_name: str) -> dict[str, typ.Any]:
 
     Returns
     -------
-    dict[str, typ.Any]
+    dict[str, object]
         The input's declaration.
     """
     dispatch = _triggers(workflow_name).get("workflow_dispatch")
     assert isinstance(dispatch, dict), "the dispatch trigger must declare inputs"
-    declared = dispatch["inputs"]["publish-baseline"]
+    inputs = dispatch["inputs"]
+    assert isinstance(inputs, dict), "the dispatch trigger must declare a mapping"
+    declared = inputs["publish-baseline"]
     assert isinstance(declared, dict), "publish-baseline must be a mapping"
-    return typ.cast("dict[str, typ.Any]", declared)
+    return typ.cast("dict[str, object]", declared)
 
 
 #: Every way the trunk publisher can be reached, and what it must resolve to.
 #: A dispatch defaults to publishing because carrying an automerged change is
 #: the common case; a measurement run turns it off.
 PUBLICATION_CASES = [
-    pytest.param("push", "", "always", id="push-to-main"),
-    pytest.param("workflow_dispatch", True, "always", id="dispatch-default"),
-    pytest.param("workflow_dispatch", False, "auto", id="dispatch-opted-out"),
+    pytest.param("push", "", MAIN, "always", id="push-to-main"),
+    pytest.param("workflow_dispatch", True, MAIN, "always", id="dispatch-default"),
+    pytest.param("workflow_dispatch", False, MAIN, "auto", id="dispatch-opted-out"),
+    # `push` is restricted to main by its trigger, but `workflow_dispatch` is
+    # not: `gh workflow run coverage-main.yml --ref some-branch` runs this job
+    # against that branch. Publishing there would put a feature branch's
+    # coverage into the baseline every pull request is measured against.
+    pytest.param(
+        "workflow_dispatch", True, "refs/heads/feature", "auto", id="dispatch-off-main"
+    ),
 ]
 
 
 @pytest.mark.parametrize(
-    ("event_name", "dispatch_input", "expected"), PUBLICATION_CASES
+    ("event_name", "dispatch_input", "ref", "expected"), PUBLICATION_CASES
 )
 def test_the_trunk_publisher_resolves_publication_per_event(
-    event_name: str, dispatch_input: object, expected: str
+    event_name: str, dispatch_input: object, ref: str, expected: str
 ) -> None:
     """Each way of reaching the trunk publisher must resolve as documented.
 
@@ -252,12 +284,13 @@ def test_the_trunk_publisher_resolves_publication_per_event(
     expression = str(inputs.get("publish-baseline"))
 
     resolved = _resolve_publication(
-        expression, event_name=event_name, dispatch_input=dispatch_input
+        expression, event_name=event_name, dispatch_input=dispatch_input, ref=ref
     )
 
     assert resolved == expected, (
-        f"{event_name} with publish-baseline={dispatch_input!r} resolves to "
-        f"{resolved!r}, expected {expected!r}; expression was {expression!r}"
+        f"{event_name} on {ref} with publish-baseline={dispatch_input!r} "
+        f"resolves to {resolved!r}, expected {expected!r}; expression was "
+        f"{expression!r}"
     )
 
 
@@ -272,7 +305,11 @@ def test_the_dispatch_input_defaults_to_publishing() -> None:
     assert declared["default"] is True, (
         f"publish-baseline must default to publishing, got {declared['default']!r}"
     )
-    assert "measurement" in declared["description"], (
+    description = declared["description"]
+    assert isinstance(description, str), (
+        f"publish-baseline's description must be text, got {description!r}"
+    )
+    assert "measurement" in description, (
         "the description must say what turning it off is for"
     )
 

--- a/tests/test_ci_ratchet_publication.py
+++ b/tests/test_ci_ratchet_publication.py
@@ -25,6 +25,7 @@ import typing as typ
 import pytest
 
 from tests.helpers.ci_runners import GENERATE_COVERAGE, step_inputs, steps
+from tests.helpers.ci_workflows import workflow_document
 
 if typ.TYPE_CHECKING:
     from tests.helpers.workflow_types import Step
@@ -52,24 +53,243 @@ def _coverage_step(workflow_name: str, job_name: str) -> Step:
     return matches[0]
 
 
-def test_the_trunk_publisher_opts_in_to_publishing() -> None:
-    """The workflow carrying an automerged change must publish its baseline.
+def _truthy(value: object) -> bool:
+    """Return whether an expression operand is truthy, as Actions judges it.
 
-    Its merges fire no push event, so under the action's default guard the
-    dispatch that uploads an automerged change's coverage would publish
-    nothing, and the baseline every pull request is measured against would stop
-    advancing.
+    Parameters
+    ----------
+    value : object
+        The operand to judge.
+
+    Returns
+    -------
+    bool
+        Whether Actions would treat it as true.
+    """
+    return value not in {False, "", None}
+
+
+def _operand(text: str, *, event_name: str, dispatch_input: object) -> object:
+    """Evaluate one leaf of the publication expression.
+
+    Parameters
+    ----------
+    text : str
+        The leaf's source text.
+    event_name : str
+        The event the run was triggered by.
+    dispatch_input : object
+        The dispatch input's value, or ``""`` when the event supplies none.
+
+    Returns
+    -------
+    object
+        The leaf's value.
+
+    Raises
+    ------
+    AssertionError
+        If the expression uses an operand this evaluator does not model, which
+        means the contract can no longer speak to what the workflow resolves.
+    """
+    text = text.strip()
+    if text.startswith("'") and text.endswith("'"):
+        return text[1:-1]
+    if text == "inputs.publish-baseline":
+        return dispatch_input
+    if text == "github.event_name == 'push'":
+        return event_name == "push"
+    message = f"unsupported operand in the publication expression: {text!r}"
+    raise AssertionError(message)
+
+
+def _resolve_publication(
+    expression: str, *, event_name: str, dispatch_input: object
+) -> object:
+    """Evaluate the workflow's publish-baseline expression.
+
+    Actions' ``&&`` and ``||`` yield an operand rather than a boolean, and
+    ``&&`` binds tighter, which is what makes the ternary idiom work. Reading
+    the shipped expression and evaluating it is the point: asserting its text
+    would pass for an expression that reads well and resolves wrongly.
+
+    Parameters
+    ----------
+    expression : str
+        The single Actions expression the workflow declares.
+    event_name : str
+        The event the run was triggered by.
+    dispatch_input : object
+        The dispatch input's value, or ``""`` when the event supplies none.
+
+    Returns
+    -------
+    object
+        The operand the expression yields, which is the mode passed to the
+        action.
+    """
+    body = expression.strip()
+    assert body.startswith("${{"), f"not an Actions expression: {expression!r}"
+    assert body.endswith("}}"), f"not a single Actions expression: {expression!r}"
+    body = body[3:-2].strip().replace("(", " ( ").replace(")", " ) ")
+    # One bracketed group only, which the guard uses to group the disjunction.
+    if "(" in body:
+        before, _, rest = body.partition("(")
+        grouped, _, after = rest.partition(")")
+        resolved = _resolve_group(
+            grouped, event_name=event_name, dispatch_input=dispatch_input
+        )
+        body = f"{before} {'TRUE' if _truthy(resolved) else 'FALSE'} {after}"
+    return _resolve_group(body, event_name=event_name, dispatch_input=dispatch_input)
+
+
+def _resolve_group(body: str, *, event_name: str, dispatch_input: object) -> object:
+    """Evaluate a bracket-free ``||`` of ``&&`` chains.
+
+    Parameters
+    ----------
+    body : str
+        The expression body, with any bracketed group already reduced.
+    event_name : str
+        The event the run was triggered by.
+    dispatch_input : object
+        The dispatch input's value, or ``""`` when the event supplies none.
+
+    Returns
+    -------
+    object
+        The operand the group yields.
+    """
+    result: object = ""
+    for index, alternative in enumerate(body.split("||")):
+        value: object = True
+        for term in alternative.split("&&"):
+            term = term.strip()
+            if term in {"TRUE", "FALSE"}:
+                candidate: object = term == "TRUE"
+            else:
+                candidate = _operand(
+                    term, event_name=event_name, dispatch_input=dispatch_input
+                )
+            if not _truthy(candidate):
+                value = candidate
+                break
+            value = candidate
+        if _truthy(value):
+            return value
+        result = value if index == 0 else result
+    return result
+
+
+def _triggers(workflow_name: str) -> dict[str, typ.Any]:
+    """Return a workflow's ``on:`` mapping.
+
+    Parameters
+    ----------
+    workflow_name : str
+        File name of the workflow.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The declared triggers.
+    """
+    document = workflow_document(workflow_name)
+    # PyYAML parses the bare `on:` key as the boolean True.
+    triggers = document.get("on", document.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return typ.cast("dict[str, typ.Any]", triggers)
+
+
+def _dispatch_input(workflow_name: str) -> dict[str, typ.Any]:
+    """Return the workflow's declared ``publish-baseline`` dispatch input.
+
+    Parameters
+    ----------
+    workflow_name : str
+        File name of the workflow.
+
+    Returns
+    -------
+    dict[str, typ.Any]
+        The input's declaration.
+    """
+    dispatch = _triggers(workflow_name).get("workflow_dispatch")
+    assert isinstance(dispatch, dict), "the dispatch trigger must declare inputs"
+    declared = dispatch["inputs"]["publish-baseline"]
+    assert isinstance(declared, dict), "publish-baseline must be a mapping"
+    return typ.cast("dict[str, typ.Any]", declared)
+
+
+#: Every way the trunk publisher can be reached, and what it must resolve to.
+#: A dispatch defaults to publishing because carrying an automerged change is
+#: the common case; a measurement run turns it off.
+PUBLICATION_CASES = [
+    pytest.param("push", "", "always", id="push-to-main"),
+    pytest.param("workflow_dispatch", True, "always", id="dispatch-default"),
+    pytest.param("workflow_dispatch", False, "auto", id="dispatch-opted-out"),
+]
+
+
+@pytest.mark.parametrize(
+    ("event_name", "dispatch_input", "expected"), PUBLICATION_CASES
+)
+def test_the_trunk_publisher_resolves_publication_per_event(
+    event_name: str, dispatch_input: object, expected: str
+) -> None:
+    """Each way of reaching the trunk publisher must resolve as documented.
+
+    Its merges fire no push event, so a dispatch has to be able to publish or
+    the baseline stops advancing. A dispatch is also how warm-cache evidence is
+    gathered, and such a run must read the generation it is measuring rather
+    than replace it, which is what the input is for.
     """
     workflow_name, job_name = TRUNK_PUBLISHER
     inputs = step_inputs(
         _coverage_step(workflow_name, job_name),
         f"{workflow_name}:{job_name} coverage must declare inputs",
     )
+    expression = str(inputs.get("publish-baseline"))
 
-    assert inputs.get("publish-baseline") == "always", (
-        f"{workflow_name}:{job_name} must set publish-baseline: always, got "
-        f"{inputs.get('publish-baseline')!r}; without it an automerged change "
-        f"never advances the baseline"
+    resolved = _resolve_publication(
+        expression, event_name=event_name, dispatch_input=dispatch_input
+    )
+
+    assert resolved == expected, (
+        f"{event_name} with publish-baseline={dispatch_input!r} resolves to "
+        f"{resolved!r}, expected {expected!r}; expression was {expression!r}"
+    )
+
+
+def test_the_dispatch_input_defaults_to_publishing() -> None:
+    """The common dispatch carries an automerged change, so it must publish."""
+    workflow_name, _job_name = TRUNK_PUBLISHER
+    declared = _dispatch_input(workflow_name)
+
+    assert declared["type"] == "boolean", (
+        f"publish-baseline must be a boolean, got {declared['type']!r}"
+    )
+    assert declared["default"] is True, (
+        f"publish-baseline must default to publishing, got {declared['default']!r}"
+    )
+    assert "measurement" in declared["description"], (
+        "the description must say what turning it off is for"
+    )
+
+
+def test_the_trunk_push_trigger_stays_on_main() -> None:
+    """`always` must not become reachable from another ref.
+
+    The expression names the push event without checking the ref, because the
+    trigger already restricts it. Widening the trigger would silently widen
+    publication.
+    """
+    workflow_name, _job_name = TRUNK_PUBLISHER
+    push = _triggers(workflow_name)["push"]
+    assert isinstance(push, dict), "the push trigger must declare branches"
+
+    assert push.get("branches") == ["main"], (
+        f"the push trigger must stay restricted to main, got {push.get('branches')!r}"
     )
 
 


### PR DESCRIPTION
## What

Repins `generate-coverage` from `c5a54701` to `77ea1034`, which is the revision
that stops a pull request publishing the ratchet baseline it is measured
against.

## Why it matters here

Before `77ea1034` the shared action published a baseline from every run that
reached its save step. It was guarded on `success()` and on the ratchet being
enabled, and on nothing else.

Two consequences for this repository:

- `ci.yml`'s coverage job runs on `pull_request` with `with-ratchet: 'true'`,
  so every pull request advanced the baseline it was then measured against.
- A `workflow_dispatch` of `coverage-main.yml`, which is how warm-cache
  evidence is gathered, replaced the generation it was measuring. Issue
  leynos/shared-actions#444 measured exactly that on this repository: two
  sequential dispatches over an unchanged tree wrote two new baselines.

Neither is visible from a green run. A ratchet comparing each pull request
against itself passes just as one comparing against trunk does, and goes on
passing while coverage falls.

## coverage-main.yml must opt back in

From this pin the save requires a push to `refs/heads/main`. This repository's
merges are performed by the automerge workflow's `GITHUB_TOKEN`, which fires no
push event, which is why `coverage-main.yml` carries a `workflow_dispatch`
trigger and says so in its own header:

> `workflow_dispatch` is intentional and required: merges performed by the
> automerge workflow's `GITHUB_TOKEN` do not fire push-event workflows, so
> automerged changes to main only get their coverage uploaded via a manual
> dispatch.

Under the default guard, the dispatch that uploads an automerged change's
coverage would publish no baseline, and the baseline every pull request is
measured against would stop advancing. Note that this dispatch remains a manual
step after the merge: nothing automates it.

So the job publishes on a dispatch, but says which kind of dispatch it is. The
workflow gains a `workflow_dispatch` boolean input, `publish-baseline`,
defaulting to true because carrying an automerged change is the common case; a
cache-warming or measurement run sets it false. The step resolves to:

```yaml
publish-baseline: >-
  ${{ (github.event_name == 'push' || inputs.publish-baseline)
  && 'always' || 'auto' }}
```

A push needs no opt-in, since the action's own guard already admits it, but
naming it keeps the rule readable in one place. The expression does not check
the ref, relying on the `push: branches: [main]` trigger to restrict it, and a
contract holds that trigger there.

`ci.yml` leaves the input unset, so it takes the guarded default and pull
requests stop moving the baseline.

## Contracts

`tests/test_ci_ratchet_publication.py` pins the arrangement, because none of it
is observable from a passing run:

- each way of reaching the trunk publisher resolves as documented: a push
  publishes, a default dispatch publishes, and a dispatch with the input false
  does not;
- the dispatch input is a boolean defaulting to true, and its description says
  what turning it off is for;
- the push trigger stays restricted to `main`, since the expression relies on
  it rather than checking the ref;
- the pull-request lane does not set the input at all;
- both lanes enable the ratchet, since the guard governs nothing otherwise.

The publication contract evaluates the expression rather than matching its
text, because text that reads well can resolve wrongly. A small evaluator
models the operand semantics Actions uses, where `&&` and `||` yield an operand
rather than a boolean.

Four mutations were run against it, and each is caught:

| Mutation | Failing case |
| --- | --- |
| Swap `always` and `auto` | all three resolution cases |
| Conjoin the conditions instead of disjoining them | `dispatch-default` |
| Default the input to false | the input declaration |
| Widen the push trigger past `main` | the trigger restriction |

`GENERATE_COVERAGE` continues to assert the pin by value rather than by shape,
so a bump has to update the constant and make someone confirm the new revision
still keeps a pull request from publishing.

## One pin, not two

`GENERATE_COVERAGE` is now ahead of `SETUP_RUST`, which stays at `c5a54701`.
Their shared comment claimed both shared actions sat on one revision; that is
corrected rather than left false, with a note that the next estate-wide bump
should bring `setup-rust` up to meet this one rather than pulling this one
back. No other pin is touched.

## Validation

`make check-fmt`, `python-lint`, `typecheck`, `markdownlint`, `nixie`, and the
Python suite: 255 passed, 11 skipped.

## Summary by Sourcery

Stabilize coverage ratchet baselines by updating the shared coverage action and making trunk baseline publication explicit for manual dispatches.

Bug Fixes:
- Prevent pull-request and non-main coverage runs from publishing the ratchet baseline they are measured against.

Enhancements:
- Repin the shared generate-coverage action to the revision that restricts baseline publication.
- Add explicit dispatch control so coverage-main can publish baselines for automerged changes while opting out for cache-warming or measurement runs.

Tests:
- Add workflow contract tests covering baseline publication behavior across push, dispatch, non-main, and pull-request lanes.

Chores:
- Keep the generate-coverage pin independently ahead of the setup-rust pin and document the pinning rationale.