### PR TITLE
Prepare Rust formatter toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,15 @@ jobs:
       - name: Install Nixie
         uses: leynos/shared-actions/.github/actions/install-nixie@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
 
+      # The formatter profile needs nightly-only settings. Install its pinned
+      # maintenance toolchain before restoring the supported project compiler.
+      - name: Install formatter Rust toolchain
+        uses: leynos/shared-actions/.github/actions/setup-rust@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
+        with:
+          toolchain: 'nightly-2026-05-28'
+          cache-provider: external
+          use-sccache: 'false'
+
       - name: Install project Rust toolchain
         uses: leynos/shared-actions/.github/actions/setup-rust@c5a54701c8603a0fa756a6b34c49bc2af75a6c11
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,11 @@ working on the Rust portions of the project:
     running the Rust test suite with warnings denied. Use `make fmt`
     (`cargo fmt --all`) to apply formatting fixes reported by the formatter
     check alongside the Python and Markdown formatters.
+- The project toolchain stays pinned to Rust `1.85.0` and declares `rustfmt`,
+  `clippy`, and `rust-analyzer`. CI also provisions `nightly-2026-05-28` for
+  the maintenance formatter, then restores the project toolchain. The current
+  `fmt` and `check-fmt` recipes still use the project toolchain; the nightly is
+  not a build, test, lint, or documentation toolchain.
 - Clippy warnings MUST be disallowed.
 - Fix any warnings emitted during tests in code instead of silencing them.
 - Where a function is too long, extract meaningfully named helper functions

--- a/cuprum/unittests/__snapshots__/test_maturin_build.ambr
+++ b/cuprum/unittests/__snapshots__/test_maturin_build.ambr
@@ -211,6 +211,7 @@
       'cuprum/unittests/test_rust_errno.py',
       'cuprum/unittests/test_rust_errno_windows.py',
       'cuprum/unittests/test_rust_extension.py',
+      'cuprum/unittests/test_rust_formatter_toolchain.py',
       'cuprum/unittests/test_rust_pump_debug_abort.py',
       'cuprum/unittests/test_rust_pump_handoff_metrics.py',
       'cuprum/unittests/test_rust_pump_handoff_observability.py',

--- a/cuprum/unittests/test_rust_formatter_toolchain.py
+++ b/cuprum/unittests/test_rust_formatter_toolchain.py
@@ -1,0 +1,60 @@
+"""Contracts for the Rust formatter's maintenance toolchain."""
+
+from __future__ import annotations
+
+import tomllib
+
+from tests.helpers.docs import repo_root
+from tests.helpers.workflow import Workflow, step_named, steps
+
+_SHARED_ACTION_REVISION = "c5a54701c8603a0fa756a6b34c49bc2af75a6c11"
+_SETUP_RUST = (
+    f"leynos/shared-actions/.github/actions/setup-rust@{_SHARED_ACTION_REVISION}"
+)
+_FORMATTER_TOOLCHAIN = "nightly-2026-05-28"
+_PROJECT_TOOLCHAIN = "1.85.0"
+
+
+def test_formatter_toolchain_precedes_the_project_toolchain(
+    workflow_data: Workflow,
+) -> None:
+    """The cold CI path installs the formatter without changing project Rust."""
+    formatter_setup = step_named(
+        workflow_data, "lint-test", "Install formatter Rust toolchain"
+    )
+    project_setup = step_named(
+        workflow_data, "lint-test", "Install project Rust toolchain"
+    )
+
+    assert formatter_setup.get("uses") == _SETUP_RUST, (
+        "the formatter toolchain must use the pinned shared Rust setup action"
+    )
+    assert formatter_setup.get("with") == {
+        "toolchain": _FORMATTER_TOOLCHAIN,
+        "cache-provider": "external",
+        "use-sccache": "false",
+    }, "the formatter setup must provision the pinned nightly on every runner"
+    assert project_setup.get("with") == {
+        "toolchain": _PROJECT_TOOLCHAIN,
+        "cache-provider": "external",
+        "use-sccache": "false",
+    }, "the project setup must restore the supported stable compiler"
+
+    lint_steps = steps(workflow_data, "lint-test")
+    assert lint_steps.index(formatter_setup) < lint_steps.index(project_setup), (
+        "the stable project toolchain must replace setup-rust's formatter override"
+    )
+
+
+def test_project_toolchain_declares_maintenance_components() -> None:
+    """The stable toolchain keeps editor and lint components available locally."""
+    configuration = tomllib.loads(
+        (repo_root() / "rust" / "rust-toolchain.toml").read_text(encoding="utf-8")
+    )
+    toolchain = configuration.get("toolchain")
+    assert isinstance(toolchain, dict), "rust-toolchain.toml must declare a toolchain"
+    assert toolchain == {
+        "channel": _PROJECT_TOOLCHAIN,
+        "profile": "minimal",
+        "components": ["rustfmt", "clippy", "rust-analyzer"],
+    }, "the stable pin must retain its compiler and declare each required component"

