### PR TITLE
Make Rust availability probe const

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2098,6 +2098,11 @@ The Rust availability API uses a single source of truth:
   `set_rust_availability_for_testing(is_available=...)`, which also clears the
   two relevant caches.
 
+The native Rust marker `_rust_backend_native::is_available()` is a
+`pub const fn` that returns `true` once the extension loads. Its PyO3
+registration remains the runtime Python export, while the compile-pass UI
+fixture verifies that Rust callers can use the marker in a constant.
+
 Keep tests that bypass `cuprum.is_rust_available()` focused on this private
 layer, because `_rust_backend.is_available()` is an uncached import probe
 without lifetime caching.

--- a/rust/cuprum-rust/src/lib.rs
+++ b/rust/cuprum-rust/src/lib.rs
@@ -53,16 +53,10 @@ use utf8::{FinalChunk, decode_utf8_replace};
 ///
 /// # Returns
 /// `true` whenever the extension is loaded and callable.
-// Tracking: https://github.com/leynos/cuprum/issues/128 records the runtime
-// availability resolver boundary that keeps this PyO3 export non-const.
 #[must_use]
-#[expect(
-    clippy::missing_const_for_fn,
-    reason = "runtime #[pyfunction] FFI boundary: the body is const-evaluable but the export must stay a runtime function, not a const item"
-)]
 #[doc(hidden)]
 #[pyfunction]
-pub fn is_available() -> bool {
+pub const fn is_available() -> bool {
     true
 }
 

--- a/rust/cuprum-rust/tests/ui/fail/const_availability_export.rs
+++ b/rust/cuprum-rust/tests/ui/fail/const_availability_export.rs
@@ -1,5 +1,0 @@
-//! Compile-fail UI test: the availability export remains runtime-only.
-
-const RUST_AVAILABLE: bool = _rust_backend_native::is_available();
-
-fn main() {}

--- a/rust/cuprum-rust/tests/ui/fail/const_availability_export.stderr
+++ b/rust/cuprum-rust/tests/ui/fail/const_availability_export.stderr
@@ -1,7 +1,0 @@
-error[E0015]: cannot call non-const function `is_available` in constants
- --> tests/ui/fail/const_availability_export.rs:3:30
-  |
-3 | const RUST_AVAILABLE: bool = _rust_backend_native::is_available();
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: calls in constants are limited to constant functions, tuple structs and tuple variants

--- a/rust/cuprum-rust/tests/ui/pass/const_availability_export.rs
+++ b/rust/cuprum-rust/tests/ui/pass/const_availability_export.rs
@@ -1,0 +1,10 @@
+//! Compile-pass UI test: the native availability marker is const-evaluable.
+//!
+//! Validates that the native marker retains its compile-time contract while
+//! its PyO3 registration continues to provide the runtime Python export.
+
+const RUST_AVAILABLE: bool = _rust_backend_native::is_available();
+
+fn main() {
+    assert!(RUST_AVAILABLE, "the loaded native extension must be available");
+}


### PR DESCRIPTION
## Summary

This branch makes the native Rust availability marker constant while retaining
its public PyO3 export, module registration, and `true` runtime result. It
retires the obsolete compile-fail contract, adds the matching compile-pass
regression fixture, and documents the native Rust boundary for maintainers.

It is the source-constness layer above [PR #382](https://github.com/leynos/cuprum/pull/382)
and below formatter prerequisites, formatting, baseline configuration, and the
Whitaker gate.

## Review walkthrough

- Start with [`is_available`](https://github.com/leynos/cuprum/blob/harden-lint-constness/rust/cuprum-rust/src/lib.rs#L48-L61), which changes only its Rust constness and removes the fulfilled tracking expectation.
- Review the [`compile-pass fixture`](https://github.com/leynos/cuprum/blob/harden-lint-constness/rust/cuprum-rust/tests/ui/pass/const_availability_export.rs#L1-L10), which calls the actual native marker in a constant and asserts the loaded extension remains available.
- Read the [`native availability contract`](https://github.com/leynos/cuprum/blob/harden-lint-constness/docs/developers-guide.md#L2101-L2104), which distinguishes compile-time Rust use from the runtime PyO3 export.
- Confirm the unchanged PyO3 stream registration remains in
  [`lib.rs`](https://github.com/leynos/cuprum/blob/harden-lint-constness/rust/cuprum-rust/src/lib.rs#L341-L348).

## Validation

- A temporary reversion of `pub const fn is_available()` to `pub fn` made the new compile-pass fixture fail with Rust error `E0015`; restoration was byte-identical and `cargo test --test compile_tests compile_time_ui` then passed.
- `make check-fmt`: passed in 1 second (422 files checked).
- `make lint`: passed in 105 seconds, including Rustdoc, Clippy, Whitaker, spelling, YAML lint, and actionlint.
- `make typecheck`: passed in 1 second with `ty 0.0.74`.
- `make test`: passed in 208 seconds: Python 1,509 passed and 56 skipped; behaviour 18 passed and 8 skipped; Rust 107 passed and 0 skipped, including the UI suite.
- `make markdownlint`: passed in 9 seconds; `make nixie`: passed in 1 second.
- `cs delta 797d97c9ed07c3ea2435e04c2137818fbe0398ba harden-lint-constness`: passed with CodeScene CLI 1.0.33, including the uncommitted two-path repair; no issues. The committed repair is that exact two-path diff.

## Notes

A scratch remeasurement at the final complexity thresholds remains a follow-up
layer and does not change this branch. The estate-wide `unsafe_code`,
disallowed-method, and nested-surface auditor coverage gaps remain explicitly
unmeasured outside this source-constness scope.

## References

- [Lody execution session](https://lody.ai/leynos/sessions/934d2efe-ceff-4a48-876a-6c022311b70d)
