### PR TITLE
Enforce tracked Markdown formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 MDLINT ?= markdownlint-cli2
+MDTABLEFIX ?= mdtablefix
+# CI installs these exact releases. Keep the local installation instructions
+# and the workflow contract test in step when either formatter changes.
+MARKDOWNLINT_VERSION ?= 0.20.0
+MDTABLEFIX_VERSION ?= 0.5.1
 NIXIE ?= nixie
-MDFORMAT_ALL ?= mdformat-all
 YAMLLINT ?= yamllint
 ACTIONLINT ?= actionlint
-TOOLS = $(MDFORMAT_ALL) $(MDLINT) $(YAMLLINT) $(ACTIONLINT) uv
+TOOLS = $(MDTABLEFIX) $(MDLINT) $(YAMLLINT) $(ACTIONLINT) uv
 VENV_TOOLS = pytest ruff
 RUST_DIR ?= rust
 CARGO ?= cargo
@@ -130,10 +134,17 @@ DF12_PYLINT = $(PYLINT_ENV) $(UV_RUN_ENV) uv run --isolated \
   --disable=all --load-plugins=df12_python_lints \
   --enable=$(DF12_PYLINT_MESSAGES)
 AMBRLEAKS = $(UV_RUN_ENV) uv run --python $(DF12_PYTHON) ambrleaks
-# Existing tracked Markdown files, NUL-delimited for safe transport to the
-# formatter. `pipefail` preserves the check-fmt gate's fail-closed behaviour
-# when Git cannot enumerate its index.
-MD_FILES_FIND = bash -o pipefail -c 'git ls-files -z -- "$$1" | while IFS= read -r -d "" markdown_file; do if [ -e "$$markdown_file" ]; then printf "%s\0" "$$markdown_file"; fi; done' -- '*.md'
+# Existing tracked regular Markdown files, NUL-delimited for safe transport to
+# the formatter. The command covers the three recognised Markdown extensions
+# without rewriting contributors' untracked notes or ignored build output.
+# `pipefail` preserves fail-closed behaviour when Git cannot enumerate its
+# index. A root-level leading dash is made explicitly relative before xargs
+# supplies it to either formatter. `mdformat-all` used the same two formatter
+# stages, but discovered files with a mutable local-tool policy rather than
+# this repository contract.
+MARKDOWN_GLOBS = '*.md' '*.markdown' '*.mdx'
+MD_FILES_FIND = bash -o pipefail -c 'git ls-files -z -- "$$@" | while IFS= read -r -d "" markdown_file; do if [ -f "$$markdown_file" ] && [ ! -L "$$markdown_file" ]; then case "$$markdown_file" in -*) printf "./%s\0" "$$markdown_file" ;; *) printf "%s\0" "$$markdown_file" ;; esac; fi; done' -- $(MARKDOWN_GLOBS)
+MDTABLEFIX_FLAGS = --in-place --wrap --renumber --breaks --ellipsis --fences
 
 .PHONY: help all clean build build-release lint python-lint rust-lint \
         github-actions-lint \
@@ -198,13 +209,21 @@ $(VENV_TOOLS): ## Verify required CLI tools in venv
 	$(call ensure_tool_venv,$@)
 endif
 
-fmt: ruff $(MDFORMAT_ALL) ## Format sources
+fmt: ruff $(MDTABLEFIX) $(MDLINT) ## Format sources
 	$(RUFF) format
 	$(RUFF) check --select I --fix
 	cd $(RUST_DIR) && $(CARGO) fmt --all
-	$(LOCAL_TOOL_ENV) $(MDFORMAT_ALL)
+	@markdown_files="$$(mktemp)" || exit $$?; \
+	trap 'rm -f "$$markdown_files"' 0; \
+	if ! $(MD_FILES_FIND) > "$$markdown_files"; then \
+		exit 1; \
+	fi; \
+	if [ -s "$$markdown_files" ]; then \
+		$(LOCAL_TOOL_ENV) xargs -0 $(MDTABLEFIX) $(MDTABLEFIX_FLAGS) < "$$markdown_files" || exit $$?; \
+		$(LOCAL_TOOL_ENV) xargs -0 $(MDLINT) --fix < "$$markdown_files"; \
+	fi
 
-check-fmt: ruff ## Verify formatting
+check-fmt: ruff $(MDTABLEFIX) ## Verify formatting
 	$(RUFF) format --check
 	cd $(RUST_DIR) && $(CARGO) fmt --all -- --check
 	@markdown_files="$$(mktemp)" || exit $$?; \
@@ -212,15 +231,16 @@ check-fmt: ruff ## Verify formatting
 	if ! $(MD_FILES_FIND) > "$$markdown_files"; then \
 		exit 1; \
 	fi; \