--- a/cuprum/unittests/test_rust_formatter_toolchain.py
+++ b/cuprum/unittests/test_rust_formatter_toolchain.py
@@ -29,6 +29,9 @@ def test_formatter_toolchain_precedes_the_project_toolchain(
     assert formatter_setup.get("uses") == _SETUP_RUST, (
         "the formatter toolchain must use the pinned shared Rust setup action"
     )
+    assert project_setup.get("uses") == _SETUP_RUST, (
+        "the project toolchain must use the pinned shared Rust setup action"
+    )
     assert formatter_setup.get("with") == {
         "toolchain": _FORMATTER_TOOLCHAIN,
         "cache-provider": "external",

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -312,10 +312,23 @@ cranelift; the coverage gate cannot, because cranelift has no
 The lint job installs Nixie and Whitaker through the pinned
 `leynos/shared-actions` installers. Nixie's installer also provisions Merman;
 the bootstrap uses Rust `1.95.0` because Merman CLI `0.7.0` requires that
-compiler. The job then restores Rust `1.85.0`, the project's supported
+compiler. The job then installs `nightly-2026-05-28` with `rustfmt` for the
+maintenance formatter before restoring Rust `1.85.0`, the project's supported
 toolchain, before installing Whitaker and running the project gates. The
-Whitaker action receives `WHITAKER_INSTALLER_VERSION` from the job environment
-(`0.2.7`, the workflow's configured installer version).
+following stable setup replaces the shared action's temporary override, so the
+build, test, lint, and documentation commands continue to use Rust `1.85.0`.
+The current `fmt` and `check-fmt` recipes also continue to use that stable
+toolchain; the pinned nightly is provisioned for the later formatter-profile
+layer. The stable pin declares `rustfmt`, `clippy`, and `rust-analyzer` for
+local maintenance. The Whitaker action receives `WHITAKER_INSTALLER_VERSION`
+from the job environment (`0.2.7`, the workflow's configured installer version).
+
+The `pipe` rstest fixtures retain a scoped `#[rustfmt::skip]`. Rustfmt
+`1.9.0-nightly (57d06900fd 2026-05-27)` turns either fixture into a one-line
+form whose rstest `0.26.1` expansion triggers `unused_braces` under Rust
+`1.85.0`. The formatter profile remains unchanged and applies to every other
+item. Remove the two skips only after a candidate formatter or rstest update
+passes the profile check and warnings-denied pipe-fixture test.
 
 cargo-nextest is no longer installed here at all. The coverage job is the only
 place it runs, and the shared action installs it from checksummed official

--- a/rust/cuprum-rust/src/io_utils/tests.rs
+++ b/rust/cuprum-rust/src/io_utils/tests.rs
@@ -16,6 +16,10 @@ use rstest::{fixture, rstest};
 /// A fresh `pipe(2)` pair (`read_end`, `write_end`) for descriptor-backed
 /// tests, so the shared setup lives in one place rather than a repeated
 /// `make_pipe()` call per test.
+// `fn_single_line` in rustfmt 1.9.0-nightly turns this rstest fixture into a
+// form that triggers `unused_braces` under Rust 1.85. Remove this skip when
+// that formatter/rstest combination compiles the configured profile cleanly.
+#[rustfmt::skip]
 #[fixture]
 fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     make_pipe()

--- a/rust/cuprum-rust/src/splice/tests.rs
+++ b/rust/cuprum-rust/src/splice/tests.rs
@@ -22,6 +22,10 @@ type PipePair = (OwnedFd, OwnedFd);
 /// Exposing the shared pipe setup as a fixture keeps its construction in
 /// one place; tests needing several independent pipes request it once per
 /// `#[from(pipe)]` parameter.
+// `fn_single_line` in rustfmt 1.9.0-nightly turns this rstest fixture into a
+// form that triggers `unused_braces` under Rust 1.85. Remove this skip when
+// that formatter/rstest combination compiles the configured profile cleanly.
+#[rustfmt::skip]
 #[fixture]
 fn pipe() -> io::Result<PipePair> {
     make_pipe()

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.85.0"
 profile = "minimal"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/tests/test_ci_compiler_cache.py
+++ b/tests/test_ci_compiler_cache.py
@@ -144,8 +144,9 @@ def test_shared_rust_setup_owns_no_cache_of_its_own() -> None:
 
     Selecting `external` delegates cache ownership to the workflow. The lint
     job temporarily selects a second toolchain because Nixie's Merman
-    dependency needs newer Rust than the project gate; both setup steps must
-    keep that same external cache policy.
+    dependency needs newer Rust than the project gate. Its Nixie, formatter
+    nightly, and restored project-stable setup steps must keep that same
+    external cache policy.
     """
     for workflow_name, job_name in expand(CACHED_JOBS):
         setup_steps = [
@@ -156,7 +157,7 @@ def test_shared_rust_setup_owns_no_cache_of_its_own() -> None:
         if not setup_steps:
             continue
         expected_count = (
-            2 if (workflow_name, job_name) == ("ci.yml", "lint-test") else 1
+            3 if (workflow_name, job_name) == ("ci.yml", "lint-test") else 1
         )
         assert len(setup_steps) == expected_count, (
             f"{workflow_name}:{job_name} must use shared setup-rust "


### PR DESCRIPTION
## Summary

This branch pre-provisions the pinned nightly formatter for the lint CI job,
then restores the supported Rust `1.85.0` compiler for project gates. It adds
`rust-analyzer` to the stable maintenance components and guards the ordering,
cache policy, package layout, and formatter compatibility boundary.

## Stack position

This formatter-prerequisite layer follows the test-quality, module, and
constness layers. It precedes the Markdown tooling and mechanical Rust
formatter-profile layers. It does not add a formatter profile, change Make
recipes, or reformat general Rust source.

## Review walkthrough

- Start with [CI provisioning](https://github.com/leynos/cuprum/blob/harden-lint-format-prerequisites/.github/workflows/ci.yml#L243-L257): the existing pinned shared action installs
  `nightly-2026-05-28` with `rustfmt`, then restores `1.85.0`.
- Review the [stable toolchain declaration](https://github.com/leynos/cuprum/blob/harden-lint-format-prerequisites/rust/rust-toolchain.toml#L1-L4) and its
  [cold-CI contract](https://github.com/leynos/cuprum/blob/harden-lint-format-prerequisites/cuprum/unittests/test_rust_formatter_toolchain.py#L18-L60).
- The [CI cache contract](https://github.com/leynos/cuprum/blob/harden-lint-format-prerequisites/tests/test_ci_compiler_cache.py#L142-L176) covers all three
  shared Rust setup steps; the [wheel snapshot](https://github.com/leynos/cuprum/blob/harden-lint-format-prerequisites/cuprum/unittests/__snapshots__/test_maturin_build.ambr#L211-L216)
  records the intentional packaged test module.
- Finish with the [fixture compatibility exception](https://github.com/leynos/cuprum/blob/harden-lint-format-prerequisites/rust/cuprum-rust/src/io_utils/tests.rs#L16-L26), its
  [sibling](https://github.com/leynos/cuprum/blob/harden-lint-format-prerequisites/rust/cuprum-rust/src/splice/tests.rs#L19-L31), and the
  [maintainer guidance](https://github.com/leynos/cuprum/blob/harden-lint-format-prerequisites/docs/developers-guide.md#L310-L331).

## Validation

- `env -u BASH_ENV uv run pytest cuprum/unittests/test_rust_formatter_toolchain.py -q`: 2 passed.
- A wrong-action mutation of the stable setup failed as expected; the restored focused contract passed.
- `uv run pytest cuprum/unittests/test_maturin_build.py --snapshot-update -k test_maturin_wheel_build_snapshot`:
  1 passed; generated only the sorted packaged-file entry.
- `make check-fmt`, `make lint`, `make typecheck`, `make test`,
  `make markdownlint`, and `make nixie`: passed sequentially on the final
  head. `make test` completed in 572 seconds with 1,511 Python tests passed,
  56 skipped, and 107 Rust tests passed.
- Changed-tree CodeScene analysis: passed.
- The exact prospective nightly profile was tested before this PR. Without the
  two scoped skips, rustfmt `1.9.0-nightly (57d06900fd 2026-05-27)` and rstest
  `0.26.1` produced `unused_braces` under Rust `1.85.0`; with the skips, the
  profile check and warnings-denied pipe-fixture test passed. UI fixtures were
  byte-identical and the escape-corruption scans were clean.

## Notes

The scoped `#[rustfmt::skip]` annotations are formatter compatibility
exceptions, not lint suppressions. Remove them only when a candidate formatter
or rstest update passes the documented profile and pipe-fixture checks. The
later mechanical formatter layer owns the profile and source reformat.

## References

https://lody.ai/leynos/sessions/934d2efe-ceff-4a48-876a-6c022311b70d
