### PR TITLE
Propagate Rust test setup failures

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2533,6 +2533,18 @@ The splice behavioural tests expose that shared `make_pipe` as an rstest `pipe`
 fixture, so scenarios needing several independent pipes inject it once per
 `#[from(pipe)]` parameter.
 
+### Fallible Rust test I/O
+
+The Unix-only `test_support` helpers `make_pipe`, `dup_as_file`,
+`write_all_to`, and `read_all_from` return `io::Result` values. They preserve
+operating-system errors from pipe creation, descriptor duplication, reads, and
+writes. Fixtures in `io_utils/tests.rs`, `lib_tests.rs`, and `splice/tests.rs`
+pass those results into recognized test bodies, which use
+`test_support::unwrap_ok` at the assertion boundary under the current lint
+configuration. Keep this error propagation intact when adding descriptor-backed
+tests. Keep the sibling `test_support_tests.rs` errno assertion local to this
+descriptor contract; it is not a general assertion framework.
+
 ## Rust property testing and verification
 
 Rust-level tests for `cuprum-rust` live with the crate under

--- a/rust/cuprum-rust/src/consume_snapshot_tests.rs
+++ b/rust/cuprum-rust/src/consume_snapshot_tests.rs
@@ -20,6 +20,7 @@
 //! Each case feeds a fixed payload through a real pipe, so the decode is driven
 //! by actual descriptor reads rather than a synthetic byte buffer.
 
+use crate::errors::PumpError;
 use crate::test_support::{make_pipe, write_all_to};
 use crate::{BufferSize, consume_stream_files};
 
@@ -29,22 +30,19 @@ use crate::{BufferSize, consume_stream_files};
 /// The whole payload is written and the write end closed before decoding, so
 /// the loop reads the buffered bytes and then observes EOF. Payloads must stay
 /// well within a pipe's capacity so the unbuffered write never blocks.