-	xargs -0 sh -c '\
-		if [ "$$#" -gt 0 ]; then \
-			scripts/check-markdown-format.sh "$$@"; \
-		fi' sh < "$$markdown_files"
+	if [ -s "$$markdown_files" ]; then \
+		xargs -0 env MDTABLEFIX=$(call shell_quote,$(MDTABLEFIX)) sh -c '\
+			scripts/check-markdown-format.sh "$$@"' sh < "$$markdown_files"; \
+	fi
 
 test-markdown-format: ## Validate the Markdown formatter checker
 	@PYTHONPATH=scripts $(UV_RUN_ENV) uv run --no-project --python 3.13 \
-		--with pytest==9.0.2 --with hypothesis==6.151.9 \
-		python -m pytest scripts/tests/test_check_markdown_format.py -c /dev/null \
+		--with pytest==9.0.2 --with hypothesis==6.151.9 --with syrupy==6.0.0 \
+		python -m pytest scripts/tests/test_check_markdown_format.py \
+		scripts/tests/test_markdown_format_makefile.py -c /dev/null \
 		--rootdir=. -p no:cacheprovider
 
 lint: python-lint rust-lint github-actions-lint ## Run Python, Rust, and GitHub Actions linters
@@ -255,7 +275,14 @@ typecheck: build ## Run typechecking
 	$(TY) check --python .venv
 
 markdownlint: $(MDLINT) ## Lint Markdown files
-	$(LOCAL_TOOL_ENV) git ls-files -z '*.md' | $(LOCAL_TOOL_ENV) xargs -0 $(MDLINT)
+	@markdown_files="$$(mktemp)" || exit $$?; \
+	trap 'rm -f "$$markdown_files"' 0; \
+	if ! $(MD_FILES_FIND) > "$$markdown_files"; then \
+		exit 1; \
+	fi; \
+	if [ -s "$$markdown_files" ]; then \
+		$(LOCAL_TOOL_ENV) xargs -0 $(MDLINT) < "$$markdown_files"; \
+	fi
 	+$(MAKE) spelling
 
 spelling: $(SPELLING_HELPER_TARGET) _run_spelling_gate ## Enforce en-GB-oxendict spelling in prose and source

--- a/cuprum/unittests/test_toolchain_pins.py
+++ b/cuprum/unittests/test_toolchain_pins.py
@@ -286,6 +286,26 @@ def test_mdtablefix_uses_its_pinned_prebuilt_installer() -> None:
     }, "the shared Whitaker installer must receive the configured version"
 
 
+def test_markdown_formatter_pins_match_the_ci_installations() -> None:
+    """Keep Make's local formatter guidance aligned with the CI tools."""
+    root = repo_root()
+    job = _lint_test_job(root)
+    environment = job.get("env")
+    assert isinstance(environment, dict), "the lint-test job must declare env"
+    assert _read_makefile_pin(root, "MDTABLEFIX_VERSION") == environment.get(
+        "MDTABLEFIX_VERSION"
+    ), "Makefile and CI must select the same mdtablefix release"
+    assert _read_makefile_pin(root, "MARKDOWNLINT_VERSION") == _read_workflow_env(
+        root,
+        "MARKDOWNLINT_VERSION",
+    ), "Makefile and CI must select the same markdownlint-cli2 release"
+
+    install_tools = _lint_test_step_script(job, "Install CLI tools")
+    assert "markdownlint-cli2@${MARKDOWNLINT_VERSION}" in install_tools, (
+        "the CI installer must consume the selected markdownlint-cli2 release"
+    )
+
+
 def test_make_lint_and_typecheck_use_the_pinned_tool_commands() -> None:
     """The dry-run recipes invoke Ruff and ty through their synchronized pins."""
     root = repo_root()
@@ -325,20 +345,23 @@ def test_interrogate_targets_override_reaches_the_lint_recipe() -> None:
     )
 
 
