### PR TITLE
Stabilize parallel tracing captures (#366)

### DIFF
--- a/docs/debugging/debugging-plan-20260907-tracing-interest-race.md
+++ b/docs/debugging/debugging-plan-20260907-tracing-interest-race.md
@@ -1,0 +1,83 @@
+# Debugging plan: tracing capture interest race
+
+- Generated: 2026-09-07.
+- Issue: [#366](https://github.com/leynos/cuprum/issues/366).
+- Falsification sub-agent: `alchemist`.
+- Planning boundary: the planning agent prepares the experiment; `alchemist`
+  executes it independently and reports the result.
+
+## Observed failure
+
+The proposed `FilterCapture::register_callsite` override returning
+`Interest::sometimes()` passes the repository gates and nextest but does not
+eliminate parallel tracing failures. A six-thread plain Cargo unit-suite run
+failed the EINTR warning assertion at repetitions 100 and 174 and the DEBUG
+read-event assertion at repetition 136. Existing assertions remain unchanged.
+The baseline also contains a separate descriptor-close assertion flake, which
+is outside this investigation.
+
+## Hypothesis
+
+Tracing-core 0.1.36's single-dispatch registration fast path consults the
+registering thread's default subscriber. An uncaptured thread can therefore
+register a shared callsite with `never`, even while another thread has an
+active capture. The capture's `register_callsite` override is bypassed in this
+case. Its later event uses the cached `never` and disappears.
+
+Prediction: a fresh warning callsite first executed on an uncaptured child
+thread, while the parent holds a WARN capture, remains disabled when the parent
+executes the same callsite. No timing delay is needed: joining the child fixes
+the order. A successful parent capture on the existing override-only harness
+would falsify this specific explanation.
+
+## Minimal falsification experiment
+
+Run only the new test, in a fresh process, from `rust/`:
+
+```bash
+cargo test -p cuprum-rust --lib \
+  tracing_capture::tests::warn_capture_records_callsite_first_seen_without_subscriber \
+  -- --exact
+```
+
+Capture output with `tee` and preserve the command's exit status. The expected
+failure is the parent warning assertion, not a thread panic or a build error.
+Do not run repository gates or other tests concurrently. The executing agent
+must not edit tracked files.
+
+## Candidate mitigation
+
+Retain a dormant dispatch before constructing any capture dispatch. The dormant
+subscriber enables nothing and reports `LevelFilter::OFF`, keeping tracing
+disabled during initialization. Every subsequent capture then registers beside
+the retained dispatch, selecting tracing-core's synchronized registry path
+instead of the thread-local single-dispatch fast path. It must never be
+installed as a thread-local or global default.
+
+After the planning agent adds this mitigation, repeat the exact experiment. The
+parent must capture exactly one warning, and the child must remain uncaptured.
+Any missing or extra event falsifies the candidate mitigation. Then run the
+required gates and parallel stress verification through `scrutineer` before
+review or publication.
+
+## Results
+
+The isolated experiment failed at the parent warning assertion with only the
+`Interest::sometimes()` override. The child joined successfully. After adding
+the dormant dispatch, the same experiment passed, including the assertion that
+exactly one event was captured. Both runs were executed by `alchemist`; this
+did not falsify the hypothesis or candidate mitigation.
+
+Source inspection explains why one dormant dispatch suffices. Tracing-core
+updates its single-dispatch flag during dispatch registration, not removal.
+Each capture registers beside the retained guard, keeping that flag false.
+Unlike `NoSubscriber`, which supplies no level hint and thereby enables TRACE
+during initialization, the dormant subscriber reports OFF. Neither
+initialization nor later callsite registration needs to consult an uncaptured
+thread's default subscriber.
+
+The earlier same-thread ERROR then WARN test passes on the old harness because
+creating the second dispatch rebuilds callsite interest. Separate
+registration-policy checks fail on the old harness and pass with
+`Interest::sometimes()`, but do not cover registration from a thread without a
+subscriber. The cross-thread regression is therefore required alongside them.

--- a/docs/debugging/debugging-plan-20260907-tracing-interest-race.md
+++ b/docs/debugging/debugging-plan-20260907-tracing-interest-race.md
@@ -81,3 +81,11 @@ creating the second dispatch rebuilds callsite interest. Separate
 registration-policy checks fail on the old harness and pass with
 `Interest::sometimes()`, but do not cover registration from a thread without a
 subscriber. The cross-thread regression is therefore required alongside them.
+
+A proptest supplements that concrete regression with generated histories. Each
+history varies the parent capture level, child-first or parent-first ordering,
+whether the child uses its default subscriber or a separately filtered capture,
+the child's level, and reused warning sequences. The final assertion requires
+each parent warning exactly when the parent level is WARN; child warnings must
+never enter the parent's capture. This widens state coverage without replacing
+the deterministic child-first proof of the original failure.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2790,6 +2790,24 @@ make check-fmt
 make lint
 ```
 
+The Rust tracing capture harness also supports parallel `cargo test` execution
+within one process. Its `FilterCapture` subscriber returns
+`Interest::sometimes()` from `register_callsite`, so each event and span checks
+the active capture's level through `enabled()`.
+
+The harness retains one dormant dispatch before registering a capture. This
+private guard keeps registration on tracing-core's synchronized registry path:
+its single-dispatch fast path can otherwise cache `never` from a thread without
+a default subscriber, bypassing the active capture's interest entirely. The
+guard reports `LevelFilter::OFF` to prevent that same race during
+initialization and is never installed as a default subscriber. Together with
+dynamic interest, it prevents another thread's verdict from disabling a
+captured event. Reuse the guard only through the capture harness; it is not a
+production tracing setup. Capture correctness does not depend on nextest's
+process isolation; nextest remains the project's test runner. The
+[tracing investigation](debugging/debugging-plan-20260907-tracing-interest-race.md)
+records the deterministic regression and the rejected override-only fix.
+
 Run Kani separately because it is a bounded model checker rather than a normal
 unit-test runner. The Kani installer places the verifier under `~/.kani`; the
 dynamic library path is required when invoking the crate harnesses. Resolve the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2804,9 +2804,9 @@ initialization and is never installed as a default subscriber. Together with
 dynamic interest, it prevents another thread's verdict from disabling a
 captured event. Reuse the guard only through the capture harness; it is not a
 production tracing setup. Capture correctness does not depend on nextest's
-process isolation; nextest remains the project's test runner. The
-[tracing investigation](debugging/debugging-plan-20260907-tracing-interest-race.md)
-records the deterministic regression and the rejected override-only fix.
+process isolation; nextest remains the project's test runner. The tracing
+investigation records the deterministic regression and the rejected
+[override-only fix](debugging/debugging-plan-20260907-tracing-interest-race.md).
 
 Run Kani separately because it is a bounded model checker rather than a normal
 unit-test runner. The Kani installer places the verifier under `~/.kani`; the

--- a/rust/cuprum-rust/src/tracing_capture.rs
+++ b/rust/cuprum-rust/src/tracing_capture.rs
@@ -10,11 +10,13 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Debug;
-use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard, PoisonError};
 
 use tracing::field::{Field, Visit};
+use tracing::level_filters::LevelFilter;
 use tracing::span::{Attributes, Id, Record};
-use tracing::{Event, Level, Metadata, Subscriber};
+use tracing::subscriber::{Interest, NoSubscriber};
+use tracing::{Dispatch, Event, Level, Metadata, Subscriber};
 
 /// A captured event: its level, the field names reachable from the active span
 /// stack when it was emitted, and the values it carried itself.
@@ -124,6 +126,10 @@ fn lock(state: &Arc<Mutex<CaptureState>>) -> MutexGuard<'_, CaptureState> {
 }
 
 impl Subscriber for FilterCapture {
+    fn register_callsite(&self, _metadata: &'static Metadata<'static>) -> Interest {
+        Interest::sometimes()
+    }
+
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         // `Level` orders ERROR < WARN < INFO < DEBUG < TRACE, so an item is
         // enabled when its level is at or below the configured verbosity.
@@ -183,14 +189,55 @@ impl Subscriber for FilterCapture {
     }
 }
 
+/// Keep registration on tracing's synchronized registry path for all threads.
+///
+/// Each capture registers beside this retained dispatch, avoiding the
+/// single-dispatch fast path that consults only the registering thread's
+/// default subscriber. The guard is never installed as a default subscriber.
+static REGISTRY_GUARD: LazyLock<Dispatch> = LazyLock::new(|| Dispatch::new(DormantSubscriber));
+
+/// Disable tracing until the first capture has joined the shared registry.
+struct DormantSubscriber;
+
+impl Subscriber for DormantSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        false
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        // NoSubscriber alone reports no hint, enabling callsite registration
+        // while this guard is still the only dispatch in the registry.
+        Some(LevelFilter::OFF)
+    }
+
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        NoSubscriber::new().new_span(attrs)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, _event: &Event<'_>) {}
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
 /// Run `body` under a subscriber limited to `max_level` and return what it
 /// captured.
 ///
-/// Tests using this must run under `cargo nextest` (the project's test
-/// runner), which isolates each test in its own process. That isolation keeps
-/// tracing's process-global callsite `Interest` cache from being shared across
-/// tests that install different subscribers.
+/// `FilterCapture` returns `Interest::sometimes()` from `register_callsite`,
+/// so tracing re-evaluates `enabled()` for every event and span. A retained,
+/// dormant dispatch also makes registration consult tracing's synchronized
+/// registry rather than only the registering thread's default subscriber.
+/// Together these prevent the process-global callsite cache from retaining
+/// another capture's max-level verdict or an uncaptured thread's `never`.
+/// Correctness no longer depends on process isolation, although `cargo nextest`
+/// remains the project's test runner.
 pub(crate) fn capture(max_level: Level, body: impl FnOnce()) -> Captured {
+    let _ = LazyLock::force(&REGISTRY_GUARD);
     let state = Arc::new(Mutex::new(CaptureState::default()));
     let subscriber = FilterCapture {
         max_level,
@@ -206,7 +253,7 @@ pub(crate) fn capture(max_level: Level, body: impl FnOnce()) -> Captured {
 
 #[cfg(test)]
 mod tests {
-    //! Tests for the capture harness's own matchers.
+    //! Tests for capture isolation and the harness's own matchers.
     //!
     //! `event_matches` is what other modules assert their diagnostics with, so
     //! a predicate it quietly ignores would weaken every one of those tests at
@@ -215,6 +262,7 @@ mod tests {
 
     use rstest::rstest;
     use tracing::Level;
+    use tracing::callsite::Callsite;
 
     use super::capture;
 
@@ -223,6 +271,67 @@ mod tests {
         capture(Level::DEBUG, || {
             tracing::debug!(bytes_transferred = 0_u64, "probe event");
         })
+    }
+
+    #[rstest]
+    fn warn_capture_records_the_same_callsite_after_error_capture() {
+        let emit_warning = || tracing::warn!(attempt = 1_u64, "warning probe");
+
+        let error_capture = capture(Level::ERROR, emit_warning);
+        assert!(
+            error_capture.events.is_empty(),
+            "ERROR must filter out WARN"
+        );
+
+        let warn_capture = capture(Level::WARN, emit_warning);
+        assert!(
+            warn_capture.event_matches(Level::WARN, "warning probe", &[("attempt", "1")]),
+            "WARN must capture the warning after ERROR used the same callsite",
+        );
+    }
+
+    #[rstest]
+    fn warn_capture_records_callsite_first_seen_without_subscriber() {
+        let emit_warning = || tracing::warn!(attempt = 1_u64, "cross-thread warning probe");
+        let captured = capture(Level::WARN, || {
+            // The new thread has no default subscriber, but shares the
+            // process-global callsite with this thread's active capture.
+            let child_result = std::thread::spawn(emit_warning).join();
+            assert!(child_result.is_ok(), "the warning probe thread must finish");
+            emit_warning();
+        });
+        assert!(
+            captured.event_matches(
+                Level::WARN,
+                "cross-thread warning probe",
+                &[("attempt", "1")],
+            ),
+            "registration on an uncaptured thread must not disable this capture",
+        );
+        assert_eq!(captured.events.len(), 1, "only this thread is captured");
+    }
+
+    #[rstest]
+    #[case::disabled(Level::ERROR)]
+    #[case::enabled(Level::WARN)]
+    fn callsite_registration_keeps_level_filter_dynamic(#[case] max_level: Level) {
+        let callsite = tracing::callsite! {
+            name: "registration probe",
+            kind: tracing::metadata::Kind::EVENT,
+            level: Level::WARN,
+            fields:
+        };
+        capture(max_level, || {
+            let interest = tracing::dispatcher::get_default(|dispatch| {
+                dispatch.register_callsite(callsite.metadata())
+            });
+            // Dispatch creation rebuilds interest, so sequential captures alone
+            // cannot detect a stale registration overwriting a concurrent one.
+            assert!(
+                interest.is_sometimes(),
+                "registration must defer to each capture's enabled check",
+            );
+        });
     }
 
     #[rstest]

--- a/rust/cuprum-rust/src/tracing_capture.rs
+++ b/rust/cuprum-rust/src/tracing_capture.rs
@@ -126,16 +126,19 @@ fn lock(state: &Arc<Mutex<CaptureState>>) -> MutexGuard<'_, CaptureState> {
 }
 
 impl Subscriber for FilterCapture {
+    /// Request an `enabled` check for every event at this callsite.
     fn register_callsite(&self, _metadata: &'static Metadata<'static>) -> Interest {
         Interest::sometimes()
     }
 
+    /// Accept metadata at or below this capture's configured level.
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         // `Level` orders ERROR < WARN < INFO < DEBUG < TRACE, so an item is
         // enabled when its level is at or below the configured verbosity.
         *metadata.level() <= self.max_level
     }
 
+    /// Allocate a span identifier and retain its initial fields.
     fn new_span(&self, attrs: &Attributes<'_>) -> Id {
         let mut fields = BTreeMap::new();
         attrs.record(&mut FieldVisitor(&mut fields));
@@ -146,6 +149,7 @@ impl Subscriber for FilterCapture {
         Id::from_u64(id)
     }
 
+    /// Merge fields recorded after a span's creation into its retained state.
     fn record(&self, span: &Id, values: &Record<'_>) {
         let mut fields = BTreeMap::new();
         values.record(&mut FieldVisitor(&mut fields));
@@ -155,8 +159,10 @@ impl Subscriber for FilterCapture {
         }
     }
 
+    /// Ignore causal links because capture assertions inspect only active spans.
     fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
 
+    /// Record an event with its direct and active-span fields.
     fn event(&self, event: &Event<'_>) {
         let mut fields = {
             let state = lock(&self.state);
@@ -177,10 +183,12 @@ impl Subscriber for FilterCapture {
         });
     }
 
+    /// Add the entered span to the active context stack.
     fn enter(&self, span: &Id) {
         lock(&self.state).stack.push(span.into_u64());
     }
 
+    /// Remove the most recently entered matching span from the context stack.
     fn exit(&self, span: &Id) {
         let mut state = lock(&self.state);
         if let Some(pos) = state.stack.iter().rposition(|&id| id == span.into_u64()) {
@@ -200,28 +208,36 @@ static REGISTRY_GUARD: LazyLock<Dispatch> = LazyLock::new(|| Dispatch::new(Dorma
 struct DormantSubscriber;
 
 impl Subscriber for DormantSubscriber {
+    /// Keep the retained guard dormant so it never receives events.
     fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
         false
     }
 
+    /// Disable callsites while this is the registry's only dispatch.
     fn max_level_hint(&self) -> Option<LevelFilter> {
         // NoSubscriber alone reports no hint, enabling callsite registration
         // while this guard is still the only dispatch in the registry.
         Some(LevelFilter::OFF)
     }
 
+    /// Produce inert span identifiers because the guard retains no span state.
     fn new_span(&self, attrs: &Attributes<'_>) -> Id {
         NoSubscriber::new().new_span(attrs)
     }
 
+    /// Ignore records because the dormant guard retains no span state.
     fn record(&self, _span: &Id, _values: &Record<'_>) {}
 
+    /// Ignore causal links because the dormant guard retains no span state.
     fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
 
+    /// Discard events because the retained guard is never a test capture.
     fn event(&self, _event: &Event<'_>) {}
 
+    /// Ignore span entry because the dormant guard retains no context.
     fn enter(&self, _span: &Id) {}
 
+    /// Ignore span exit because the dormant guard retains no context.
     fn exit(&self, _span: &Id) {}
 }
 
@@ -252,114 +268,5 @@ pub(crate) fn capture(max_level: Level, body: impl FnOnce()) -> Captured {
 }
 
 #[cfg(test)]
-mod tests {
-    //! Tests for capture isolation and the harness's own matchers.
-    //!
-    //! `event_matches` is what other modules assert their diagnostics with, so
-    //! a predicate it quietly ignores would weaken every one of those tests at
-    //! once. The negative cases below vary exactly one of level, message, and
-    //! field value, so no single dropped predicate can pass them all.
-
-    use rstest::rstest;
-    use tracing::Level;
-    use tracing::callsite::Callsite;
-
-    use super::capture;
-
-    /// Emit one known event and return what the harness captured.
-    fn captured_probe() -> super::Captured {
-        capture(Level::DEBUG, || {
-            tracing::debug!(bytes_transferred = 0_u64, "probe event");
-        })
-    }
-
-    #[rstest]
-    fn warn_capture_records_the_same_callsite_after_error_capture() {
-        let emit_warning = || tracing::warn!(attempt = 1_u64, "warning probe");
-
-        let error_capture = capture(Level::ERROR, emit_warning);
-        assert!(
-            error_capture.events.is_empty(),
-            "ERROR must filter out WARN"
-        );
-
-        let warn_capture = capture(Level::WARN, emit_warning);
-        assert!(
-            warn_capture.event_matches(Level::WARN, "warning probe", &[("attempt", "1")]),
-            "WARN must capture the warning after ERROR used the same callsite",
-        );
-    }
-
-    #[rstest]
-    fn warn_capture_records_callsite_first_seen_without_subscriber() {
-        let emit_warning = || tracing::warn!(attempt = 1_u64, "cross-thread warning probe");
-        let captured = capture(Level::WARN, || {
-            // The new thread has no default subscriber, but shares the
-            // process-global callsite with this thread's active capture.
-            let child_result = std::thread::spawn(emit_warning).join();
-            assert!(child_result.is_ok(), "the warning probe thread must finish");
-            emit_warning();
-        });
-        assert!(
-            captured.event_matches(
-                Level::WARN,
-                "cross-thread warning probe",
-                &[("attempt", "1")],
-            ),
-            "registration on an uncaptured thread must not disable this capture",
-        );
-        assert_eq!(captured.events.len(), 1, "only this thread is captured");
-    }
-
-    #[rstest]
-    #[case::disabled(Level::ERROR)]
-    #[case::enabled(Level::WARN)]
-    fn callsite_registration_keeps_level_filter_dynamic(#[case] max_level: Level) {
-        let callsite = tracing::callsite! {
-            name: "registration probe",
-            kind: tracing::metadata::Kind::EVENT,
-            level: Level::WARN,
-            fields:
-        };
-        capture(max_level, || {
-            let interest = tracing::dispatcher::get_default(|dispatch| {
-                dispatch.register_callsite(callsite.metadata())
-            });
-            // Dispatch creation rebuilds interest, so sequential captures alone
-            // cannot detect a stale registration overwriting a concurrent one.
-            assert!(
-                interest.is_sometimes(),
-                "registration must defer to each capture's enabled check",
-            );
-        });
-    }
-
-    #[rstest]
-    fn event_matches_accepts_the_exact_event() {
-        assert!(
-            captured_probe().event_matches(
-                Level::DEBUG,
-                "probe event",
-                &[("bytes_transferred", "0")],
-            ),
-            "the event that fired must match its own level, message, and fields",
-        );
-    }
-
-    #[rstest]
-    #[case::wrong_level(Level::WARN, "probe event", "bytes_transferred", "0")]
-    #[case::wrong_message(Level::DEBUG, "a different event", "bytes_transferred", "0")]
-    #[case::wrong_value(Level::DEBUG, "probe event", "bytes_transferred", "1")]
-    #[case::absent_field(Level::DEBUG, "probe event", "no_such_field", "0")]
-    fn event_matches_rejects_a_single_mismatch(
-        #[case] level: Level,
-        #[case] message: &str,
-        #[case] field: &str,
-        #[case] value: &str,
-    ) {
-        assert!(
-            !captured_probe().event_matches(level, message, &[(field, value)]),
-            "event_matches must require every predicate, not just some",
-        );
-    }
-}
+#[path = "tracing_capture_tests.rs"]
+mod tests;

--- a/rust/cuprum-rust/src/tracing_capture_tests.rs
+++ b/rust/cuprum-rust/src/tracing_capture_tests.rs
@@ -1,0 +1,183 @@
+//! Tests for capture isolation and the harness's own matchers.
+//!
+//! `event_matches` is what other modules assert their diagnostics with, so a
+//! predicate it quietly ignores would weaken every one of those tests at once.
+//! The negative cases vary exactly one predicate, while the property below
+//! generates registration histories around one shared warning callsite.
+
+use proptest::prelude::*;
+use rstest::rstest;
+use tracing::Level;
+use tracing::callsite::Callsite;
+
+use super::{Captured, capture};
+
+/// Emit one known event and return what the harness captured.
+fn captured_probe() -> Captured {
+    capture(Level::DEBUG, || {
+        tracing::debug!(bytes_transferred = 0_u64, "probe event");
+    })
+}
+
+/// Emit the shared warning callsite used to vary registration histories.
+fn emit_registration_probe(is_parent: bool, sequence: u16) {
+    tracing::warn!(
+        is_parent,
+        sequence = u64::from(sequence),
+        "registration probe"
+    );
+}
+
+/// Let a child emit with either its default subscriber or its own capture.
+fn run_child_capture(is_captured: bool, max_level: Level, sequence: u16) -> bool {
+    std::thread::spawn(move || {
+        if is_captured {
+            let _ = capture(max_level, || emit_registration_probe(false, sequence));
+        } else {
+            emit_registration_probe(false, sequence);
+        }
+    })
+    .join()
+    .is_ok()
+}
+
+/// Preserve WARN capture after the same callsite was filtered at ERROR.
+#[rstest]
+fn warn_capture_records_the_same_callsite_after_error_capture() {
+    let emit_warning = || tracing::warn!(attempt = 1_u64, "warning probe");
+
+    let error_capture = capture(Level::ERROR, emit_warning);
+    assert!(
+        error_capture.events.is_empty(),
+        "ERROR must filter out WARN"
+    );
+
+    let warn_capture = capture(Level::WARN, emit_warning);
+    assert!(
+        warn_capture.event_matches(Level::WARN, "warning probe", &[("attempt", "1")]),
+        "WARN must capture the warning after ERROR used the same callsite",
+    );
+}
+
+/// Preserve a parent capture after an uncaptured child first uses its callsite.
+#[rstest]
+fn warn_capture_records_callsite_first_seen_without_subscriber() {
+    let emit_warning = || tracing::warn!(attempt = 1_u64, "cross-thread warning probe");
+    let captured = capture(Level::WARN, || {
+        // The new thread has no default subscriber, but shares the
+        // process-global callsite with this thread's active capture.
+        let child_result = std::thread::spawn(emit_warning).join();
+        assert!(child_result.is_ok(), "the warning probe thread must finish");
+        emit_warning();
+    });
+    assert!(
+        captured.event_matches(
+            Level::WARN,
+            "cross-thread warning probe",
+            &[("attempt", "1")],
+        ),
+        "registration on an uncaptured thread must not disable this capture",
+    );
+    assert_eq!(captured.events.len(), 1, "only this thread is captured");
+}
+
+proptest! {
+    /// Preserve every parent warning through generated child registration histories.
+    #[test]
+    fn generated_registration_histories_preserve_parent_capture(
+        parent_max_level in prop_oneof![Just(Level::ERROR), Just(Level::WARN)],
+        history in prop::collection::vec(
+            (
+                any::<bool>(),
+                any::<bool>(),
+                prop_oneof![Just(Level::ERROR), Just(Level::WARN)],
+                any::<u16>(),
+            ),
+            1..5,
+        ),
+    ) {
+        let mut children_finished = true;
+        let captured = capture(parent_max_level, || {
+            for (child_first, child_is_captured, child_max_level, sequence) in &history {
+                if *child_first {
+                    children_finished &=
+                        run_child_capture(*child_is_captured, *child_max_level, *sequence);
+                }
+                emit_registration_probe(true, *sequence);
+                if !child_first {
+                    children_finished &=
+                        run_child_capture(*child_is_captured, *child_max_level, *sequence);
+                }
+            }
+        });
+
+        prop_assert!(children_finished, "each generated child must finish");
+        let expected_events = if parent_max_level == Level::WARN {
+            history.len()
+        } else {
+            0
+        };
+        prop_assert_eq!(captured.events.len(), expected_events);
+        if parent_max_level == Level::WARN {
+            for (_, _, _, sequence) in history {
+                let sequence_text = sequence.to_string();
+                prop_assert!(captured.event_matches(
+                    Level::WARN,
+                    "registration probe",
+                    &[("is_parent", "true"), ("sequence", sequence_text.as_str())],
+                ));
+            }
+        }
+    }
+}
+
+/// Require registration to defer level filtering to each active capture.
+#[rstest]
+#[case::disabled(Level::ERROR)]
+#[case::enabled(Level::WARN)]
+fn callsite_registration_keeps_level_filter_dynamic(#[case] max_level: Level) {
+    let callsite = tracing::callsite! {
+        name: "registration probe",
+        kind: tracing::metadata::Kind::EVENT,
+        level: Level::WARN,
+        fields:
+    };
+    capture(max_level, || {
+        let interest = tracing::dispatcher::get_default(|dispatch| {
+            dispatch.register_callsite(callsite.metadata())
+        });
+        // Dispatch creation rebuilds interest, so sequential captures alone
+        // cannot detect a stale registration overwriting a concurrent one.
+        assert!(
+            interest.is_sometimes(),
+            "registration must defer to each capture's enabled check",
+        );
+    });
+}
+
+/// Accept an event whose level, message, and fields all match.
+#[rstest]
+fn event_matches_accepts_the_exact_event() {
+    assert!(
+        captured_probe().event_matches(Level::DEBUG, "probe event", &[("bytes_transferred", "0")],),
+        "the event that fired must match its own level, message, and fields",
+    );
+}
+
+/// Reject an event when any one matching predicate differs.
+#[rstest]
+#[case::wrong_level(Level::WARN, "probe event", "bytes_transferred", "0")]
+#[case::wrong_message(Level::DEBUG, "a different event", "bytes_transferred", "0")]
+#[case::wrong_value(Level::DEBUG, "probe event", "bytes_transferred", "1")]
+#[case::absent_field(Level::DEBUG, "probe event", "no_such_field", "0")]
+fn event_matches_rejects_a_single_mismatch(
+    #[case] level: Level,
+    #[case] message: &str,
+    #[case] field: &str,
+    #[case] value: &str,
+) {
+    assert!(
+        !captured_probe().event_matches(level, message, &[(field, value)]),
+        "event_matches must require every predicate, not just some",
+    );
+}


### PR DESCRIPTION
## Summary

Parallel tracing captures now consult the active capture's level even when a
shared callsite is first used on a thread without a subscriber. The harness
returns `Interest::sometimes()` and retains a dormant dispatch to keep callsite
registration on tracing-core's synchronized registry path.

Closes #366.

The planned interest override alone was insufficient: stress testing still
failed the original EINTR warning assertion. Tracing-core's single-dispatch
fast path can consult an uncaptured thread's default subscriber and cache
`never`, bypassing the capture's override entirely. The dormant dispatch closes
that gap. It reports `LevelFilter::OFF` during initialization and is never
installed as a thread-local or global default.

## Review walkthrough

- [Capture harness and regression tests](https://github.com/leynos/cuprum/blob/issue-366-stabilise-parallel-tracing-assertion-for-eintr-warning/rust/cuprum-rust/src/tracing_capture.rs#L129)
  contain dynamic interest, the ERROR-then-WARN check and a deterministic
  cross-thread regression. The latter joins an uncaptured child that first
  emits a warning, then requires exactly the parent's warning at the same
  callsite. It fails without the registry guard and passes with it.
- [Private registry guard](https://github.com/leynos/cuprum/blob/issue-366-stabilise-parallel-tracing-assertion-for-eintr-warning/rust/cuprum-rust/src/tracing_capture.rs#L192)
  retains one dormant dispatch so every capture registers beside another live
  dispatch. Its OFF hint prevents callsite registration during initialization.
- [Developer guidance](https://github.com/leynos/cuprum/blob/issue-366-stabilise-parallel-tracing-assertion-for-eintr-warning/docs/developers-guide.md#L2793)
  documents the guard's scope and why correctness no longer depends on nextest
  process isolation.
- [Investigation record](https://github.com/leynos/cuprum/blob/issue-366-stabilise-parallel-tracing-assertion-for-eintr-warning/docs/debugging/debugging-plan-20260907-tracing-interest-race.md#L1)
  records the hypothesis and deterministic before/after experiment.

Existing I/O assertions, the `enabled()` predicate, production tracing and
all dependency manifests are unchanged. The Namespace runner rollout remains
outside this change.

## Validation

- `make check-fmt`, `make lint`, `make typecheck`, `make test`,
  `make markdownlint` and `make nixie`: passed on the final layout.
- Nextest: 109 tests passed, including generated registration histories over
  capture levels, child subscription states, registration orderings and
  reused event sequences.
- Five complete plain `cargo test -p cuprum-rust` runs: all passed.
- `RUSTFLAGS='-D warnings' cargo test -p cuprum-rust`: passed.
- Final focused I/O suite: 20 six-thread repetitions passed. Earlier guard
  verification passed all 235 focused repetitions and had zero tracing failures
  across 235 full-library repetitions. Three full-library runs hit the known
  unrelated descriptor-close assertion.
- Deterministic regression: fails with the interest override alone and passes
  with the dormant dispatch; captures exactly the parent event. The generated
  property also fails when dynamic callsite interest is deliberately replaced
  with `Interest::never()`.
- `coderabbit review --agent`: completed with zero findings.

## Reproduction notes

The unchanged baseline passed 30 complete plain Cargo runs but lost DEBUG
read events in three of 235 six-thread unit-suite repetitions; the isolated
tracing tests passed. With only the proposed interest override, a later stress
run reproduced the original WARN failure twice and the DEBUG failure once.
The new cross-thread regression then reproduced the missing warning
deterministically and passed after adding the dormant dispatch.

Separate descriptor-close assertion failures appeared in the unchanged
baseline and in the guard stress run. They are outside this tracing-only fix;
the five final-layout full Cargo runs and all required Makefile gates passed.

## Summary by Sourcery

Stabilize parallel tracing captures so active subscribers consistently receive events across threads.

Bug Fixes:
- Prevent parallel tracing captures from losing events when a shared callsite is first registered on a thread without a subscriber.

Enhancements:
- Make capture interest dynamic so each event is evaluated against the active capture level.
- Stabilize tracing callsite registration across threads with a dormant registry guard and remove reliance on process isolation.
- Expand tracing capture coverage with deterministic cross-thread regressions and generated registration-history tests.

Documentation:
- Document the tracing capture safeguards, their scope, and the investigation into cross-thread interest races.

Tests:
- Add regression and property-based tests covering cross-thread callsite registration, capture levels, subscriber states, and event isolation.

## References

[Lody session](https://lody.ai/leynos/sessions/443fa357-dbcc-4964-a68e-d2c488eb2811)