-fn consume(payload: &[u8], buffer_size: usize) -> String {
-    let (read_end, write_end) = make_pipe();
-    write_all_to(&write_end, payload);
+fn consume(payload: &[u8], buffer_size: usize) -> Result<String, PumpError> {
+    let (read_end, write_end) = make_pipe()?;
+    write_all_to(&write_end, payload)?;
     // Close the write end so the read loop reaches EOF and terminates.
     drop(write_end);
 
     let mut reader = read_end;
-    match consume_stream_files(&mut reader, BufferSize(buffer_size)) {
-        Ok(text) => text,
-        Err(err) => panic!("consume over a closed pipe failed: {err:?}"),
-    }
+    consume_stream_files(&mut reader, BufferSize(buffer_size))
 }
 
 #[test]
 fn pure_ascii_decodes_verbatim() {
-    let output = consume(b"cuprum reads pipes", 64);
+    let output = crate::test_support::unwrap_ok(consume(b"cuprum reads pipes", 64));
     insta::assert_snapshot!(output, @"cuprum reads pipes");
 }
 
@@ -53,18 +51,18 @@ fn multibyte_sequences_split_across_buffer_boundaries() {
     // Each non-ASCII scalar is 2-3 bytes, so a one-byte buffer forces every
     // multi-byte sequence to straddle at least one read boundary.
     let payload = "héllo, 世界! ☕".as_bytes();
-    let byte_at_a_time = consume(payload, 1);
+    let byte_at_a_time = crate::test_support::unwrap_ok(consume(payload, 1));
 
     // The decode must be independent of where the buffer boundaries fall: a
     // one-byte, three-byte, and whole-payload buffer all yield the same text.
     assert_eq!(
         byte_at_a_time,
-        consume(payload, 3),
+        crate::test_support::unwrap_ok(consume(payload, 3)),
         "a three-byte buffer must decode identically to a one-byte buffer",
     );
     assert_eq!(
         byte_at_a_time,
-        consume(payload, 64),
+        crate::test_support::unwrap_ok(consume(payload, 64)),
         "a whole-payload buffer must decode identically to a one-byte buffer",
     );
 
@@ -76,16 +74,16 @@ fn invalid_bytes_become_replacement_characters() {
     // 0xFF is never a valid lead byte and 0x80 is a lone continuation byte;
     // each is replaced with a single U+FFFD, independent of the buffer size.
     let payload = b"x\xffy\x80z";
-    let byte_at_a_time = consume(payload, 1);
+    let byte_at_a_time = crate::test_support::unwrap_ok(consume(payload, 1));
 
     assert_eq!(
         byte_at_a_time,
-        consume(payload, 3),
+        crate::test_support::unwrap_ok(consume(payload, 3)),
         "a three-byte buffer must decode identically to a one-byte buffer",
     );
     assert_eq!(
         byte_at_a_time,
-        consume(payload, 64),
+        crate::test_support::unwrap_ok(consume(payload, 64)),
         "invalid-byte replacement must not depend on the buffer size",
     );
 
@@ -98,16 +96,16 @@ fn incomplete_trailing_sequence_is_replaced_at_eof() {
     // three-byte sequence that must resolve to a single U+FFFD once EOF marks
     // the final chunk, rather than being silently dropped.
     let payload = b"euro sign: \xe2\x82";
-    let byte_at_a_time = consume(payload, 1);
+    let byte_at_a_time = crate::test_support::unwrap_ok(consume(payload, 1));
 
     assert_eq!(
         byte_at_a_time,
-        consume(payload, 3),
+        crate::test_support::unwrap_ok(consume(payload, 3)),
         "a three-byte buffer must decode identically to a one-byte buffer",
     );
     assert_eq!(
         byte_at_a_time,
-        consume(payload, 64),
+        crate::test_support::unwrap_ok(consume(payload, 64)),
         "EOF replacement of an incomplete tail must not depend on the buffer size",
     );
 
@@ -145,7 +143,7 @@ mod properties {
         ) {
             let expected = String::from_utf8_lossy(&payload);
             prop_assert_eq!(
-                consume(&payload, buffer_size),
+                crate::test_support::unwrap_ok(consume(&payload, buffer_size)),
                 expected.into_owned(),
                 "the read loop must decode identically to from_utf8_lossy",
             );
@@ -164,8 +162,8 @@ mod properties {
         ) {
             prop_assume!(first != second);
             prop_assert_eq!(
-                consume(&payload, first),
-                consume(&payload, second),
+                crate::test_support::unwrap_ok(consume(&payload, first)),
+                crate::test_support::unwrap_ok(consume(&payload, second)),
                 "two buffer sizes must split the same payload to the same text",
             );
         }

--- a/rust/cuprum-rust/src/consume_snapshot_tests.rs
+++ b/rust/cuprum-rust/src/consume_snapshot_tests.rs
@@ -40,12 +40,14 @@ fn consume(payload: &[u8], buffer_size: usize) -> Result<String, PumpError> {
     consume_stream_files(&mut reader, BufferSize(buffer_size))
 }
 
+/// ASCII payloads pass through the pipe and decoder without transformation.
 #[test]
 fn pure_ascii_decodes_verbatim() {
     let output = crate::test_support::unwrap_ok(consume(b"cuprum reads pipes", 64));
     insta::assert_snapshot!(output, @"cuprum reads pipes");
 }
 
+/// Multi-byte UTF-8 remains intact when every byte arrives in a separate read.
 #[test]
 fn multibyte_sequences_split_across_buffer_boundaries() {
     // Each non-ASCII scalar is 2-3 bytes, so a one-byte buffer forces every
@@ -69,6 +71,7 @@ fn multibyte_sequences_split_across_buffer_boundaries() {
     insta::assert_snapshot!(byte_at_a_time, @"héllo, 世界! ☕");
 }
 
+/// Invalid lead and continuation bytes each become one replacement character.
 #[test]
 fn invalid_bytes_become_replacement_characters() {
     // 0xFF is never a valid lead byte and 0x80 is a lone continuation byte;
@@ -90,6 +93,7 @@ fn invalid_bytes_become_replacement_characters() {
     insta::assert_snapshot!(byte_at_a_time, @"x�y�z");
 }
 
+/// An incomplete UTF-8 sequence is replaced when the final read reaches EOF.
 #[test]
 fn incomplete_trailing_sequence_is_replaced_at_eof() {
     // The euro sign is E2 82 AC; dropping the final byte leaves an incomplete

--- a/rust/cuprum-rust/src/io_utils/tests.rs
+++ b/rust/cuprum-rust/src/io_utils/tests.rs
@@ -17,7 +17,7 @@ use rstest::{fixture, rstest};
 /// tests, so the shared setup lives in one place rather than a repeated
 /// `make_pipe()` call per test.
 #[fixture]
-fn pipe() -> (OwnedFd, OwnedFd) {
+fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     make_pipe()
 }
 
@@ -46,9 +46,9 @@ fn ssize(len: usize) -> libc::ssize_t {
 }
 
 #[rstest]
-fn read_stream_reads_pipe_bytes(pipe: (OwnedFd, OwnedFd)) {
-    let (mut read_end, write_end) = pipe;
-    write_all_to(&write_end, b"chunk");
+fn read_stream_reads_pipe_bytes(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
+    let (mut read_end, write_end) = unwrap_ok(pipe);
+    unwrap_ok(write_all_to(&write_end, b"chunk"));
     drop(write_end);
     let mut buffer = [0_u8; 8];
 
@@ -59,8 +59,8 @@ fn read_stream_reads_pipe_bytes(pipe: (OwnedFd, OwnedFd)) {
 }
 
 #[rstest]
-fn read_stream_reports_unreadable_descriptor(pipe: (OwnedFd, OwnedFd)) {
-    let (_read_end, mut write_end) = pipe;
+fn read_stream_reports_unreadable_descriptor(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
+    let (_read_end, mut write_end) = unwrap_ok(pipe);
     let mut buffer = [0_u8; 8];
 
     let err = unwrap_err(read_stream(&mut write_end, &mut buffer));
@@ -69,8 +69,8 @@ fn read_stream_reports_unreadable_descriptor(pipe: (OwnedFd, OwnedFd)) {
 }
 
 #[rstest]
-fn read_raw_fd_reports_eof(pipe: (OwnedFd, OwnedFd)) {
-    let (read_end, write_end) = pipe;
+fn read_raw_fd_reports_eof(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
+    let (read_end, write_end) = unwrap_ok(pipe);
     drop(write_end);
     let mut buffer = [0_u8; 8];
 
@@ -96,8 +96,8 @@ fn read_raw_fd_retries_after_interruption() {
 }
 
 #[rstest]
-fn handle_write_returns_complete_outcome(pipe: (OwnedFd, OwnedFd)) {
-    let (read_end, mut write_end) = pipe;
+fn handle_write_returns_complete_outcome(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
+    let (read_end, mut write_end) = unwrap_ok(pipe);
 
     let outcome = unwrap_ok(handle_write(&mut write_end, b"chunk"));
 
@@ -106,8 +106,8 @@ fn handle_write_returns_complete_outcome(pipe: (OwnedFd, OwnedFd)) {
 }
 
 #[rstest]
-fn handle_write_reports_unwritable_descriptor(pipe: (OwnedFd, OwnedFd)) {
-    let (mut read_end, _write_end) = pipe;
+fn handle_write_reports_unwritable_descriptor(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
+    let (mut read_end, _write_end) = unwrap_ok(pipe);
 
     let err = unwrap_err(handle_write(&mut read_end, b"chunk"));
 

--- a/rust/cuprum-rust/src/io_utils/tests.rs
+++ b/rust/cuprum-rust/src/io_utils/tests.rs
@@ -45,6 +45,7 @@ fn ssize(len: usize) -> libc::ssize_t {
     libc::ssize_t::try_from(len).unwrap_or(libc::ssize_t::MAX)
 }
 
+/// Reading from a pipe copies the complete payload into the supplied buffer.
 #[rstest]
 fn read_stream_reads_pipe_bytes(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
     let (mut read_end, write_end) = unwrap_ok(pipe);
@@ -58,6 +59,7 @@ fn read_stream_reads_pipe_bytes(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd
     assert_eq!(buffer.get(..read_len), Some(&b"chunk"[..]));
 }
 
+/// Passing a pipe's write end to the reader reports the underlying I/O error.
 #[rstest]
 fn read_stream_reports_unreadable_descriptor(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
     let (_read_end, mut write_end) = unwrap_ok(pipe);
@@ -68,6 +70,7 @@ fn read_stream_reports_unreadable_descriptor(#[from(pipe)] pipe: io::Result<(Own
     assert!(matches!(err, PumpError::Io(_)));
 }
 
+/// A closed pipe writer is surfaced as a zero-byte read at EOF.
 #[rstest]
 fn read_raw_fd_reports_eof(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
     let (read_end, write_end) = unwrap_ok(pipe);
@@ -95,6 +98,7 @@ fn read_raw_fd_retries_after_interruption() {
     assert_eq!(attempts, 2);
 }
 
+/// Writing to an open pipe reports a complete write with its byte count.
 #[rstest]
 fn handle_write_returns_complete_outcome(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
     let (read_end, mut write_end) = unwrap_ok(pipe);
@@ -105,6 +109,7 @@ fn handle_write_returns_complete_outcome(#[from(pipe)] pipe: io::Result<(OwnedFd
     drop(read_end);
 }
 
+/// Passing a pipe's read end to the writer propagates the fatal I/O error.
 #[rstest]
 fn handle_write_reports_unwritable_descriptor(#[from(pipe)] pipe: io::Result<(OwnedFd, OwnedFd)>) {
     let (mut read_end, _write_end) = unwrap_ok(pipe);

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for the borrowed file-descriptor ownership contract.
 
-use std::io::Read;
+use std::io::{self, Read};
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -28,34 +28,39 @@ enum BorrowedReaderScenario {
 }
 
 #[fixture]
-fn borrowed_reader_pipe() -> BorrowedReaderPipe {
-    let (read_end, write_end) = make_pipe();
+fn borrowed_reader_pipe() -> io::Result<BorrowedReaderPipe> {
+    let (read_end, write_end) = make_pipe()?;
     let raw_fd = read_end.as_raw_fd();
 
-    BorrowedReaderPipe {
+    Ok(BorrowedReaderPipe {
         read_end,
         write_end,
         raw_fd,
-    }
+    })
 }
 
 #[rstest]
 #[case::panicking_operation(BorrowedReaderScenario::Panic)]
 #[case::successful_operation(BorrowedReaderScenario::Success)]
 fn borrowed_reader_stays_open_after_operation(
-    borrowed_reader_pipe: BorrowedReaderPipe,
+    #[from(borrowed_reader_pipe)] borrowed_reader_pipe_result: io::Result<BorrowedReaderPipe>,
     #[case] scenario: BorrowedReaderScenario,
 ) {
     let BorrowedReaderPipe {
         read_end,
         write_end,
         raw_fd,
-    } = borrowed_reader_pipe;
+    } = crate::test_support::unwrap_ok(borrowed_reader_pipe_result);
 
     match scenario {
         BorrowedReaderScenario::Panic => assert_panicking_reader_keeps_fd_open(raw_fd),
         BorrowedReaderScenario::Success => {
-            assert_successful_reader_keeps_fd_usable(raw_fd, write_end);
+            let collected =
+                crate::test_support::unwrap_ok(successful_reader_bytes(raw_fd, write_end));
+            assert_eq!(
+                collected, b"ping",
+                "the borrowed reader must retain the pipe bytes",
+            );
         }
     }
 
@@ -65,8 +70,8 @@ fn borrowed_reader_stays_open_after_operation(
 
 #[rstest]
 fn stream_from_raw_owns_and_reads_the_descriptor() {
-    let (read_end, write_end) = make_pipe();
-    write_all_to(&write_end, b"pong");
+    let (read_end, write_end) = crate::test_support::unwrap_ok(make_pipe());
+    crate::test_support::unwrap_ok(write_all_to(&write_end, b"pong"));
     drop(write_end);
 
     // Transfer ownership of the read descriptor into the constructed handle
@@ -88,9 +93,9 @@ fn stream_from_raw_owns_and_reads_the_descriptor() {
 
 #[rstest]
 fn consume_records_total_bytes_and_retries_on_span() {
-    let (read_end, write_end) = make_pipe();
+    let (read_end, write_end) = crate::test_support::unwrap_ok(make_pipe());
     let payload = b"boundary-check-payload";
-    write_all_to(&write_end, payload);
+    crate::test_support::unwrap_ok(write_all_to(&write_end, payload));
     // Close the write end so the read loop reaches EOF and terminates.
     drop(write_end);
 
@@ -124,10 +129,10 @@ fn consume_records_total_bytes_and_retries_on_span() {
 #[rstest]
 fn pump_records_span_fields_under_error_filter() {
     // Source pipe: the payload the pump reads. Sink pipe: where it writes.
-    let (source_read, source_write) = make_pipe();
-    let (sink_read, sink_write) = make_pipe();
+    let (source_read, source_write) = crate::test_support::unwrap_ok(make_pipe());
+    let (sink_read, sink_write) = crate::test_support::unwrap_ok(make_pipe());
     let payload = b"pump-span-check";
-    write_all_to(&source_write, payload);
+    crate::test_support::unwrap_ok(write_all_to(&source_write, payload));
     // Close the source's write end so the read loop reaches EOF.
     drop(source_write);
 
@@ -142,8 +147,9 @@ fn pump_records_span_fields_under_error_filter() {
     // Close the write end, then confirm the sink received exactly the source
     // payload — a data oracle so same-length corruption cannot pass.
     drop(writer);
+    let received = crate::test_support::unwrap_ok(read_all_from(&sink_read));
     assert_eq!(
-        read_all_from(&sink_read).as_slice(),
+        received.as_slice(),
         &payload[..],
         "the pump must deliver the source bytes unchanged to the sink",
     );
@@ -186,7 +192,7 @@ fn assert_panicking_reader_keeps_fd_open(raw_fd: i32) {
 
 #[rstest]
 fn classify_write_reports_a_completed_write() {
-    let (read_end, mut write_end) = make_pipe();
+    let (read_end, mut write_end) = crate::test_support::unwrap_ok(make_pipe());
 
     let event = match classify_write(&mut write_end, b"chunk") {
         Ok(event) => event,
@@ -202,7 +208,7 @@ fn classify_write_reports_a_completed_write() {
 fn classify_write_propagates_a_fatal_error() {
     // Writing to the read end of a pipe is a fatal `EBADF`, which must
     // propagate rather than latch the writer closed.
-    let (mut read_end, _write_end) = make_pipe();
+    let (mut read_end, _write_end) = crate::test_support::unwrap_ok(make_pipe());
 
     match classify_write(&mut read_end, b"chunk") {
         Ok(event) => panic!("expected a fatal write error, got {event:?}"),
@@ -210,23 +216,18 @@ fn classify_write_propagates_a_fatal_error() {
     }
 }
 
-fn assert_successful_reader_keeps_fd_usable(raw_fd: i32, write_end: OwnedFd) {
-    write_all_to(&write_end, b"ping");
+fn successful_reader_bytes(raw_fd: i32, write_end: OwnedFd) -> io::Result<Vec<u8>> {
+    write_all_to(&write_end, b"ping")?;
     drop(write_end);
 
-    let collected = with_borrowed_reader(raw_fd, |reader| {
+    with_borrowed_reader(raw_fd, |reader| {
         // SAFETY: reading through the borrowed handle's raw descriptor.
         let mut file =
             unsafe { std::mem::ManuallyDrop::new(std::fs::File::from_raw_fd(reader.as_raw_fd())) };
         let mut data = Vec::new();
-        match file.read_to_end(&mut data) {
-            Ok(_) => {}
-            Err(err) => panic!("pipe read failed: {err}"),
-        }
-        data
-    });
-
-    assert_eq!(collected, b"ping");
+        file.read_to_end(&mut data)?;
+        Ok(data)
+    })
 }
 
 #[rstest]
@@ -235,10 +236,10 @@ fn pump_drains_the_reader_after_the_writer_breaks() {
     // the real-world `head`-style early exit. The loop must latch the writer
     // closed, keep draining the upstream reader to EOF, and report success
     // with the bytes that actually reached the sink — none, here.
-    let (source_read, source_write) = make_pipe();
-    let (sink_read, sink_write) = make_pipe();
+    let (source_read, source_write) = crate::test_support::unwrap_ok(make_pipe());
+    let (sink_read, sink_write) = crate::test_support::unwrap_ok(make_pipe());
     let payload = b"payload-written-after-the-downstream-hangs-up";
-    write_all_to(&source_write, payload);
+    crate::test_support::unwrap_ok(write_all_to(&source_write, payload));
     // Close the source's write end so the read loop can reach EOF.
     drop(source_write);
     // Close the sink's read end so every write fails with a broken pipe.

--- a/rust/cuprum-rust/src/lib_tests.rs
+++ b/rust/cuprum-rust/src/lib_tests.rs
@@ -27,6 +27,7 @@ enum BorrowedReaderScenario {
     Success,
 }
 
+/// Builds a pipe whose read descriptor can be borrowed across an operation.
 #[fixture]
 fn borrowed_reader_pipe() -> io::Result<BorrowedReaderPipe> {
     let (read_end, write_end) = make_pipe()?;
@@ -39,6 +40,7 @@ fn borrowed_reader_pipe() -> io::Result<BorrowedReaderPipe> {
     })
 }
 
+/// A borrowed reader keeps its descriptor open after success or panic.
 #[rstest]
 #[case::panicking_operation(BorrowedReaderScenario::Panic)]
 #[case::successful_operation(BorrowedReaderScenario::Success)]
@@ -68,6 +70,7 @@ fn borrowed_reader_stays_open_after_operation(
     drop(read_end);
 }
 
+/// Transferring a raw descriptor creates an owning stream that reads its data.
 #[rstest]
 fn stream_from_raw_owns_and_reads_the_descriptor() {
     let (read_end, write_end) = crate::test_support::unwrap_ok(make_pipe());
@@ -91,6 +94,7 @@ fn stream_from_raw_owns_and_reads_the_descriptor() {
     assert!(!fd_is_open(raw_fd), "the owned FD must be closed on drop");
 }
 
+/// Consuming a pipe records its byte total and zero read retries in the span.
 #[rstest]
 fn consume_records_total_bytes_and_retries_on_span() {
     let (read_end, write_end) = crate::test_support::unwrap_ok(make_pipe());
@@ -126,6 +130,7 @@ fn consume_records_total_bytes_and_retries_on_span() {
     );
 }
 
+/// The pump records completion fields even when its span filter allows errors.
 #[rstest]
 fn pump_records_span_fields_under_error_filter() {
     // Source pipe: the payload the pump reads. Sink pipe: where it writes.
@@ -190,6 +195,7 @@ fn assert_panicking_reader_keeps_fd_open(raw_fd: i32) {
     assert!(outcome.is_err(), "the panic must propagate to the caller");
 }
 
+/// A successful write is classified with the number of bytes delivered.
 #[rstest]
 fn classify_write_reports_a_completed_write() {
     let (read_end, mut write_end) = crate::test_support::unwrap_ok(make_pipe());
@@ -204,6 +210,7 @@ fn classify_write_reports_a_completed_write() {
     drop(read_end);
 }
 
+/// A fatal write error is returned instead of being treated as a closed writer.
 #[rstest]
 fn classify_write_propagates_a_fatal_error() {
     // Writing to the read end of a pipe is a fatal `EBADF`, which must
@@ -216,6 +223,7 @@ fn classify_write_propagates_a_fatal_error() {
     }
 }
 
+/// Writes a probe payload and reads it through the borrowed descriptor.
 fn successful_reader_bytes(raw_fd: i32, write_end: OwnedFd) -> io::Result<Vec<u8>> {
     write_all_to(&write_end, b"ping")?;
     drop(write_end);
@@ -230,6 +238,7 @@ fn successful_reader_bytes(raw_fd: i32, write_end: OwnedFd) -> io::Result<Vec<u8
     })
 }
 
+/// A broken writer still drains the reader before the pump reports completion.
 #[rstest]
 fn pump_drains_the_reader_after_the_writer_breaks() {
     // The downstream stage hangs up before the pump writes anything, which is

--- a/rust/cuprum-rust/src/splice/tests.rs
+++ b/rust/cuprum-rust/src/splice/tests.rs
@@ -23,20 +23,20 @@ type PipePair = (OwnedFd, OwnedFd);
 /// one place; tests needing several independent pipes request it once per
 /// `#[from(pipe)]` parameter.
 #[fixture]
-fn pipe() -> PipePair {
+fn pipe() -> io::Result<PipePair> {
     make_pipe()
 }
 
 #[rstest]
 fn splice_transfers_all_bytes_between_pipes(
-    #[from(pipe)] source: PipePair,
-    #[from(pipe)] sink: PipePair,
+    #[from(pipe)] source_result: io::Result<PipePair>,
+    #[from(pipe)] sink_result: io::Result<PipePair>,
 ) {
-    let (source_read, source_write) = source;
-    let (sink_read, sink_write) = sink;
+    let (source_read, source_write) = unwrap_ok(source_result);
+    let (sink_read, sink_write) = unwrap_ok(sink_result);
     let payload = b"unified splice loop payload";
 
-    write_all_to(&source_write, payload);
+    unwrap_ok(write_all_to(&source_write, payload));
     drop(source_write); // EOF for the splice loop.
 
     let outcome = try_splice_pump(&source_read, &sink_write, 4096);
@@ -49,7 +49,8 @@ fn splice_transfers_all_bytes_between_pipes(
         }
         other => panic!("expected Some(Ok(_)) from pipe splice, got {other:?}"),
     }
-    assert_eq!(read_all_from(&sink_read), payload);
+    let collected = unwrap_ok(read_all_from(&sink_read));
+    assert_eq!(collected, payload);
 }
 
 #[rstest]
@@ -76,14 +77,14 @@ fn unsupported_descriptors_signal_fallback() {
 
 #[rstest]
 fn broken_pipe_drains_reader_and_reports_transferred_bytes(
-    #[from(pipe)] source: PipePair,
-    #[from(pipe)] sink: PipePair,
+    #[from(pipe)] source_result: io::Result<PipePair>,
+    #[from(pipe)] sink_result: io::Result<PipePair>,
 ) {
-    let (source_read, source_write) = source;
-    let (sink_read, sink_write) = sink;
+    let (source_read, source_write) = unwrap_ok(source_result);
+    let (sink_read, sink_write) = unwrap_ok(sink_result);
     let payload = b"bytes that can no longer be delivered";
 
-    write_all_to(&source_write, payload);
+    unwrap_ok(write_all_to(&source_write, payload));
     drop(source_write);
     drop(sink_read); // Break the downstream pipe before pumping.
 
@@ -95,7 +96,7 @@ fn broken_pipe_drains_reader_and_reports_transferred_bytes(
 
     // The drain must have consumed the source to EOF so upstream writers
     // cannot block on a full pipe buffer.
-    let leftover = read_all_from(&source_read);
+    let leftover = unwrap_ok(read_all_from(&source_read));
     assert!(
         leftover.is_empty(),
         "reader must be drained, got {leftover:?}"
@@ -103,14 +104,14 @@ fn broken_pipe_drains_reader_and_reports_transferred_bytes(
 }
 
 #[rstest]
-fn drain_reader_consumes_to_eof(pipe: PipePair) {
-    let (read_end, write_end) = pipe;
-    write_all_to(&write_end, b"residual data");
+fn drain_reader_consumes_to_eof(#[from(pipe)] pipe_result: io::Result<PipePair>) {
+    let (read_end, write_end) = unwrap_ok(pipe_result);
+    unwrap_ok(write_all_to(&write_end, b"residual data"));
     drop(write_end);
 
     unwrap_ok(drain_reader(read_end.as_raw_fd(), 8));
 
-    let leftover = read_all_from(&read_end);
+    let leftover = unwrap_ok(read_all_from(&read_end));
     assert!(leftover.is_empty(), "drain must consume the pipe to EOF");
 }
 

--- a/rust/cuprum-rust/src/splice/tests.rs
+++ b/rust/cuprum-rust/src/splice/tests.rs
@@ -27,6 +27,7 @@ fn pipe() -> io::Result<PipePair> {
     make_pipe()
 }
 
+/// A pipe payload reaches the sink intact through the splice loop.
 #[rstest]
 fn splice_transfers_all_bytes_between_pipes(
     #[from(pipe)] source_result: io::Result<PipePair>,
@@ -75,6 +76,7 @@ fn unsupported_descriptors_signal_fallback() {
     );
 }
 
+/// A broken sink drains the source and reports zero delivered bytes.
 #[rstest]
 fn broken_pipe_drains_reader_and_reports_transferred_bytes(
     #[from(pipe)] source_result: io::Result<PipePair>,
@@ -103,6 +105,7 @@ fn broken_pipe_drains_reader_and_reports_transferred_bytes(
     );
 }
 
+/// Draining a reader consumes all pending bytes through EOF.
 #[rstest]
 fn drain_reader_consumes_to_eof(#[from(pipe)] pipe_result: io::Result<PipePair>) {
     let (read_end, write_end) = unwrap_ok(pipe_result);

--- a/rust/cuprum-rust/src/test_support.rs
+++ b/rust/cuprum-rust/src/test_support.rs
@@ -5,38 +5,39 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 
-pub(crate) fn make_pipe() -> (OwnedFd, OwnedFd) {
+pub(crate) fn make_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     let mut fds = [0_i32; 2];
     // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
     let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
-    assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
+    if rc == -1 {
+        return Err(io::Error::last_os_error());
+    }
     // SAFETY: on success `pipe(2)` returned two freshly opened descriptors
     // that this process exclusively owns.
-    unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+    Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
 }
 
-pub(crate) fn dup_as_file(fd: &OwnedFd) -> File {
+pub(crate) fn dup_as_file(fd: &OwnedFd) -> io::Result<File> {
     // SAFETY: duplicating an owned descriptor for a scoped `File` wrapper.
     let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
-    assert_ne!(
-        duplicated_fd,
-        -1,
-        "dup(2) failed: {}",
-        io::Error::last_os_error(),
-    );
+    if duplicated_fd == -1 {
+        return Err(io::Error::last_os_error());
+    }
     // SAFETY: `duplicated_fd` was checked for `dup(2)` failure above and is
     // now owned by this scoped `File`.
-    unsafe { File::from_raw_fd(duplicated_fd) }
+    Ok(unsafe { File::from_raw_fd(duplicated_fd) })
 }
 
-pub(crate) fn write_all_to(fd: &OwnedFd, payload: &[u8]) {
-    unwrap_ok(dup_as_file(fd).write_all(payload));
+pub(crate) fn write_all_to(fd: &OwnedFd, payload: &[u8]) -> io::Result<()> {
+    let mut file = dup_as_file(fd)?;
+    file.write_all(payload)
 }
 
-pub(crate) fn read_all_from(fd: &OwnedFd) -> Vec<u8> {
+pub(crate) fn read_all_from(fd: &OwnedFd) -> io::Result<Vec<u8>> {
     let mut collected = Vec::new();
-    unwrap_ok(dup_as_file(fd).read_to_end(&mut collected));
-    collected
+    let mut file = dup_as_file(fd)?;
+    file.read_to_end(&mut collected)?;
+    Ok(collected)
 }
 
 pub(crate) fn unwrap_ok<T, E: Debug>(result: Result<T, E>) -> T {

--- a/rust/cuprum-rust/src/test_support.rs
+++ b/rust/cuprum-rust/src/test_support.rs
@@ -5,6 +5,10 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 
+/// Create an anonymous pipe as `(read_end, write_end)`.
+///
+/// Returns the operating-system error from `pipe(2)` so fixtures can pass it
+/// to the test body, where the failure receives assertion context.
 pub(crate) fn make_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     let mut fds = [0_i32; 2];
     // SAFETY: `fds` is a valid two-element array for `pipe(2)` to fill.
@@ -17,8 +21,12 @@ pub(crate) fn make_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
 }
 
-pub(crate) fn dup_as_file(fd: &OwnedFd) -> io::Result<File> {
-    // SAFETY: duplicating an owned descriptor for a scoped `File` wrapper.
+/// Duplicate a descriptor view into an independently owned [`File`].
+///
+/// The caller retains ownership of its descriptor. Returning the `dup(2)`
+/// error also permits tests to exercise invalid descriptor handling safely.
+pub(crate) fn dup_as_file(fd: &impl AsRawFd) -> io::Result<File> {
+    // SAFETY: duplicating the supplied descriptor view for a scoped `File` wrapper.
     let duplicated_fd = unsafe { libc::dup(fd.as_raw_fd()) };
     if duplicated_fd == -1 {
         return Err(io::Error::last_os_error());
@@ -28,11 +36,19 @@ pub(crate) fn dup_as_file(fd: &OwnedFd) -> io::Result<File> {
     Ok(unsafe { File::from_raw_fd(duplicated_fd) })
 }
 
+/// Write every byte of `payload` through a duplicated descriptor.
+///
+/// This preserves failures from both `dup(2)` and [`Write::write_all`] for the
+/// test body to assert on.
 pub(crate) fn write_all_to(fd: &OwnedFd, payload: &[u8]) -> io::Result<()> {
     let mut file = dup_as_file(fd)?;
     file.write_all(payload)
 }
 
+/// Read to EOF through a duplicated descriptor.
+///
+/// This preserves failures from both `dup(2)` and [`Read::read_to_end`] for
+/// the test body to assert on.
 pub(crate) fn read_all_from(fd: &OwnedFd) -> io::Result<Vec<u8>> {
     let mut collected = Vec::new();
     let mut file = dup_as_file(fd)?;
@@ -40,6 +56,7 @@ pub(crate) fn read_all_from(fd: &OwnedFd) -> io::Result<Vec<u8>> {
     Ok(collected)
 }
 
+/// Extract a successful fixture result at a recognized test boundary.
 pub(crate) fn unwrap_ok<T, E: Debug>(result: Result<T, E>) -> T {
     match result {
         Ok(value) => value,
@@ -47,6 +64,8 @@ pub(crate) fn unwrap_ok<T, E: Debug>(result: Result<T, E>) -> T {
     }
 }
 
+/// Extract an expected failure while retaining the successful value in panic
+/// output.
 pub(crate) fn unwrap_err<T: Debug, E>(result: Result<T, E>) -> E {
     match result {
         Ok(value) => panic!("expected Err(..), got Ok({value:?})"),
@@ -54,6 +73,7 @@ pub(crate) fn unwrap_err<T: Debug, E>(result: Result<T, E>) -> E {
     }
 }
 
+/// Report whether `fd` remains open without taking ownership of it.
 pub(crate) fn fd_is_open(fd: i32) -> bool {
     loop {
         // SAFETY: F_GETFD on an arbitrary integer reports EBADF for a closed
@@ -68,3 +88,7 @@ pub(crate) fn fd_is_open(fd: i32) -> bool {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "test_support_tests.rs"]
+mod tests;

--- a/rust/cuprum-rust/src/test_support_tests.rs
+++ b/rust/cuprum-rust/src/test_support_tests.rs
@@ -1,0 +1,41 @@
+//! Error-path coverage for shared Unix file-descriptor test helpers.
+
+use std::io;
+
+use super::{dup_as_file, make_pipe, read_all_from, unwrap_err, unwrap_ok, write_all_to};
+
+/// Assert that a descriptor operation preserves its native `EBADF` failure.
+///
+/// This remains local to the test-support error contract rather than becoming
+/// a general assertion framework.
+#[track_caller]
+fn assert_bad_file_descriptor(error: &io::Error, operation: &str) {
+    assert_eq!(
+        error.raw_os_error(),
+        Some(libc::EBADF),
+        "{operation} must preserve the invalid-descriptor error",
+    );
+}
+
+#[test]
+fn dup_as_file_returns_an_error_for_an_invalid_raw_descriptor() {
+    let error = unwrap_err(dup_as_file(&-1));
+
+    assert_bad_file_descriptor(&error, "dup(2)");
+}
+
+#[test]
+fn write_all_to_returns_an_error_for_a_pipe_read_end() {
+    let (read_end, _write_end) = unwrap_ok(make_pipe());
+    let error = unwrap_err(write_all_to(&read_end, b"cannot write here"));
+
+    assert_bad_file_descriptor(&error, "write_all");
+}
+
+#[test]
+fn read_all_from_returns_an_error_for_a_pipe_write_end() {
+    let (_read_end, write_end) = unwrap_ok(make_pipe());
+    let error = unwrap_err(read_all_from(&write_end));
+
+    assert_bad_file_descriptor(&error, "read_to_end");
+}

--- a/rust/cuprum-rust/src/test_support_tests.rs
+++ b/rust/cuprum-rust/src/test_support_tests.rs
@@ -17,6 +17,7 @@ fn assert_bad_file_descriptor(error: &io::Error, operation: &str) {
     );
 }
 
+/// Invalid descriptors preserve the native error returned by `dup(2)`.
 #[test]
 fn dup_as_file_returns_an_error_for_an_invalid_raw_descriptor() {
     let error = unwrap_err(dup_as_file(&-1));
@@ -24,6 +25,7 @@ fn dup_as_file_returns_an_error_for_an_invalid_raw_descriptor() {
     assert_bad_file_descriptor(&error, "dup(2)");
 }
 
+/// Attempting to write through a pipe read end returns `EBADF`.
 #[test]
 fn write_all_to_returns_an_error_for_a_pipe_read_end() {
     let (read_end, _write_end) = unwrap_ok(make_pipe());
@@ -32,6 +34,7 @@ fn write_all_to_returns_an_error_for_a_pipe_read_end() {
     assert_bad_file_descriptor(&error, "write_all");
 }
 
+/// Attempting to read through a pipe write end returns `EBADF`.
 #[test]
 fn read_all_from_returns_an_error_for_a_pipe_write_end() {
     let (_read_end, write_end) = unwrap_ok(make_pipe());


### PR DESCRIPTION
## Summary

This branch makes Rust pipe and descriptor setup fallible, so recognized test
bodies report ordinary setup failures through the existing assertion wrapper.
It preserves descriptor ownership and EOF contracts while separating the
borrowed-reader query from its assertion.

This is layer 1 of the Rust-baseline stack, based on `main`. Its immediate successor is
[#382](https://github.com/leynos/cuprum/pull/382), the module extraction.
Later layers cover measured source fixes, formatting, lint configuration,
and Whitaker binding.

## Review walkthrough

- Start with [test_support.rs](https://github.com/leynos/cuprum/blob/test-quality-sweep/rust/cuprum-rust/src/test_support.rs#L8)
  for the fallible pipe, descriptor duplication, and read/write helpers.
- Continue with [lib_tests.rs](https://github.com/leynos/cuprum/blob/test-quality-sweep/rust/cuprum-rust/src/lib_tests.rs#L45)
  for the result fixture and borrowed-reader ownership assertion.
- Finish with [consume_snapshot_tests.rs](https://github.com/leynos/cuprum/blob/test-quality-sweep/rust/cuprum-rust/src/consume_snapshot_tests.rs#L33),
  [io_utils/tests.rs](https://github.com/leynos/cuprum/blob/test-quality-sweep/rust/cuprum-rust/src/io_utils/tests.rs#L20),
  and [splice/tests.rs](https://github.com/leynos/cuprum/blob/test-quality-sweep/rust/cuprum-rust/src/splice/tests.rs#L26)
  for the propagated fixture and helper outcomes at test bodies.

- Review [test_support_tests.rs](https://github.com/leynos/cuprum/blob/f4aef80b7ff0cfa3120e411dee0943b6e516471e/rust/cuprum-rust/src/test_support_tests.rs) for three safe error-path tests and the developers' guide for the internal fallible-helper contract.

## Validation

- `make check-fmt`: passed.
- `make lint`: passed, including Whitaker.
- `make typecheck`: passed.
- `make test`: passed; 1,509 passed and 56 skipped in Python, with 107 Rust
  tests passing.
- All validation ran with the layer's existing configuration and Rust 1.85.0;
  the baseline gates had no pre-existing failures.
- `cs delta 34a59eac4cd13de82c3730d4b569eeaefbb5ee61 5b6b90e4e2088e899940590a48aa79fe30b180eb`:
  passed with no issues on CodeScene 1.0.33.

- Review repair `f4aef80b7ff0cfa3120e411dee0943b6e516471e` passed the full gates above, `make markdownlint`, and `make nixie`. Controlled mutations proved the three error-path tests detect a duplication panic and swallowed read/write errors.
- `CS_DISABLE_VERSION_CHECK=true cs delta 5b6b90e4e2088e899940590a48aa79fe30b180eb f4aef80b7ff0cfa3120e411dee0943b6e516471e`: passed with no issues.
- Existing Python BDD deprecation warnings are tracked separately in [#384](https://github.com/leynos/cuprum/issues/384).

- Documentation-only commit `7176c7a026a0457cb023ab2b3505c1f05566f6d6` passed the full gate set again. All 34 functions whose bodies this PR changes now have adjacent Rustdoc (100% under the explicit PR-scoped count); the patch adds only 24 documentation lines.
- CodeScene inspected the five-file documentation working-tree delta against `f4aef80` before commit and reported no issues.

## Notes

The train-wide `unsafe_code` policy conflict, unavailable disallowed-methods
list, and the canonical auditor's nested-workspace coverage gap remain outside
this test-quality layer and are tracked independently.

## Summary by Sourcery

Propagate Rust test setup and descriptor I/O failures through the existing assertion wrapper while preserving ownership and EOF contracts.

Bug Fixes:
- Propagate Rust test I/O setup and descriptor-operation failures to recognized test assertion boundaries instead of panicking inside shared helpers.

Enhancements:
- Preserve descriptor ownership and EOF behavior while making pipe, duplication, read, and write test helpers fallible.
- Separate borrowed-reader result handling from assertion logic and add focused invalid-descriptor error-path coverage.

Documentation:
- Document the fallible Rust test I/O helper contract for descriptor-backed tests.

Tests:
- Update Rust pipe, stream, splice, snapshot, and ownership tests to handle fallible fixtures and helper results.

## References

https://lody.ai/leynos/sessions/934d2efe-ceff-4a48-876a-6c022311b70d