-def test_markdownlint_lints_tracked_files_through_the_local_tool_path() -> None:
-    """The markdownlint recipe pipes tracked files with the local tool PATH."""
-    recipes = _expanded_make_recipes(repo_root(), targets=("markdownlint",))
-    assert "git ls-files -z '*.md'" in recipes, (
-        "make markdownlint must lint exactly the tracked Markdown files"
+def test_markdownlint_lints_all_tracked_markdown_extensions() -> None:
+    """The linter reuses the formatter's tracked, NUL-safe discovery contract."""
+    markdownlint = "/opt/markdown-tools/markdownlint-cli2"
+    recipes = _expanded_make_recipes(
+        repo_root(),
+        targets=("markdownlint",),
+        extra_variables={"MDLINT": markdownlint},
     )
-    assert re.search(r'PATH="[^"]+" git ls-files', recipes) is not None, (
-        "LOCAL_TOOL_ENV must reach the git side of the pipeline"
+    assert 'git ls-files -z -- "$@"' in recipes, (
+        "make markdownlint must discover tracked Markdown paths through Git"
     )
-    assert "| PATH=" in recipes, (
-        "LOCAL_TOOL_ENV must reach the xargs side so a clean PATH resolves the tool"
-    )
-    assert "xargs -0 markdownlint-cli2" in recipes, (
-        "the pipeline must run markdownlint-cli2 over the null-delimited file list"
+    for extension in ("'*.md'", "'*.markdown'", "'*.mdx'"):
+        assert extension in recipes, (
+            "make markdownlint must cover every supported Markdown extension"
+        )
+    assert f"xargs -0 {markdownlint}" in recipes, (
+        "the injected linter must receive the formatter's NUL-delimited file list"
     )
 
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2879,33 +2879,48 @@ The short version is:
 
 ### Markdown formatting
 
-`make fmt` runs `mdformat-all`, which applies `mdtablefix` with
-`--wrap --renumber --breaks --ellipsis --fences --in-place` before applying
-`markdownlint-cli2 --fix`. `mdtablefix` therefore owns table padding and
-paragraph wrapping, while `make markdownlint` verifies the result.
+`make fmt` formats every tracked regular Markdown source with a `.md`,
+`.markdown`, or `.mdx` suffix. It applies `mdtablefix` with
+`--in-place --wrap --renumber --breaks --ellipsis --fences`, then applies
+`markdownlint-cli2 --fix` to the same NUL-delimited file list. `mdtablefix`
+therefore owns table padding and paragraph wrapping, while `markdownlint`
+applies its configured source fixes. The Makefile owns this pipeline directly;
+it does not delegate file discovery to a machine-local wrapper. Untracked
+notes, ignored files, and symlink aliases are deliberately outside the
+repository formatting contract. A root-level filename beginning with a dash is
+made explicitly relative before either formatter receives it, and Make avoids
+invoking either formatter when the tracked list is empty.
 
-`make check-fmt` passes repository Markdown files to
+`make check-fmt` passes that same tracked source set to
 `scripts/check-markdown-format.sh`. Because `mdtablefix` has no check-only
 mode, the checker formats temporary copies and compares them with the source
 files; it never modifies the worktree. It accepts exact LF or CRLF output, but
-rejects mixed line endings. Run `make test-markdown-format` after changing the
-checker.
+rejects mixed line endings. The `markdownlint` target checks the second stage,
+so the formatter check can expose an incompatible transformation instead of
+silently applying it. Run `make test-markdown-format` after changing the
+checker or its Makefile contract.
 
-The gate installs the `mdtablefix` version pinned by `MDTABLEFIX_VERSION` in
-`.github/workflows/ci.yml` through the
+The Makefile records the formatter releases selected by CI:
+`MDTABLEFIX_VERSION=0.5.1` and `MARKDOWNLINT_VERSION=0.20.0`. The gate installs
+the former through the
 `leynos/shared-actions/.github/actions/install-mdtablefix` action. The action
 requires `mdtablefix` 0.5.1 or later, installs only a matching prebuilt
 release, and fails closed when the runner has no supported archive; it never
 builds the formatter from source. Cuprum's project toolchain remains Rust
-1.85.0.
+1.85.0. The CI job installs the selected `markdownlint-cli2` release before
+running the Make targets. Local contributors install those releases before
+running the same targets; command variables remain injectable for contract
+tests.
 
 Install the pinned prebuilt version locally with `cargo-binstall` so formatter
 output matches CI:
 
 ```bash
 MDTABLEFIX_VERSION=0.5.1
+MARKDOWNLINT_VERSION=0.20.0
 cargo binstall --no-confirm --locked --disable-strategies compile \
   --install-path "$HOME/.local/bin" "mdtablefix@${MDTABLEFIX_VERSION}"
+npm install --global "markdownlint-cli2@${MARKDOWNLINT_VERSION}"
 ```
 
 ### Docstring structure
@@ -2945,14 +2960,15 @@ assertion, alias, suppression rationale, or dispatch structure instead.
 
 ### Markdown linting
 
-The `markdownlint` target lints exactly the Markdown files tracked by Git. The
-recipe feeds `git ls-files -z '*.md'` through `xargs -0` to `markdownlint-cli2`
-with `$(LOCAL_TOOL_ENV)` applied to both pipeline stages, so the tool resolves
-from `~/.local/bin` or `~/.bun/bin` even under a minimal `PATH`, arguments with
-spaces survive intact, and untracked scratch files can never fail the gate. The
-`.vtcode/**` directory is excluded in `.markdownlint-cli2.jsonc` as
-session-scratch content. The target then runs the shared `spelling` recipe, so
-one invocation covers both Markdown structure and en-GB-oxendict spelling.
+The `markdownlint` target reuses the formatting pipeline's Git-tracked regular
+`.md`, `.markdown`, and `.mdx` source set. It transports those paths with NUL
+delimiters to `markdownlint-cli2`, so names with spaces and newlines survive
+intact while untracked, ignored, and symlink-alias content remains outside the
+gate. `$(LOCAL_TOOL_ENV)` resolves the linter from `~/.local/bin` or
+`~/.bun/bin` under a minimal `PATH`. The `.vtcode/**` directory is excluded in
+`.markdownlint-cli2.jsonc` as session-scratch content. The target then runs the
+shared `spelling` recipe, so one invocation covers Markdown structure and
+en-GB-oxendict spelling.
 
 ### GitHub Actions workflow linting
 

--- a/scripts/check-markdown-format.sh
+++ b/scripts/check-markdown-format.sh
@@ -7,8 +7,7 @@
 # result against the corresponding source without modifying tracked files.
 # `mdtablefix` emits LF, whereas Git can check text out with CRLF on Windows;
 # the comparison accepts only either exact line-ending form. Keep the flags in
-# step with the `mdtablefix` invocation in
-# `mdformat-all`, which `make fmt` runs.
+# step with `MDTABLEFIX_FLAGS` in the Makefile, which `make fmt` uses.
 #
 # `make fmt` also applies `markdownlint-cli2 --fix` after `mdtablefix`, but that
 # pass is deliberately not replayed here. `make markdownlint` already rejects

--- a/scripts/markdown_format_test_support.py
+++ b/scripts/markdown_format_test_support.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import dataclasses as dc
 import os
 import shutil
 import subprocess  # ruff: ignore[suspicious-subprocess-import] - the process boundary is under test.
+import sys
+import textwrap
 import typing as typ
 from pathlib import Path
 
@@ -16,6 +19,8 @@ CHECKER = REPOSITORY_ROOT / "scripts" / "check-markdown-format.sh"
 
 _DEFAULT_TRACKED_FILES = (
     Path("guide.md"),
+    Path("guide.markdown"),
+    Path("guide.mdx"),
     Path("nested") / "tracked with spaces.md",
     Path("nested") / "tracked\nwith newline.md",
 )
@@ -31,6 +36,25 @@ class _UnavailableTestDependencyError(RuntimeError):
     def __str__(self) -> str:
         """Name the missing dependency in the failure message."""
         return f"the gate integration test requires {self._dependency}"
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _MarkdownFormatterTools:
+    """Keep the controlled formatter boundary reusable only by Markdown Make tests."""
+
+    formatter: Path
+    linter: Path
+    call_log: Path
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _MarkdownMakeGate:
+    """Describe one controlled Markdown Make invocation for these gate tests only."""
+
+    target: str
+    environment: cabc.Mapping[str, str]
+    mdtablefix: Path | None = None
+    markdownlint: Path | None = None
 
 
 def run_process(
@@ -77,7 +101,7 @@ def stage_markdown_sources(repository: Path, tracked_files: tuple[Path, ...]) ->
     if initialized.returncode != 0:
         raise AssertionError(initialized.stdout + initialized.stderr)
     added = run_process(
-        [git, "add", ".gitignore", *(str(path) for path in tracked_files)],
+        [git, "add", "--", ".gitignore", *(str(path) for path in tracked_files)],
         os.environ,
         repository,
     )
@@ -91,6 +115,40 @@ def run_check_format_gate(
     markdown_discovery: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run the real formatting recipe against the controlled repository."""
+    return _run_markdown_make_gate(
+        repository,
+        _MarkdownMakeGate(
+            target="check-fmt",
+            environment=os.environ | {"MARKDOWN_CHECKER_CALL_LOG": str(checker_log)},
+        ),
+        markdown_discovery,
+    )
+
+
+def run_format_gate(
+    repository: Path,
+    tools: _MarkdownFormatterTools,
+    markdown_discovery: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real formatter recipe against controlled Markdown tools."""
+    return _run_markdown_make_gate(
+        repository,
+        _MarkdownMakeGate(
+            target="fmt",
+            environment=os.environ | {"MARKDOWN_FORMAT_CALL_LOG": str(tools.call_log)},
+            mdtablefix=tools.formatter,
+            markdownlint=tools.linter,
+        ),
+        markdown_discovery,
+    )
+
+
+def _run_markdown_make_gate(
+    repository: Path,
+    gate: _MarkdownMakeGate,
+    markdown_discovery: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a controlled Markdown Make target; reuse only from this test support."""
     make = shutil.which("make")
     if make is None:
         raise _UnavailableTestDependencyError("make")
@@ -98,19 +156,23 @@ def run_check_format_gate(
     discovery_override = (
         [] if markdown_discovery is None else [f"MD_FILES_FIND={markdown_discovery}"]
     )
+    mdtablefix = gate.mdtablefix or command_stub
+    markdownlint = [] if gate.markdownlint is None else [f"MDLINT={gate.markdownlint}"]
     return run_process(
         [
             make,
             "-f",
             str(REPOSITORY_ROOT / "Makefile"),
-            "check-fmt",
+            gate.target,
             "VENV_TOOLS=",
             f"RUFF={command_stub}",
             f"CARGO={command_stub}",
             "RUST_DIR=.",
+            f"MDTABLEFIX={mdtablefix}",
+            *markdownlint,
             *discovery_override,
         ],
-        os.environ | {"MARKDOWN_CHECKER_CALL_LOG": str(checker_log)},
+        gate.environment,
         repository,
     )
 
@@ -134,3 +196,69 @@ def write_markdown_checker_stub(directory: Path) -> Path:
     )
     checker.chmod(0o755)
     return checker
+
+
+def write_markdown_formatter_stubs(directory: Path) -> _MarkdownFormatterTools:
+    """Create formatter and linter doubles that record their ordered inputs."""
+    call_log = directory / "markdown-format-calls.jsonl"
+    formatter = directory / "mdtablefix"
+    linter = directory / "markdownlint-cli2"
+    formatter.write_text(
+        textwrap.dedent(
+            """\
+            #!__PYTHON__
+            import json
+            import os
+            import pathlib
+            import sys
+
+            flags = [
+                "--in-place",
+                "--wrap",
+                "--renumber",
+                "--breaks",
+                "--ellipsis",
+                "--fences",
+            ]
+            arguments = sys.argv[1:]
+            if arguments[:len(flags)] != flags:
+                raise SystemExit(64)
+            paths = arguments[len(flags):]
+            call_log = pathlib.Path(os.environ["MARKDOWN_FORMAT_CALL_LOG"])
+            with call_log.open("a") as log:
+                print(json.dumps({"tool": "mdtablefix", "paths": paths}), file=log)
+            for path in paths:
+                source = pathlib.Path(path)
+                source.write_bytes(
+                    source.read_bytes().replace(b"unformatted", b"formatted")
+                )
+            """
+        ).replace("__PYTHON__", sys.executable),
+        encoding="utf-8",
+    )
+    linter.write_text(
+        textwrap.dedent(
+            """\
+            #!__PYTHON__
+            import json
+            import os
+            import pathlib
+            import sys
+
+            arguments = sys.argv[1:]
+            if arguments[:1] != ["--fix"]:
+                raise SystemExit(64)
+            paths = arguments[1:]
+            if any(b"unformatted" in pathlib.Path(path).read_bytes() for path in paths):
+                raise SystemExit(65)
+            call_log = pathlib.Path(os.environ["MARKDOWN_FORMAT_CALL_LOG"])
+            with call_log.open("a") as log:
+                entry = {"tool": "markdownlint-cli2", "paths": paths}
+                print(json.dumps(entry), file=log)
+            """
+        ).replace("__PYTHON__", sys.executable),
+        encoding="utf-8",
+    )
+    formatter.chmod(0o755)
+    linter.chmod(0o755)
+    return _MarkdownFormatterTools(formatter, linter, call_log)

--- a/scripts/tests/__snapshots__/test_markdown_format_makefile.ambr
+++ b/scripts/tests/__snapshots__/test_markdown_format_makefile.ambr
@@ -1,0 +1,61 @@
+# serializer version: 1
+# name: test_fmt_excludes_tracked_symlink_aliases
+  list([
+    dict({
+      'paths': list([
+        'guide.markdown',
+        'guide.md',
+        'guide.mdx',
+        '''
+          nested/tracked
+          with newline.md
+        ''',
+        'nested/tracked with spaces.md',
+      ]),
+      'tool': 'mdtablefix',
+    }),
+    dict({
+      'paths': list([
+        'guide.markdown',
+        'guide.md',
+        'guide.mdx',
+        '''
+          nested/tracked
+          with newline.md
+        ''',
+        'nested/tracked with spaces.md',
+      ]),
+      'tool': 'markdownlint-cli2',
+    }),
+  ])
+# ---
+# name: test_fmt_formats_each_tracked_markdown_extension_in_order
+  list([
+    dict({
+      'paths': list([
+        'guide.markdown',
+        'guide.md',
+        'guide.mdx',
+        '''
+          nested/tracked
+          with newline.md
+        ''',
+        'nested/tracked with spaces.md',
+      ]),
+      'tool': 'mdtablefix',
+    }),
+    dict({
+      'paths': list([
+        'guide.markdown',
+        'guide.md',
+        'guide.mdx',
+        '''
+          nested/tracked
+          with newline.md
+        ''',
+        'nested/tracked with spaces.md',
+      ]),
+      'tool': 'markdownlint-cli2',
+    }),
+  ])
+# ---

--- a/scripts/tests/test_markdown_format_makefile.py
+++ b/scripts/tests/test_markdown_format_makefile.py
@@ -1,0 +1,245 @@
+"""Exercise the Makefile-owned Markdown formatting pipeline.
+
+The tests run ``make fmt`` against controlled executables so they prove the
+repository's discovery, ordering, and failure behaviour without formatting the
+checkout that runs the tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import typing as typ
+from pathlib import Path
+
+import pytest
+from hypothesis import example, given, settings
+from hypothesis import strategies as st
+
+from scripts.markdown_format_test_support import (
+    create_format_gate_repository,
+    run_format_gate,
+    run_process,
+    stage_markdown_sources,
+    write_markdown_formatter_stubs,
+)
+
+if typ.TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
+
+FILENAME_ALPHABET = tuple("abcde12345 -_\néü")
+
+
+def _read_calls(call_log: Path) -> list[dict[str, object]]:
+    """Read the ordered formatter-double calls recorded by one recipe run."""
+    return [
+        json.loads(line) for line in call_log.read_text(encoding="utf-8").splitlines()
+    ]
+
+
+def _formatter_path(path: Path) -> str:
+    """Return the path form that cannot be mistaken for a tool option."""
+    source = path.as_posix()
+    return f"./{source}" if source.startswith("-") else source
+
+
+def _assert_two_stage_formatter_calls(
+    calls: list[dict[str, object]], expected_paths: list[str]
+) -> None:
+    """Assert the Make pipeline invokes both formatters over the same inputs."""
+    assert [call["tool"] for call in calls] == ["mdtablefix", "markdownlint-cli2"], (
+        "the Markdown pipeline must run mdtablefix before markdownlint-cli2"
+    )
+    assert all(call["paths"] == expected_paths for call in calls), (
+        "each Markdown formatter must receive precisely the tracked source paths"
+    )
+
+
+def _assert_formatter_only_call(
+    calls: list[dict[str, object]], expected_paths: list[str]
+) -> None:
+    """Assert the failed first stage did not permit the linter stage to run."""
+    assert len(calls) == 1, "a first-stage failure must record only one tool call"
+    assert calls[0]["tool"] == "mdtablefix", (
+        "the first-stage failure must be recorded as an mdtablefix invocation"
+    )
+    assert calls[0]["paths"] == expected_paths, (
+        "the failed formatter must receive every tracked Markdown source"
+    )
+
+
+def test_fmt_formats_each_tracked_markdown_extension_in_order(
+    tmp_path: Path, snapshot: SnapshotAssertion
+) -> None:
+    """Format tracked Markdown once before lint-fixing the identical file set."""
+    repository, tracked_files, _ = create_format_gate_repository(tmp_path)
+    stage_markdown_sources(repository, tracked_files)
+    for path in tracked_files:
+        (repository / path).write_text("unformatted\n", encoding="utf-8")
+    (repository / "untracked.md").write_text("unformatted\n", encoding="utf-8")
+    (repository / "ignored.md").write_text("unformatted\n", encoding="utf-8")
+    tools = write_markdown_formatter_stubs(repository)
+
+    result = run_format_gate(repository, tools)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    expected_paths = sorted(_formatter_path(path) for path in tracked_files)
+    calls = _read_calls(tools.call_log)
+    assert calls == snapshot, (
+        "the stable formatter transcript must preserve both tool names and inputs"
+    )
+    _assert_two_stage_formatter_calls(calls, expected_paths)
+    assert all(
+        (repository / path).read_text(encoding="utf-8") == "formatted\n"
+        for path in tracked_files
+    ), "the formatter must update every tracked Markdown source before linting"
+    assert (repository / "untracked.md").read_text(
+        encoding="utf-8"
+    ) == "unformatted\n", (
+        "untracked Markdown must remain outside the formatter input set"
+    )
+    assert (repository / "ignored.md").read_text(encoding="utf-8") == "unformatted\n", (
+        "ignored Markdown must remain outside the formatter input set"
+    )
+
+
+def test_fmt_excludes_tracked_symlink_aliases(
+    tmp_path: Path, snapshot: SnapshotAssertion
+) -> None:
+    """Leave tracked symlink aliases outside the regular-file formatter contract."""
+    repository, tracked_files, _ = create_format_gate_repository(tmp_path)
+    stage_markdown_sources(repository, tracked_files)
+    alias = repository / "guide-alias.md"
+    try:
+        alias.symlink_to("guide.md")
+    except OSError as error:
+        pytest.skip(f"the platform cannot create the tracked symlink fixture: {error}")
+    git = shutil.which("git")
+    assert git is not None, "the formatter contract test requires Git"
+    staged = run_process([git, "add", alias.name], os.environ, repository)
+    assert staged.returncode == 0, staged.stdout + staged.stderr
+    tools = write_markdown_formatter_stubs(repository)
+
+    result = run_format_gate(repository, tools)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    expected_paths = sorted(_formatter_path(path) for path in tracked_files)
+    calls = _read_calls(tools.call_log)
+    assert calls == snapshot, (
+        "the symlink-safe formatter transcript must preserve both tool stages"
+    )
+    _assert_two_stage_formatter_calls(calls, expected_paths)
+
+
+@given(component=st.text(FILENAME_ALPHABET, min_size=1, max_size=20))
+@example(component="-leading-option")
+@example(component="space name")
+@example(component="line\nbreak")
+@example(component="naïve")
+@settings(deadline=None, max_examples=20)
+def test_fmt_round_trips_valid_tracked_filename_components(
+    component: str,
+) -> None:
+    """Pass valid Git filename components to both stages without option parsing."""
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        source = Path(f"{component}.md")
+        repository, tracked_files, _ = create_format_gate_repository(
+            Path(temporary_directory),
+            (source,),
+        )
+        stage_markdown_sources(repository, tracked_files)
+        (repository / source).write_text("unformatted\n", encoding="utf-8")
+        untracked = repository / "untracked-no-format.md"
+        untracked.write_text("unformatted\n", encoding="utf-8")
+        tools = write_markdown_formatter_stubs(repository)
+
+        result = run_format_gate(repository, tools)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        expected_paths = [_formatter_path(source)]
+        _assert_two_stage_formatter_calls(_read_calls(tools.call_log), expected_paths)
+        assert (repository / source).read_text(encoding="utf-8") == "formatted\n", (
+            "the tracked generated filename must be formatted"
+        )
+        assert untracked.read_text(encoding="utf-8") == "unformatted\n", (
+            "the untracked generated filename must not be formatted"
+        )
+
+
+def test_fmt_skips_markdown_tools_when_git_tracks_no_markdown(tmp_path: Path) -> None:
+    """Avoid invoking either tool without a tracked source to format."""
+    repository, tracked_files, _ = create_format_gate_repository(tmp_path, ())
+    stage_markdown_sources(repository, tracked_files)
+    tools = write_markdown_formatter_stubs(repository)
+
+    result = run_format_gate(repository, tools)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not tools.call_log.exists(), "the Markdown tools must not run without inputs"
+
+
+def test_fmt_rejects_markdown_discovery_failure_before_tools_run(
+    tmp_path: Path,
+) -> None:
+    """Fail closed instead of allowing a failed Git walk to reach the tools."""
+    repository, tracked_files, _ = create_format_gate_repository(tmp_path)
+    stage_markdown_sources(repository, tracked_files)
+    for path in tracked_files:
+        (repository / path).write_text("unformatted\n", encoding="utf-8")
+    tools = write_markdown_formatter_stubs(repository)
+
+    result = run_format_gate(
+        repository,
+        tools,
+        markdown_discovery="false",
+    )
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert not tools.call_log.exists(), (
+        "the Markdown tools must not run after discovery fails"
+    )
+
+
+def test_fmt_propagates_the_first_formatter_failure(tmp_path: Path) -> None:
+    """Stop before lint-fixing when the canonical formatter fails."""
+    repository, tracked_files, _ = create_format_gate_repository(tmp_path)
+    stage_markdown_sources(repository, tracked_files)
+    for path in tracked_files:
+        (repository / path).write_text("unformatted\n", encoding="utf-8")
+    tools = write_markdown_formatter_stubs(repository)
+    tools.formatter.write_text("#!/bin/sh\nexit 67\n", encoding="utf-8")
+    tools.formatter.chmod(0o755)
+
+    result = run_format_gate(repository, tools)
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert not tools.call_log.exists(), (
+        "the linter must not run after formatter failure"
+    )
+    assert all(
+        (repository / path).read_text(encoding="utf-8") == "unformatted\n"
+        for path in tracked_files
+    ), "formatter failure must leave every tracked Markdown source unchanged"
+
+
+def test_fmt_propagates_the_linter_failure_after_formatting(tmp_path: Path) -> None:
+    """Report the second-stage failure after canonical formatting completes."""
+    repository, tracked_files, _ = create_format_gate_repository(tmp_path)
+    stage_markdown_sources(repository, tracked_files)
+    tools = write_markdown_formatter_stubs(repository)
+    tools.linter.write_text("#!/bin/sh\nexit 68\n", encoding="utf-8")
+    tools.linter.chmod(0o755)
+
+    result = run_format_gate(repository, tools)
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    _assert_formatter_only_call(
+        _read_calls(tools.call_log),
+        sorted(_formatter_path(path) for path in tracked_files),
+    )
+    assert all(
+        (repository / path).read_text(encoding="utf-8") == "formatted\n"
+        for path in tracked_files
+    ), "the successful first stage must format every tracked Markdown source"


### PR DESCRIPTION
## Summary

This branch replaces the machine-local `mdformat-all` wrapper with a Makefile-owned,
tracked-only Markdown formatting contract. It runs `mdtablefix` before
`markdownlint-cli2 --fix`, gives `check-fmt` the Netsuke-style temporary-copy
comparison for the same source set, and makes the formatter versions explicit.

The branch follows the merged formatter-prerequisites layer at
`2b2ffef2b2c2902104712d4514bfb83a78134f96` (PR #386). It contains no
mechanical Markdown churn: the actual pinned Make probe preserved the before and
after hashes of all 56 tracked Markdown sources, so the planned conditional
Markdown-only child is not required.

The implementation preserves Cuprum's CRLF-safe comparison behaviour while adapting
the mdtablefix-driven `check-fmt` design verified from Netsuke revision
`df6f0058b7e9d90354464534f4e1f6582635fc6f`. CI provisions mdtablefix through the
immutable shared-action revision
`c5a54701c8603a0fa756a6b34c49bc2af75a6c11` and selects mdtablefix 0.5.1 plus
markdownlint-cli2 0.20.0.

## Review walkthrough

- Start with [Makefile](https://github.com/leynos/cuprum/blob/harden-markdown-format-tooling-merged-replay-934d2efe/Makefile#L134): Git provides the NUL-delimited, tracked regular `.md`, `.markdown`, and `.mdx` set; root-level leading-dash paths are explicitly relative; ignored, untracked, and symlink-alias paths remain outside the contract.
- Review the formatter recipes in [Makefile](https://github.com/leynos/cuprum/blob/harden-markdown-format-tooling-merged-replay-934d2efe/Makefile#L212): `mdtablefix --in-place --wrap --renumber --breaks --ellipsis --fences` runs before `markdownlint-cli2 --fix`, both skip an empty list, and discovery failure stops the recipe.
- Review [scripts/check-markdown-format.sh](https://github.com/leynos/cuprum/blob/harden-markdown-format-tooling-merged-replay-934d2efe/scripts/check-markdown-format.sh#L1): `check-fmt` formats temporary copies and accepts only exact LF or CRLF output without changing the worktree.
- Finish with [scripts/tests/test_markdown_format_makefile.py](https://github.com/leynos/cuprum/blob/harden-markdown-format-tooling-merged-replay-934d2efe/scripts/tests/test_markdown_format_makefile.py#L1) and [scripts/markdown_format_test_support.py](https://github.com/leynos/cuprum/blob/harden-markdown-format-tooling-merged-replay-934d2efe/scripts/markdown_format_test_support.py#L1): controlled formatter doubles prove stage ordering, argument preservation, failure propagation, leading-dash and symlink handling, and the Hypothesis-backed filename invariant.
- [The stable transcript snapshot](https://github.com/leynos/cuprum/blob/harden-markdown-format-tooling-merged-replay-934d2efe/scripts/tests/__snapshots__/test_markdown_format_makefile.ambr) records only the two formatter stages and repository-relative paths; direct semantic assertions retain the generated-filename coverage.
- [cuprum/unittests/test_toolchain_pins.py](https://github.com/leynos/cuprum/blob/harden-markdown-format-tooling-merged-replay-934d2efe/cuprum/unittests/test_toolchain_pins.py#L286) keeps the Makefile versions aligned with [CI provisioning](https://github.com/leynos/cuprum/blob/harden-markdown-format-tooling-merged-replay-934d2efe/.github/workflows/ci.yml#L49); [docs/developers-guide.md](https://github.com/leynos/cuprum/blob/harden-markdown-format-tooling-merged-replay-934d2efe/docs/developers-guide.md#L2879) documents the contributor contract.

## Validation

- Passed: task-scoped prebuilt mdtablefix 0.5.1 and markdownlint-cli2 0.20.0
  were installed and version-verified. Existing global tools were not used because
  they are mdtablefix 0.5.0 and markdownlint-cli2 0.22.1.
- Passed: focused Markdown Make contract tests (18 tests), formatter pin contract
  tests (11 tests), representative missing-flag and symlink-predicate mutations,
  and `make check-fmt`.
- Passed: an isolated actual Make pipeline probe used pinned Markdown tools with
  inert Python/Rust formatter routes; all 56 tracked Markdown hashes were identical
  before and after. No universal formatting PR is needed.
- Passed on the merged parent: the no-update focused formatter contracts, full
  sequential `check-fmt`, `lint`, `typecheck`, `test`, `markdownlint`, and `nixie`
  gates. Tests reported 1,512 Python passes, 56 skips, and 107 Rust passes;
  CodeScene reported no remaining finding.

## Stack and follow-up

- Parent: formatter-prerequisites merged as PR #386 at
  `2b2ffef2b2c2902104712d4514bfb83a78134f96`.
- No mechanical Markdown-formatting successor is required for the measured tree.
- The formatter implementation retains the installed wrapper's two-stage behaviour,
  while replacing its mutable local discovery with the repository's stricter
  tracked-only, fail-closed policy.

## Summary by Sourcery

Enforce a tracked-only, CI-aligned Markdown formatting and linting contract directly through Make.

New Features:
- Define a Makefile-owned Markdown formatting pipeline for all tracked regular `.md`, `.markdown`, and `.mdx` sources.
- Add safe temporary-copy Markdown format checking that preserves the worktree and supports LF or CRLF files.

Bug Fixes:
- Prevent untracked, ignored, symlinked, and option-like Markdown paths from entering formatting and linting gates.
- Fail closed when Markdown discovery or either formatter stage fails.

Enhancements:
- Replace machine-local `mdformat-all` discovery with a shared NUL-delimited tracked-file contract and explicit two-stage formatter ordering.
- Keep Makefile formatter versions synchronized with CI and document the contributor installation and formatting contract.

Documentation:
- Update the developer guide with the tracked Markdown source contract, formatter versions, local installation instructions, and linting behavior.

Tests:
- Add Makefile integration coverage for formatter ordering, path handling, empty inputs, discovery failures, and formatter failure propagation.
- Add contract coverage ensuring Markdown extensions and formatter pins remain aligned with CI.

## References

- [Lody session](https://lody.ai/leynos/sessions/934d2efe-ceff-4a48-876a-6c022311b70d)
